### PR TITLE
Gmail push pipeline: real-time email processing

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -39,6 +39,11 @@ A human-in-the-loop scheduling agent for Long Ridge Partners, an executive searc
 - `ENCORE_API_URL` — Cluein data connector endpoint for Encore
 - `ENCORE_API_KEY` — Cluein API key
 - `ANTHROPIC_API_KEY` — Claude API key for agent reasoning
+- `PUBSUB_TOPIC` — Google Cloud Pub/Sub topic for Gmail push notifications (e.g., `projects/my-project/topics/gmail-push`)
+- `PUBSUB_WEBHOOK_AUDIENCE` — Expected OIDC audience for verifying Pub/Sub push tokens (must be set in production)
+- `PUBSUB_SERVICE_ACCOUNT` — Email of the service account that signs Pub/Sub push messages (default: `gmail-api-push@system.gserviceaccount.com`)
+- `GMAIL_TOKEN_ENCRYPTION_KEY` — Fernet key for encrypting stored Gmail OAuth refresh tokens
+- `REQUIRED_SCOPES` — Comma-separated list of Gmail OAuth scopes required for coordinator tokens
 
 ## Metrics (Business Impact)
 - **Mean Time to Interview (MTTI):** Hours from client request to interview (lower is better)

--- a/references/gmail-push-setup.md
+++ b/references/gmail-push-setup.md
@@ -1,0 +1,195 @@
+# Gmail Push Pipeline — Infrastructure Setup
+
+This guide covers the Google Cloud and Railway infrastructure needed to run the Gmail push pipeline.
+
+## Prerequisites
+
+- `gcloud` CLI authenticated with access to the GCP project (`ai-agents-dev-492713`)
+- Railway project with the API service deployed
+- At least one coordinator with a stored OAuth token (via `gmail_oauth.py`)
+
+## 1. Google Cloud Pub/Sub
+
+### 1a. Create the Pub/Sub Topic
+
+If the topic doesn't already exist:
+
+```bash
+gcloud pubsub topics create gmail-push \
+  --project=ai-agents-dev-492713
+```
+
+### 1b. Grant Gmail Permission to Publish
+
+Gmail's internal service account must be able to publish to the topic. Do this via the **GCP Console**:
+
+1. Go to **Pub/Sub > Topics** > `gmail-push`
+2. Click the **Permissions** tab (or "Show Info Panel" > Permissions)
+3. Click **Add Principal**
+4. Principal: `gmail-api-push@system.gserviceaccount.com`
+5. Role: **Pub/Sub Publisher** (`roles/pubsub.publisher`)
+6. Save
+
+Or via CLI (requires `pubsub.topics.setIamPolicy` permission):
+
+```bash
+gcloud pubsub topics add-iam-policy-binding gmail-push \
+  --project=ai-agents-dev-492713 \
+  --member="serviceAccount:gmail-api-push@system.gserviceaccount.com" \
+  --role="roles/pubsub.publisher"
+```
+
+### 1c. Create a Service Account for Push Auth
+
+This SA signs the OIDC tokens that our webhook verifies:
+
+```bash
+gcloud iam service-accounts create pubsub-push \
+  --display-name="Pub/Sub Push Auth" \
+  --project=ai-agents-dev-492713
+```
+
+Grant Pub/Sub permission to mint tokens with this SA:
+
+```bash
+# Get your project number (visible in GCP Console dashboard)
+PROJECT_NUMBER=$(gcloud projects describe ai-agents-dev-492713 --format="value(projectNumber)")
+
+gcloud iam service-accounts add-iam-policy-binding \
+  pubsub-push@ai-agents-dev-492713.iam.gserviceaccount.com \
+  --member="serviceAccount:service-${PROJECT_NUMBER}@gcp-sa-pubsub.iam.gserviceaccount.com" \
+  --role="roles/iam.serviceAccountTokenCreator"
+```
+
+### 1d. Create the Push Subscription
+
+This tells Pub/Sub to forward messages to our webhook:
+
+**For staging:**
+```bash
+gcloud pubsub subscriptions create gmail-push-staging \
+  --project=ai-agents-dev-492713 \
+  --topic=gmail-push \
+  --push-endpoint=https://api-staging-545f.up.railway.app/webhook/gmail \
+  --push-auth-service-account=pubsub-push@ai-agents-dev-492713.iam.gserviceaccount.com \
+  --push-auth-token-audience=https://api-staging-545f.up.railway.app/webhook/gmail
+```
+
+**For production** (replace domain when ready):
+```bash
+gcloud pubsub subscriptions create gmail-push-prod \
+  --project=ai-agents-dev-492713 \
+  --topic=gmail-push \
+  --push-endpoint=https://PROD_DOMAIN/webhook/gmail \
+  --push-auth-service-account=pubsub-push@ai-agents-dev-492713.iam.gserviceaccount.com \
+  --push-auth-token-audience=https://PROD_DOMAIN/webhook/gmail
+```
+
+**For local dev (via ngrok):**
+```bash
+gcloud pubsub subscriptions create gmail-push-dev \
+  --project=ai-agents-dev-492713 \
+  --topic=gmail-push \
+  --push-endpoint=https://poorly-dominant-redfish.ngrok-free.app/webhook/gmail \
+  --push-auth-service-account=pubsub-push@ai-agents-dev-492713.iam.gserviceaccount.com \
+  --push-auth-token-audience=https://poorly-dominant-redfish.ngrok-free.app/webhook/gmail
+```
+
+> **Note:** Only one push subscription should be active at a time per environment, or all environments will receive every notification. Use separate subscriptions and toggle them as needed.
+
+## 2. Environment Variables
+
+### Local Development (`.env`)
+
+```bash
+# Push pipeline
+PUBSUB_TOPIC=projects/ai-agents-dev-492713/topics/gmail-push
+REDIS_URL=redis://localhost:6379
+
+# Webhook security
+PUBSUB_WEBHOOK_AUDIENCE=https://poorly-dominant-redfish.ngrok-free.app/webhook/gmail
+PUBSUB_SERVICE_ACCOUNT=pubsub-push@ai-agents-dev-492713.iam.gserviceaccount.com
+
+# OAuth scopes (default is gmail.modify, add more as needed)
+REQUIRED_SCOPES=https://www.googleapis.com/auth/gmail.modify
+```
+
+### Railway Staging
+
+Set these in the Railway service variables:
+
+| Variable | Value |
+|----------|-------|
+| `PUBSUB_TOPIC` | `projects/ai-agents-dev-492713/topics/gmail-push` |
+| `REDIS_URL` | *(from Railway Redis addon — see section 3)* |
+| `PUBSUB_WEBHOOK_AUDIENCE` | `https://api-staging-545f.up.railway.app/webhook/gmail` |
+| `PUBSUB_SERVICE_ACCOUNT` | `pubsub-push@ai-agents-dev-492713.iam.gserviceaccount.com` |
+| `REQUIRED_SCOPES` | `https://www.googleapis.com/auth/gmail.modify` |
+
+## 3. Railway Redis
+
+The push pipeline requires Redis for the arq job queue. Railway does not yet have a Redis instance.
+
+### Add Redis to Railway
+
+1. Go to your Railway project dashboard
+2. Click **+ New** > **Database** > **Redis**
+3. Railway provisions a managed Redis instance and exposes connection details
+4. Copy the `REDIS_URL` from the Redis service's **Variables** tab (format: `redis://default:PASSWORD@HOST:PORT`)
+5. Add `REDIS_URL` as a shared variable or reference it in the API service: `${{Redis.REDIS_URL}}`
+
+### Deploy the arq Worker
+
+The arq worker runs as a **separate Railway service** alongside the API:
+
+1. In your Railway project, click **+ New** > **Service** (from same repo)
+2. Set the **start command** to:
+   ```
+   cd services/api && PYTHONPATH=src python -m arq api.gmail.workers.WorkerSettings
+   ```
+3. Set the **root directory** to `/` (repo root)
+4. Add the same environment variables as the API service (DATABASE_URL, REDIS_URL, GMAIL_TOKEN_ENCRYPTION_KEY, PUBSUB_TOPIC, etc.)
+5. The worker does NOT need a public domain — it only reads from Redis
+
+> **Important:** The worker must share the same `DATABASE_URL` and `REDIS_URL` as the API service. Use Railway's variable references (`${{Postgres.DATABASE_URL}}`, `${{Redis.REDIS_URL}}`) to keep them in sync.
+
+## 4. Database Migration
+
+Run the migration to add push pipeline columns:
+
+```bash
+# Local
+cd services/api && uv run yoyo apply --batch \
+  --database "${DATABASE_URL:-postgresql://dev:dev@localhost:5432/lrp_dev}" \
+  ./migrations
+
+# Railway (via railway run)
+railway run --service=api -- \
+  python -m yoyo apply --batch --database "$DATABASE_URL" ./migrations
+```
+
+## 5. Verification
+
+After setup, verify the pipeline works:
+
+1. **Watch registration**: The arq worker's `renew_gmail_watches` cron runs every 6 hours. To test immediately:
+   ```bash
+   cd services/api && uv run python scripts/test_push_pipeline.py \
+     --user nim@longridgepartners.com
+   ```
+
+2. **Push notification flow**: Send an email to the coordinator's inbox. Within ~10 seconds, you should see the full email logged in the worker's stdout.
+
+3. **Poll fallback**: Even without Pub/Sub configured, the worker polls every 60 seconds via `poll_gmail_history`. This is the safety net.
+
+## Architecture Reference
+
+```
+Email arrives
+    │
+    ├─ Push path (~5s): Gmail → Pub/Sub → POST /webhook/gmail → arq job → hook
+    │
+    └─ Poll path (~60s): arq cron → history.list() per coordinator → hook
+    
+Both paths → _process_history() → dedup check → classify → EmailEvent → hook.on_email()
+```

--- a/scripts/dev-all.sh
+++ b/scripts/dev-all.sh
@@ -8,8 +8,12 @@ docker compose up -d
 ./scripts/dev-api.sh &
 API_PID=$!
 
-# Trap to clean up on exit
-trap "kill $API_PID 2>/dev/null; docker compose stop" EXIT
+# Run arq worker (push pipeline)
+./scripts/dev-worker.sh &
+WORKER_PID=$!
 
-echo "All services running. Press Ctrl+C to stop."
+# Trap to clean up on exit
+trap "kill $API_PID $WORKER_PID 2>/dev/null; docker compose stop" EXIT
+
+echo "All services running (API + worker). Press Ctrl+C to stop."
 wait

--- a/scripts/dev-worker.sh
+++ b/scripts/dev-worker.sh
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+set -euo pipefail
+cd "$(dirname "$0")/../services/api"
+echo "Starting arq worker..."
+uv run python -m arq api.gmail.workers.WorkerSettings

--- a/scripts/dev-worker.sh
+++ b/scripts/dev-worker.sh
@@ -2,5 +2,9 @@
 set -euo pipefail
 cd "$(dirname "$0")/../services/api"
 export PYTHONPATH="src:${PYTHONPATH:-}"
+# Load .env for local development (production injects env vars directly)
+if [ -f .env ]; then
+  set -a; source .env; set +a
+fi
 echo "Starting arq worker..."
 uv run python -m arq api.gmail.workers.WorkerSettings

--- a/scripts/dev-worker.sh
+++ b/scripts/dev-worker.sh
@@ -1,5 +1,6 @@
 #!/usr/bin/env bash
 set -euo pipefail
 cd "$(dirname "$0")/../services/api"
+export PYTHONPATH="src:${PYTHONPATH:-}"
 echo "Starting arq worker..."
 uv run python -m arq api.gmail.workers.WorkerSettings

--- a/services/api/migrations/0003_gmail_push_pipeline.py
+++ b/services/api/migrations/0003_gmail_push_pipeline.py
@@ -1,0 +1,32 @@
+"""Add push pipeline state to gmail_tokens and create processed_messages dedup table."""
+
+from yoyo import step
+
+step(
+    """
+    ALTER TABLE gmail_tokens
+        ADD COLUMN last_history_id TEXT,
+        ADD COLUMN watch_expiry TIMESTAMPTZ;
+    """,
+    """
+    ALTER TABLE gmail_tokens
+        DROP COLUMN last_history_id,
+        DROP COLUMN watch_expiry;
+    """,
+)
+
+step(
+    """
+    CREATE TABLE processed_messages (
+        gmail_message_id    TEXT PRIMARY KEY,
+        coordinator_email   TEXT NOT NULL,
+        processed_at        TIMESTAMPTZ NOT NULL DEFAULT now()
+    );
+
+    CREATE INDEX idx_processed_messages_cleanup
+        ON processed_messages (processed_at);
+    """,
+    """
+    DROP TABLE processed_messages;
+    """,
+)

--- a/services/api/queries/gmail_push.sql
+++ b/services/api/queries/gmail_push.sql
@@ -9,16 +9,17 @@ SET last_history_id = :last_history_id, updated_at = now()
 WHERE user_email = :user_email;
 
 -- name: update_watch_state(user_email, last_history_id, watch_expiry)!
--- Update both history cursor and watch expiration after watch registration.
+-- Update watch expiration and advance history cursor (never backward).
 UPDATE gmail_tokens
-SET last_history_id = :last_history_id,
+SET last_history_id = GREATEST(last_history_id, :last_history_id),
     watch_expiry = :watch_expiry,
     updated_at = now()
 WHERE user_email = :user_email;
 
 -- name: get_all_watched_emails
--- List all coordinator emails with stored tokens (for poll fallback).
-SELECT user_email FROM gmail_tokens;
+-- List coordinator emails with active watches (for poll fallback and watch renewal).
+SELECT user_email FROM gmail_tokens
+WHERE watch_expiry IS NOT NULL AND watch_expiry > now();
 
 -- name: is_message_processed(gmail_message_id)$
 -- Check if a message has already been processed (dedup).

--- a/services/api/queries/gmail_push.sql
+++ b/services/api/queries/gmail_push.sql
@@ -1,0 +1,37 @@
+-- name: get_history_id(user_email)$
+-- Load the last-processed Gmail history ID for incremental sync.
+SELECT last_history_id FROM gmail_tokens WHERE user_email = :user_email;
+
+-- name: update_history_id(user_email, last_history_id)!
+-- Advance the history cursor after successful sync.
+UPDATE gmail_tokens
+SET last_history_id = :last_history_id, updated_at = now()
+WHERE user_email = :user_email;
+
+-- name: update_watch_state(user_email, last_history_id, watch_expiry)!
+-- Update both history cursor and watch expiration after watch registration.
+UPDATE gmail_tokens
+SET last_history_id = :last_history_id,
+    watch_expiry = :watch_expiry,
+    updated_at = now()
+WHERE user_email = :user_email;
+
+-- name: get_all_watched_emails
+-- List all coordinator emails with stored tokens (for poll fallback).
+SELECT user_email FROM gmail_tokens;
+
+-- name: is_message_processed(gmail_message_id)$
+-- Check if a message has already been processed (dedup).
+SELECT EXISTS(
+    SELECT 1 FROM processed_messages WHERE gmail_message_id = :gmail_message_id
+) AS is_processed;
+
+-- name: mark_message_processed(gmail_message_id, coordinator_email)!
+-- Record a message as processed. ON CONFLICT handles race between push and poll.
+INSERT INTO processed_messages (gmail_message_id, coordinator_email)
+VALUES (:gmail_message_id, :coordinator_email)
+ON CONFLICT (gmail_message_id) DO NOTHING;
+
+-- name: cleanup_old_processed_messages!
+-- Delete dedup records older than 30 days.
+DELETE FROM processed_messages WHERE processed_at < now() - INTERVAL '30 days';

--- a/services/api/scripts/test_push_pipeline.py
+++ b/services/api/scripts/test_push_pipeline.py
@@ -1,0 +1,353 @@
+#!/usr/bin/env python3
+"""E2E test for the Gmail push pipeline.
+
+Exercises the full flow:
+1. Registers a Pub/Sub watch for the coordinator
+2. Sends a test email to the coordinator's inbox
+3. Waits briefly, then runs a history sync (simulating poll fallback)
+4. Verifies the EmailEvent fires through the hook
+
+Usage:
+    uv run python scripts/test_push_pipeline.py \
+        --user nim@kinematiclabs.dev \
+        --sender nim@kinematiclabs.dev
+
+Requires:
+    - OAuth token stored for --user (run gmail_oauth.py first)
+    - GMAIL_TOKEN_ENCRYPTION_KEY, GOOGLE_OAUTH_CLIENT_ID, GOOGLE_OAUTH_CLIENT_SECRET
+    - DATABASE_URL, REDIS_URL, PUBSUB_TOPIC in env
+    - Pub/Sub topic created with gmail-api-push SA as publisher
+"""
+
+import argparse
+import asyncio
+import os
+import sys
+import time
+from datetime import UTC, datetime
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent / "src"))
+
+from dotenv import load_dotenv
+
+load_dotenv(Path(__file__).resolve().parent.parent / ".env")
+
+from psycopg_pool import AsyncConnectionPool  # noqa: E402
+
+from api.gmail.auth import TokenStore  # noqa: E402
+from api.gmail.client import GmailClient  # noqa: E402
+from api.gmail.hooks import (  # noqa: E402
+    EmailEvent,
+    MessageDirection,
+    MessageType,
+    classify_direction,
+    classify_message_type,
+)
+
+
+class CapturingHook:
+    """Test hook that captures events for verification."""
+
+    def __init__(self):
+        self.events: list[EmailEvent] = []
+
+    async def on_email(self, event: EmailEvent) -> None:
+        self.events.append(event)
+        print(
+            f"  ✓ EVENT: direction={event.direction.value} "
+            f"type={event.message_type.value} "
+            f"thread={event.message.thread_id} "
+            f"subject={event.message.subject!r} "
+            f"from={event.message.from_.email}"
+        )
+        if event.new_participants:
+            names = [p.email for p in event.new_participants]
+            print(f"    new_participants={names}")
+
+
+async def run_test(user_email: str, sender_email: str):
+    database_url = os.environ.get("DATABASE_URL", "postgresql://dev:dev@localhost:5432/lrp_dev")
+    encryption_key = os.environ.get("GMAIL_TOKEN_ENCRYPTION_KEY", "")
+    pubsub_topic = os.environ.get("PUBSUB_TOPIC", "")
+
+    if not encryption_key:
+        print("✗ GMAIL_TOKEN_ENCRYPTION_KEY not set")
+        return
+
+    pool = AsyncConnectionPool(conninfo=database_url)
+    await pool.open()
+    token_store = TokenStore(db_pool=pool, encryption_key=encryption_key)
+    gmail = GmailClient(token_store)
+    hook = CapturingHook()
+
+    try:
+        # Step 0: Verify we have credentials
+        print(f"\n{'='*60}")
+        print("Push Pipeline E2E Test")
+        print(f"{'='*60}")
+        print(f"  Coordinator: {user_email}")
+        print(f"  Sender: {sender_email}")
+        print()
+
+        has_token = await token_store.has_token(user_email)
+        if not has_token:
+            print(f"✗ No OAuth token for {user_email}. Run gmail_oauth.py first.")
+            return
+        print(f"✓ OAuth token found for {user_email}")
+
+        # Step 1: Register Pub/Sub watch
+        if pubsub_topic:
+            print("\n--- Step 1: Register Pub/Sub watch ---")
+            try:
+                result = await gmail.watch(user_email, pubsub_topic)
+                expiry = datetime.fromtimestamp(int(result["expiration"]) / 1000, tz=UTC)
+                history_id = result["historyId"]
+                await token_store.update_watch_state(user_email, history_id, expiry)
+                print(f"✓ Watch registered, history_id={history_id}, expires={expiry}")
+            except Exception as e:
+                print(f"✗ Watch registration failed: {e}")
+                print("  Continuing with poll-only mode...")
+        else:
+            print("\n--- Step 1: Skipping watch (PUBSUB_TOPIC not set) ---")
+
+        # Step 2: Get current history baseline
+        print("\n--- Step 2: Establish history baseline ---")
+        profile = await gmail.get_profile(user_email)
+        baseline_history_id = profile["historyId"]
+        await token_store.update_history_id(user_email, str(baseline_history_id))
+        print(f"✓ Baseline history_id={baseline_history_id}")
+
+        # Step 3: Send a test email
+        print("\n--- Step 3: Send test email ---")
+        timestamp = int(time.time())
+        subject = f"[Push Pipeline Test] {timestamp}"
+        body = (
+            f"This is an automated test of the Gmail push pipeline.\n"
+            f"Timestamp: {timestamp}\n"
+            f"If you see this, the send path works."
+        )
+        sent_msg = await gmail.send_message(
+            user_email,
+            to=[sender_email],
+            subject=subject,
+            body=body,
+        )
+        print(f"✓ Sent message id={sent_msg.id} thread={sent_msg.thread_id}")
+        print(f"  Subject: {subject}")
+
+        # Step 4: Wait for Gmail to process
+        print("\n--- Step 4: Wait for Gmail to index (10s) ---")
+        await asyncio.sleep(10)
+        print("✓ Done waiting")
+
+        # Step 5: Run history sync (simulating what the worker does)
+        print("\n--- Step 5: Process history (simulating poll) ---")
+        from api.gmail.exceptions import GmailNotFoundError
+
+        try:
+            history_response = await gmail.history_list(
+                user_email,
+                str(baseline_history_id),
+                history_types=["messageAdded"],
+            )
+        except GmailNotFoundError:
+            print("✗ History ID expired — this shouldn't happen for a fresh baseline")
+            return
+
+        new_message_ids = []
+        for entry in history_response.get("history", []):
+            for msg_added in entry.get("messagesAdded", []):
+                msg_id = msg_added.get("message", {}).get("id")
+                if msg_id:
+                    new_message_ids.append(msg_id)
+
+        print(f"✓ Found {len(new_message_ids)} new message(s) since baseline")
+
+        if not new_message_ids:
+            print("✗ No new messages found. Gmail may not have indexed yet.")
+            print("  Try increasing the wait time or check Gmail directly.")
+            return
+
+        # Step 6: Process each message through classification + hook
+        print("\n--- Step 6: Classify and fire hook ---")
+        threads_cache = {}
+
+        for msg_id in new_message_ids:
+            message = await gmail.get_message(user_email, msg_id)
+
+            thread_id = message.thread_id
+            if thread_id not in threads_cache:
+                thread = await gmail.get_thread(user_email, thread_id)
+                threads_cache[thread_id] = thread.messages
+            thread_messages = threads_cache[thread_id]
+
+            direction = classify_direction(message, user_email)
+            prior = [m for m in thread_messages if m.id != message.id and m.date < message.date]
+            msg_type, new_participants = classify_message_type(message, prior)
+
+            event = EmailEvent(
+                message=message,
+                coordinator_email=user_email,
+                direction=direction,
+                message_type=msg_type,
+                new_participants=new_participants,
+            )
+            await hook.on_email(event)
+
+        # Step 7: Verify results
+        print("\n--- Step 7: Results ---")
+        print(f"✓ Processed {len(hook.events)} event(s)")
+
+        # Check that our sent message was classified correctly
+        our_event = None
+        for evt in hook.events:
+            if evt.message.subject == subject:
+                our_event = evt
+                break
+
+        if our_event:
+            print("✓ Found our test message in events")
+            assert (
+                our_event.direction == MessageDirection.OUTGOING
+            ), f"Expected OUTGOING, got {our_event.direction}"
+            print("✓ Direction correctly classified as OUTGOING")
+            assert (
+                our_event.message_type == MessageType.NEW_THREAD
+            ), f"Expected NEW_THREAD, got {our_event.message_type}"
+            print("✓ Message type correctly classified as NEW_THREAD")
+        else:
+            print("⚠ Our test message not found in events (may be in a different history batch)")
+            print("  Events found:")
+            for evt in hook.events:
+                print(f"    - {evt.message.subject!r} ({evt.direction.value})")
+
+        # Update history cursor
+        new_history = history_response.get("historyId")
+        if new_history:
+            await token_store.update_history_id(user_email, str(new_history))
+
+        print(f"\n{'='*60}")
+        print("✓ Push pipeline E2E test complete!")
+        print(f"{'='*60}")
+
+    finally:
+        await pool.close()
+
+
+async def run_incoming_test(user_email: str):
+    """Test incoming email classification.
+
+    Skips sending (assumes an external email was already sent to the coordinator).
+    Just runs history sync and classifies whatever new messages arrived.
+    """
+    database_url = os.environ.get("DATABASE_URL", "postgresql://dev:dev@localhost:5432/lrp_dev")
+    encryption_key = os.environ.get("GMAIL_TOKEN_ENCRYPTION_KEY", "")
+
+    pool = AsyncConnectionPool(conninfo=database_url)
+    await pool.open()
+    token_store = TokenStore(db_pool=pool, encryption_key=encryption_key)
+    gmail = GmailClient(token_store)
+    hook = CapturingHook()
+
+    try:
+        print(f"\n{'='*60}")
+        print("Incoming Email Detection Test")
+        print(f"{'='*60}")
+
+        stored_history_id = await token_store.get_history_id(user_email)
+        if not stored_history_id:
+            print("✗ No history baseline — run the full test first")
+            return
+        print(f"✓ Using history_id={stored_history_id}")
+
+        print("\n--- Processing history ---")
+        from api.gmail.exceptions import GmailNotFoundError
+
+        try:
+            history_response = await gmail.history_list(
+                user_email,
+                str(stored_history_id),
+                history_types=["messageAdded"],
+            )
+        except GmailNotFoundError:
+            print("✗ History ID expired")
+            return
+
+        new_message_ids = []
+        for entry in history_response.get("history", []):
+            for msg_added in entry.get("messagesAdded", []):
+                msg_id = msg_added.get("message", {}).get("id")
+                if msg_id:
+                    new_message_ids.append(msg_id)
+
+        print(f"✓ Found {len(new_message_ids)} new message(s)")
+
+        if not new_message_ids:
+            print("⚠ No new messages. Send an email to the coordinator first.")
+            return
+
+        threads_cache = {}
+        for msg_id in new_message_ids:
+            message = await gmail.get_message(user_email, msg_id)
+            thread_id = message.thread_id
+            if thread_id not in threads_cache:
+                thread = await gmail.get_thread(user_email, thread_id)
+                threads_cache[thread_id] = thread.messages
+            thread_messages = threads_cache[thread_id]
+
+            direction = classify_direction(message, user_email)
+            prior = [m for m in thread_messages if m.id != message.id and m.date < message.date]
+            msg_type, new_participants = classify_message_type(message, prior)
+
+            event = EmailEvent(
+                message=message,
+                coordinator_email=user_email,
+                direction=direction,
+                message_type=msg_type,
+                new_participants=new_participants,
+            )
+            await hook.on_email(event)
+
+        print("\n--- Results ---")
+        for evt in hook.events:
+            status = "✓" if evt.direction == MessageDirection.INCOMING else "·"
+            print(
+                f"  {status} {evt.direction.value} {evt.message_type.value}"
+                f" — {evt.message.subject!r}"
+            )
+
+        incoming = [e for e in hook.events if e.direction == MessageDirection.INCOMING]
+        print(f"\n✓ {len(incoming)} incoming, {len(hook.events) - len(incoming)} outgoing")
+
+        new_history = history_response.get("historyId")
+        if new_history:
+            await token_store.update_history_id(user_email, str(new_history))
+
+        print(f"{'='*60}")
+    finally:
+        await pool.close()
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Test the Gmail push pipeline e2e")
+    parser.add_argument("--user", required=True, help="Coordinator email (must have OAuth token)")
+    parser.add_argument(
+        "--sender",
+        help="Email to send test message to (defaults to --user for self-send)",
+    )
+    parser.add_argument(
+        "--incoming-only",
+        action="store_true",
+        help="Skip sending, just process new incoming messages",
+    )
+    args = parser.parse_args()
+    if args.incoming_only:
+        asyncio.run(run_incoming_test(args.user))
+    else:
+        sender = args.sender or args.user
+        asyncio.run(run_test(args.user, sender))
+
+
+if __name__ == "__main__":
+    main()

--- a/services/api/src/api/addon/routes.py
+++ b/services/api/src/api/addon/routes.py
@@ -22,7 +22,7 @@ from api.addon.models import (
     PushCard,
     UpdateCard,
 )
-from api.gmail.exceptions import GmailValidationError
+from api.gmail.exceptions import GmailScopeError, GmailValidationError
 from api.scheduling.cards import (
     build_add_time_slot_form,
     build_auth_required,
@@ -105,9 +105,7 @@ async def _check_gmail_auth(request: Request, user_email: str) -> CardResponse |
     gmail = getattr(request.app.state, "gmail", None)
     if not gmail:
         return None  # GmailClient not configured — skip auth check
-    if not gmail._token_store:
-        return None
-    has = await gmail._token_store.has_token(user_email)
+    has = await gmail.has_token(user_email)
     if has:
         return None
     # Build the OAuth authorization URL
@@ -201,6 +199,11 @@ async def addon_action(body: AddonRequest, request: Request) -> dict:
     handler = _ACTION_HANDLERS.get(fn or "", _handle_unknown)
     try:
         card = await handler(body, svc, email)
+    except GmailScopeError as exc:
+        logger.warning("Gmail scope error in action %s: %s", fn, exc)
+        base = str(request.url).rsplit("/addon/", 1)[0]
+        auth_url = f"{base}/addon/oauth/start?user_email={email}"
+        card = build_auth_required(auth_url)
     except GmailValidationError as exc:
         logger.warning("Gmail validation error in action %s: %s", fn, exc)
         card = build_error_card(str(exc))

--- a/services/api/src/api/gmail/auth.py
+++ b/services/api/src/api/gmail/auth.py
@@ -8,12 +8,15 @@ from typing import TYPE_CHECKING
 from cryptography.fernet import Fernet, InvalidToken
 from google.oauth2.credentials import Credentials
 
-from api.gmail.exceptions import GmailAuthError, GmailUserNotAuthorizedError
+from api.gmail.exceptions import GmailAuthError, GmailScopeError, GmailUserNotAuthorizedError
 
 if TYPE_CHECKING:
+    from datetime import datetime
+
     from psycopg_pool import AsyncConnectionPool
 
-SCOPES = ["https://www.googleapis.com/auth/gmail.modify"]
+_DEFAULT_SCOPES = "https://www.googleapis.com/auth/gmail.modify"
+SCOPES = os.environ.get("REQUIRED_SCOPES", _DEFAULT_SCOPES).split(",")
 TOKEN_URI = "https://oauth2.googleapis.com/token"
 
 _LOAD_SQL = "SELECT refresh_token_encrypted, scopes FROM gmail_tokens WHERE user_email = %(email)s"
@@ -56,7 +59,11 @@ class TokenStore:
             )
 
     async def load_credentials(self, user_email: str) -> Credentials:
-        """Load a user's stored token and return Google OAuth Credentials."""
+        """Load a user's stored token and return Google OAuth Credentials.
+
+        Validates that stored scopes cover all REQUIRED_SCOPES. Raises
+        GmailScopeError if re-authorization is needed.
+        """
         async with self._pool.connection() as conn:
             cur = await conn.execute(_LOAD_SQL, {"email": user_email})
             row = await cur.fetchone()
@@ -64,6 +71,15 @@ class TokenStore:
         if row is None:
             raise GmailUserNotAuthorizedError(
                 f"No stored token for {user_email}. User must authorize via the add-on first."
+            )
+
+        granted = set(row[1])
+        required = set(SCOPES)
+        missing = required - granted
+        if missing:
+            raise GmailScopeError(
+                f"User {user_email} is missing scopes: {missing}. Re-authorization required.",
+                missing_scopes=list(missing),
             )
 
         refresh_token = self._decrypt(row[0])
@@ -93,3 +109,54 @@ class TokenStore:
             )
             row = await cur.fetchone()
             return row[0] if row else False
+
+    # --- Push pipeline state ---
+
+    async def get_history_id(self, user_email: str) -> str | None:
+        """Load the last-processed Gmail history ID for incremental sync."""
+        async with self._pool.connection() as conn:
+            cur = await conn.execute(
+                "SELECT last_history_id FROM gmail_tokens WHERE user_email = %(email)s",
+                {"email": user_email},
+            )
+            row = await cur.fetchone()
+            return row[0] if row else None
+
+    async def update_history_id(self, user_email: str, history_id: str) -> None:
+        """Advance the history cursor after successful sync."""
+        async with self._pool.connection() as conn:
+            await conn.execute(
+                """
+                UPDATE gmail_tokens
+                SET last_history_id = %(history_id)s, updated_at = now()
+                WHERE user_email = %(email)s
+                """,
+                {"email": user_email, "history_id": history_id},
+            )
+
+    async def update_watch_state(
+        self, user_email: str, history_id: str, watch_expiry: datetime
+    ) -> None:
+        """Update both history cursor and watch expiration after watch registration."""
+        async with self._pool.connection() as conn:
+            await conn.execute(
+                """
+                UPDATE gmail_tokens
+                SET last_history_id = %(history_id)s,
+                    watch_expiry = %(watch_expiry)s,
+                    updated_at = now()
+                WHERE user_email = %(email)s
+                """,
+                {
+                    "email": user_email,
+                    "history_id": history_id,
+                    "watch_expiry": watch_expiry,
+                },
+            )
+
+    async def get_all_watched_emails(self) -> list[str]:
+        """List all coordinator emails with stored tokens."""
+        async with self._pool.connection() as conn:
+            cur = await conn.execute("SELECT user_email FROM gmail_tokens")
+            rows = await cur.fetchall()
+            return [row[0] for row in rows]

--- a/services/api/src/api/gmail/client.py
+++ b/services/api/src/api/gmail/client.py
@@ -78,6 +78,69 @@ class GmailClient:
         except HttpError as exc:
             raise _map_http_error(exc) from exc
 
+    # --- Push pipeline ---
+
+    async def watch(self, user_email: str, topic_name: str) -> dict:
+        """Register Pub/Sub push notifications for a mailbox.
+
+        Returns {"historyId": "...", "expiration": "..."}.
+        Watches all labels — scheduling replies may be auto-archived or labeled.
+        """
+        logger.info("watch user=%s topic=%s", user_email, topic_name)
+        return await self._exec(
+            user_email,
+            lambda svc: (
+                svc.users()
+                .watch(
+                    userId="me",
+                    body={"topicName": topic_name, "labelIds": None},
+                )
+                .execute()
+            ),
+        )
+
+    async def stop_watch(self, user_email: str) -> None:
+        """Unregister push notifications for a mailbox."""
+        logger.info("stop_watch user=%s", user_email)
+        await self._exec(
+            user_email,
+            lambda svc: svc.users().stop(userId="me").execute(),
+        )
+
+    async def history_list(
+        self,
+        user_email: str,
+        start_history_id: str,
+        history_types: list[str] | None = None,
+    ) -> dict:
+        """Fetch mailbox changes since a history ID.
+
+        Returns {"history": [...], "historyId": "latest_id"}.
+        On 404 (expired historyId), raises GmailNotFoundError.
+        """
+        logger.info("history_list user=%s start=%s", user_email, start_history_id)
+        kwargs: dict = {
+            "userId": "me",
+            "startHistoryId": start_history_id,
+        }
+        if history_types:
+            kwargs["historyTypes"] = history_types
+        return await self._exec(
+            user_email,
+            lambda svc: svc.users().history().list(**kwargs).execute(),
+        )
+
+    async def get_profile(self, user_email: str) -> dict:
+        """Fetch user profile — used to get initial historyId.
+
+        Returns {"emailAddress": "...", "historyId": "...", ...}.
+        """
+        logger.info("get_profile user=%s", user_email)
+        return await self._exec(
+            user_email,
+            lambda svc: svc.users().getProfile(userId="me").execute(),
+        )
+
     # --- Read ---
 
     async def get_message(self, user_email: str, message_id: str) -> Message:

--- a/services/api/src/api/gmail/client.py
+++ b/services/api/src/api/gmail/client.py
@@ -67,6 +67,10 @@ class GmailClient:
     def __init__(self, token_store: TokenStore):
         self._token_store = token_store
 
+    async def has_token(self, user_email: str) -> bool:
+        """Check if a user has stored credentials."""
+        return await self._token_store.has_token(user_email)
+
     async def _get_creds(self, user_email: str):
         return await self._token_store.load_credentials(user_email)
 

--- a/services/api/src/api/gmail/exceptions.py
+++ b/services/api/src/api/gmail/exceptions.py
@@ -25,5 +25,13 @@ class GmailRateLimitError(GmailApiError):
     """Gmail API quota exceeded."""
 
 
+class GmailScopeError(GmailAuthError):
+    """Stored token is missing required OAuth scopes — user must re-authorize."""
+
+    def __init__(self, message: str, missing_scopes: list[str]):
+        super().__init__(message)
+        self.missing_scopes = missing_scopes
+
+
 class GmailValidationError(GmailApiError):
     """Invalid input (e.g. empty recipients) caught before making an API call."""

--- a/services/api/src/api/gmail/hooks.py
+++ b/services/api/src/api/gmail/hooks.py
@@ -1,0 +1,98 @@
+"""Email event model, hook protocol, and deterministic message classification.
+
+This module is the integration point between the Gmail push pipeline and
+downstream consumers (e.g., the scheduling agent). The pipeline fires an
+EmailEvent for every processed message; the consumer implements the
+EmailHook protocol to handle it.
+"""
+
+from __future__ import annotations
+
+import logging
+from enum import StrEnum
+from typing import Protocol
+
+from pydantic import BaseModel
+
+from api.gmail.models import EmailAddress, Message  # noqa: TC001 — needed at runtime for Pydantic
+
+logger = logging.getLogger(__name__)
+
+
+class MessageDirection(StrEnum):
+    INCOMING = "incoming"
+    OUTGOING = "outgoing"
+
+
+class MessageType(StrEnum):
+    NEW_THREAD = "new_thread"
+    REPLY = "reply"
+    FORWARD = "forward"
+
+
+class EmailEvent(BaseModel):
+    """Structured event fired for every processed email."""
+
+    message: Message
+    coordinator_email: str
+    direction: MessageDirection
+    message_type: MessageType
+    new_participants: list[EmailAddress]
+
+    model_config = {"populate_by_name": True}
+
+
+class EmailHook(Protocol):
+    """Interface for email event consumers."""
+
+    async def on_email(self, event: EmailEvent) -> None: ...
+
+
+class LoggingHook:
+    """Default hook — logs every event. Replaced by agent in production."""
+
+    async def on_email(self, event: EmailEvent) -> None:
+        logger.info(
+            "email_event direction=%s type=%s thread=%s subject=%s",
+            event.direction.value,
+            event.message_type.value,
+            event.message.thread_id,
+            event.message.subject,
+        )
+
+
+def classify_direction(message: Message, coordinator_email: str) -> MessageDirection:
+    """Determine if a message is incoming or outgoing relative to the coordinator."""
+    if message.from_.email.lower() == coordinator_email.lower():
+        return MessageDirection.OUTGOING
+    return MessageDirection.INCOMING
+
+
+def classify_message_type(
+    message: Message,
+    prior_messages: list[Message],
+) -> tuple[MessageType, list[EmailAddress]]:
+    """Classify a message as new thread, reply, or forward.
+
+    A forward is defined as: a message that adds at least one recipient
+    not seen in any prior message's from/to/cc fields. This is deterministic
+    (no heuristics, no subject-line parsing).
+    """
+    if not prior_messages:
+        return MessageType.NEW_THREAD, []
+
+    # Build cumulative participant set from all prior messages
+    seen: set[str] = set()
+    for msg in prior_messages:
+        seen.add(msg.from_.email.lower())
+        for addr in msg.to + msg.cc:
+            seen.add(addr.email.lower())
+
+    # Check current message recipients for new participants
+    current_recipients = message.to + message.cc
+    new_participants = [addr for addr in current_recipients if addr.email.lower() not in seen]
+
+    if new_participants:
+        return MessageType.FORWARD, new_participants
+
+    return MessageType.REPLY, []

--- a/services/api/src/api/gmail/hooks.py
+++ b/services/api/src/api/gmail/hooks.py
@@ -52,12 +52,46 @@ class LoggingHook:
     """Default hook — logs every event. Replaced by agent in production."""
 
     async def on_email(self, event: EmailEvent) -> None:
+        msg = event.message
+        participants = ", ".join(a.email for a in event.new_participants)
+        to_list = ", ".join(a.email for a in msg.to)
+        cc_list = ", ".join(a.email for a in msg.cc)
+
         logger.info(
-            "email_event direction=%s type=%s thread=%s subject=%s",
+            "\n"
+            "╔══════════════════════════════════════════════════\n"
+            "║ EMAIL EVENT\n"
+            "╠══════════════════════════════════════════════════\n"
+            "║ Direction:    %s\n"
+            "║ Type:         %s\n"
+            "║ Coordinator:  %s\n"
+            "╠──────────────────────────────────────────────────\n"
+            "║ From:         %s\n"
+            "║ To:           %s\n"
+            "║ CC:           %s\n"
+            "║ Subject:      %s\n"
+            "║ Date:         %s\n"
+            "║ Thread ID:    %s\n"
+            "║ Message ID:   %s\n"
+            "║ Labels:       %s\n"
+            "╠──────────────────────────────────────────────────\n"
+            "║ Body:\n%s\n"
+            "╠──────────────────────────────────────────────────\n"
+            "║ New participants: %s\n"
+            "╚══════════════════════════════════════════════════",
             event.direction.value,
             event.message_type.value,
-            event.message.thread_id,
-            event.message.subject,
+            event.coordinator_email,
+            f"{msg.from_.name} <{msg.from_.email}>" if msg.from_.name else msg.from_.email,
+            to_list,
+            cc_list or "(none)",
+            msg.subject,
+            msg.date.isoformat(),
+            msg.thread_id,
+            msg.message_id_header or "(none)",
+            ", ".join(msg.label_ids) or "(none)",
+            "\n".join(f"║   {line}" for line in msg.body_text.splitlines()) or "║   (empty)",
+            participants or "(none)",
         )
 
 

--- a/services/api/src/api/gmail/webhook.py
+++ b/services/api/src/api/gmail/webhook.py
@@ -1,0 +1,117 @@
+"""Authenticated Gmail Pub/Sub webhook endpoint.
+
+Receives push notifications from Google Cloud Pub/Sub, verifies the
+OIDC bearer token, and enqueues an arq job for background processing.
+"""
+
+from __future__ import annotations
+
+import base64
+import json
+import logging
+import os
+
+from fastapi import APIRouter, Request, Response
+from google.auth.transport import requests as google_requests
+from google.oauth2 import id_token
+
+logger = logging.getLogger(__name__)
+
+webhook_router = APIRouter(tags=["gmail-push"])
+
+PUBSUB_SERVICE_ACCOUNT = os.environ.get(
+    "PUBSUB_SERVICE_ACCOUNT",
+    "gmail-api-push@system.gserviceaccount.com",
+)
+EXPECTED_AUDIENCE = os.environ.get("PUBSUB_WEBHOOK_AUDIENCE", "")
+if not EXPECTED_AUDIENCE:
+    logger.warning(
+        "PUBSUB_WEBHOOK_AUDIENCE not set — webhook OIDC audience "
+        "validation is disabled. Set this in production."
+    )
+
+
+async def _verify_pubsub_token(request: Request) -> dict:
+    """Verify the OIDC token Google attaches to Pub/Sub push messages.
+
+    Returns the verified claims dict, or raises ValueError on failure.
+    """
+    auth_header = request.headers.get("Authorization", "")
+    if not auth_header.startswith("Bearer "):
+        raise ValueError("Missing bearer token")
+
+    token = auth_header[7:]
+    claims = id_token.verify_oauth2_token(
+        token,
+        google_requests.Request(),
+        audience=EXPECTED_AUDIENCE or None,
+    )
+
+    if claims.get("email") != PUBSUB_SERVICE_ACCOUNT:
+        raise ValueError(f"Unexpected sender: {claims.get('email')}")
+
+    return claims
+
+
+@webhook_router.post("/webhook/gmail")
+async def gmail_webhook(request: Request) -> Response:
+    """Receive Gmail Pub/Sub push notifications.
+
+    1. Verify OIDC bearer token (Google-signed)
+    2. Parse emailAddress + historyId from Pub/Sub data
+    3. Validate coordinator has authorized the app
+    4. Enqueue arq job for background processing
+    5. Always return 200 (prevents Pub/Sub retries on errors)
+    """
+    # Verify OIDC token
+    try:
+        await _verify_pubsub_token(request)
+    except (ValueError, Exception) as exc:
+        logger.warning("webhook auth failed: %s", exc)
+        # Return 200 even on auth failure to prevent Pub/Sub retries
+        # from hammering the endpoint. Log for monitoring.
+        return Response(status_code=200)
+
+    # Parse Pub/Sub message
+    try:
+        body = await request.json()
+        message_data = body.get("message", {}).get("data", "")
+        decoded = base64.b64decode(message_data).decode("utf-8")
+        notification = json.loads(decoded)
+        coordinator_email = notification.get("emailAddress", "")
+        history_id = str(notification.get("historyId", ""))
+    except Exception:
+        logger.exception("webhook parse error")
+        return Response(status_code=200)
+
+    if not coordinator_email or not history_id:
+        logger.warning("webhook missing emailAddress or historyId")
+        return Response(status_code=200)
+
+    # Check if we have credentials for this coordinator
+    token_store = request.app.state.gmail._token_store
+    if not await token_store.has_token(coordinator_email):
+        logger.debug("webhook for unknown coordinator: %s", coordinator_email)
+        return Response(status_code=200)
+
+    # Enqueue background job
+    redis = getattr(request.app.state, "redis", None)
+    if redis is None:
+        logger.warning("redis not available — cannot enqueue push job")
+        return Response(status_code=200)
+
+    try:
+        await redis.enqueue_job(
+            "process_gmail_push",
+            coordinator_email,
+            history_id,
+        )
+        logger.info(
+            "enqueued push job coordinator=%s history_id=%s",
+            coordinator_email,
+            history_id,
+        )
+    except Exception:
+        logger.exception("failed to enqueue push job for %s", coordinator_email)
+
+    return Response(status_code=200)

--- a/services/api/src/api/gmail/webhook.py
+++ b/services/api/src/api/gmail/webhook.py
@@ -6,6 +6,7 @@ OIDC bearer token, and enqueues an arq job for background processing.
 
 from __future__ import annotations
 
+import asyncio
 import base64
 import json
 import logging
@@ -40,11 +41,18 @@ async def _verify_pubsub_token(request: Request) -> dict:
     if not auth_header.startswith("Bearer "):
         raise ValueError("Missing bearer token")
 
+    if not EXPECTED_AUDIENCE:
+        raise ValueError(
+            "PUBSUB_WEBHOOK_AUDIENCE is not configured — "
+            "refusing to verify token without audience validation"
+        )
+
     token = auth_header[7:]
-    claims = id_token.verify_oauth2_token(
+    claims = await asyncio.to_thread(
+        id_token.verify_oauth2_token,
         token,
         google_requests.Request(),
-        audience=EXPECTED_AUDIENCE or None,
+        audience=EXPECTED_AUDIENCE,
     )
 
     if claims.get("email") != PUBSUB_SERVICE_ACCOUNT:
@@ -89,8 +97,11 @@ async def gmail_webhook(request: Request) -> Response:
         return Response(status_code=200)
 
     # Check if we have credentials for this coordinator
-    token_store = request.app.state.gmail._token_store
-    if not await token_store.has_token(coordinator_email):
+    gmail = getattr(request.app.state, "gmail", None)
+    if not gmail:
+        logger.warning("GmailClient not initialized — cannot process webhook")
+        return Response(status_code=200)
+    if not await gmail.has_token(coordinator_email):
         logger.debug("webhook for unknown coordinator: %s", coordinator_email)
         return Response(status_code=200)
 

--- a/services/api/src/api/gmail/workers.py
+++ b/services/api/src/api/gmail/workers.py
@@ -10,20 +10,15 @@ from __future__ import annotations
 import logging
 import os
 from datetime import UTC, datetime
-from pathlib import Path
 
-from dotenv import load_dotenv
+from arq import cron
+from arq.connections import RedisSettings
+from psycopg_pool import AsyncConnectionPool
 
-load_dotenv(Path(__file__).resolve().parent.parent.parent.parent / ".env")
-
-from arq import cron  # noqa: E402
-from arq.connections import RedisSettings  # noqa: E402
-from psycopg_pool import AsyncConnectionPool  # noqa: E402
-
-from api.gmail.auth import TokenStore  # noqa: E402
-from api.gmail.client import GmailClient  # noqa: E402
-from api.gmail.exceptions import GmailNotFoundError, GmailScopeError  # noqa: E402
-from api.gmail.hooks import (  # noqa: E402
+from api.gmail.auth import TokenStore
+from api.gmail.client import GmailClient
+from api.gmail.exceptions import GmailNotFoundError, GmailScopeError
+from api.gmail.hooks import (
     EmailEvent,
     LoggingHook,
     classify_direction,

--- a/services/api/src/api/gmail/workers.py
+++ b/services/api/src/api/gmail/workers.py
@@ -1,0 +1,292 @@
+"""arq background workers for the Gmail push pipeline.
+
+Handles push notifications, fallback polling, watch renewal, and
+dedup cleanup. All processing converges on _process_history() which
+is idempotent via the processed_messages table.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+from datetime import UTC, datetime
+
+from arq import cron
+from arq.connections import RedisSettings
+from psycopg_pool import AsyncConnectionPool
+
+from api.gmail.auth import TokenStore
+from api.gmail.client import GmailClient
+from api.gmail.exceptions import GmailNotFoundError, GmailScopeError
+from api.gmail.hooks import (
+    EmailEvent,
+    LoggingHook,
+    classify_direction,
+    classify_message_type,
+)
+
+logger = logging.getLogger(__name__)
+
+REDIS_URL = os.environ.get("REDIS_URL", "redis://localhost:6379")
+PUBSUB_TOPIC = os.environ.get("PUBSUB_TOPIC", "")
+DEBOUNCE_TTL = 60  # seconds
+
+
+async def startup(ctx: dict) -> None:
+    """Initialize shared resources for all worker jobs."""
+    database_url = os.environ.get("DATABASE_URL", "postgresql://dev:dev@localhost:5432/lrp_dev")
+    pool = AsyncConnectionPool(conninfo=database_url)
+    await pool.open()
+
+    encryption_key = os.environ.get("GMAIL_TOKEN_ENCRYPTION_KEY", "")
+    token_store = TokenStore(db_pool=pool, encryption_key=encryption_key)
+    gmail = GmailClient(token_store)
+
+    ctx["db"] = pool
+    ctx["token_store"] = token_store
+    ctx["gmail"] = gmail
+    ctx["hook"] = LoggingHook()
+    logger.info("worker startup complete")
+
+
+async def shutdown(ctx: dict) -> None:
+    """Clean up shared resources."""
+    pool = ctx.get("db")
+    if pool:
+        await pool.close()
+    logger.info("worker shutdown complete")
+
+
+async def process_gmail_push(ctx: dict, coordinator_email: str, history_id: str) -> None:
+    """Process a Gmail push notification.
+
+    Uses stored history_id as the cursor (more reliable than the push
+    notification's history_id, which may be stale if multiple pushes
+    arrive out of order).
+
+    Debounce: uses a Redis lock per coordinator to prevent redundant
+    processing when multiple push notifications arrive in rapid succession.
+    """
+    token_store: TokenStore = ctx["token_store"]
+
+    # Debounce: skip if we already processed for this coordinator recently
+    redis = ctx.get("redis")
+    if redis:
+        lock_key = f"push_lock:{coordinator_email}"
+        locked = await redis.set(lock_key, "1", nx=True, ex=DEBOUNCE_TTL)
+        if not locked:
+            logger.debug("debounced push for %s", coordinator_email)
+            return
+
+    # Use our stored cursor, not the push notification's history_id
+    stored_history_id = await token_store.get_history_id(coordinator_email)
+    if not stored_history_id:
+        # First push — establish baseline
+        logger.info("first push for %s, establishing baseline", coordinator_email)
+        await _establish_baseline(ctx, coordinator_email)
+        return
+
+    await _process_history(ctx, coordinator_email, stored_history_id)
+
+
+async def poll_gmail_history(ctx: dict) -> None:
+    """Fallback poll — process history for all watched coordinators.
+
+    Runs every 60 seconds to catch any push notifications that were
+    dropped, delayed, or missed during service restarts.
+    """
+    token_store: TokenStore = ctx["token_store"]
+    emails = await token_store.get_all_watched_emails()
+
+    for coordinator_email in emails:
+        try:
+            stored_history_id = await token_store.get_history_id(coordinator_email)
+            if not stored_history_id:
+                await _establish_baseline(ctx, coordinator_email)
+                continue
+
+            await _process_history(ctx, coordinator_email, stored_history_id)
+        except GmailScopeError:
+            logger.warning("scope error for %s — skipping until re-auth", coordinator_email)
+        except Exception:
+            logger.exception("poll error for %s", coordinator_email)
+
+
+async def renew_gmail_watches(ctx: dict) -> None:
+    """Re-register Pub/Sub watches before they expire (every 6 hours)."""
+    if not PUBSUB_TOPIC:
+        logger.debug("PUBSUB_TOPIC not configured — skipping watch renewal")
+        return
+
+    token_store: TokenStore = ctx["token_store"]
+    gmail: GmailClient = ctx["gmail"]
+    emails = await token_store.get_all_watched_emails()
+
+    for coordinator_email in emails:
+        try:
+            result = await gmail.watch(coordinator_email, PUBSUB_TOPIC)
+            expiry = datetime.fromtimestamp(int(result["expiration"]) / 1000, tz=UTC)
+            await token_store.update_watch_state(
+                coordinator_email,
+                result["historyId"],
+                expiry,
+            )
+            logger.info("renewed watch for %s, expires %s", coordinator_email, expiry)
+        except GmailScopeError:
+            logger.warning("scope error for %s — skipping watch renewal", coordinator_email)
+        except Exception:
+            logger.exception("watch renewal failed for %s", coordinator_email)
+
+
+async def cleanup_processed_messages(ctx: dict) -> None:
+    """Delete dedup records older than 30 days."""
+    pool: AsyncConnectionPool = ctx["db"]
+    async with pool.connection() as conn:
+        result = await conn.execute(
+            "DELETE FROM processed_messages WHERE processed_at < now() - INTERVAL '30 days'"
+        )
+        logger.info("cleaned up old processed messages: %s rows", result.rowcount)
+
+
+# --- Internal helpers ---
+
+
+async def _establish_baseline(ctx: dict, coordinator_email: str) -> None:
+    """Set the initial history cursor for a coordinator without processing old emails."""
+    gmail: GmailClient = ctx["gmail"]
+    token_store: TokenStore = ctx["token_store"]
+
+    try:
+        profile = await gmail.get_profile(coordinator_email)
+        history_id = profile["historyId"]
+        await token_store.update_history_id(coordinator_email, str(history_id))
+        logger.info("established baseline for %s at history_id=%s", coordinator_email, history_id)
+    except GmailScopeError:
+        raise
+    except Exception:
+        logger.exception("failed to establish baseline for %s", coordinator_email)
+
+
+async def _process_history(ctx: dict, coordinator_email: str, start_history_id: str) -> None:
+    """Core processing loop shared by push and poll paths.
+
+    1. history.list(startHistoryId) → list of new message IDs
+    2. For each message ID:
+       a. Skip if already in processed_messages (idempotent)
+       b. Mark as processed (at-most-once)
+       c. Fetch full message
+       d. Fetch thread for forward detection context
+       e. Classify direction and type
+       f. Build EmailEvent and fire hook
+    3. Update stored last_history_id
+    """
+    gmail: GmailClient = ctx["gmail"]
+    token_store: TokenStore = ctx["token_store"]
+    pool: AsyncConnectionPool = ctx["db"]
+    hook = ctx["hook"]
+
+    try:
+        history_response = await gmail.history_list(
+            coordinator_email,
+            start_history_id,
+            history_types=["messageAdded"],
+        )
+    except GmailNotFoundError:
+        # History ID expired (>30 days stale) — re-baseline
+        logger.warning("history_id expired for %s, re-establishing baseline", coordinator_email)
+        await _establish_baseline(ctx, coordinator_email)
+        return
+
+    # Extract new message IDs from history
+    new_message_ids: list[str] = []
+    for entry in history_response.get("history", []):
+        for msg_added in entry.get("messagesAdded", []):
+            msg_id = msg_added.get("message", {}).get("id")
+            if msg_id:
+                new_message_ids.append(msg_id)
+
+    if not new_message_ids:
+        # Advance cursor even if no new messages
+        new_history_id = history_response.get("historyId")
+        if new_history_id:
+            await token_store.update_history_id(coordinator_email, str(new_history_id))
+        return
+
+    # Process each new message
+    threads_cache: dict[str, list] = {}
+
+    for msg_id in new_message_ids:
+        try:
+            # Dedup check
+            async with pool.connection() as conn:
+                cur = await conn.execute(
+                    "SELECT EXISTS("
+                    "SELECT 1 FROM processed_messages "
+                    "WHERE gmail_message_id = %(id)s)",
+                    {"id": msg_id},
+                )
+                row = await cur.fetchone()
+                if row and row[0]:
+                    continue
+
+            # Mark as processed BEFORE firing hook (at-most-once)
+            async with pool.connection() as conn:
+                await conn.execute(
+                    """
+                    INSERT INTO processed_messages (gmail_message_id, coordinator_email)
+                    VALUES (%(id)s, %(email)s)
+                    ON CONFLICT (gmail_message_id) DO NOTHING
+                    """,
+                    {"id": msg_id, "email": coordinator_email},
+                )
+
+            # Fetch full message
+            message = await gmail.get_message(coordinator_email, msg_id)
+
+            # Fetch thread for forward detection (cached per thread)
+            thread_id = message.thread_id
+            if thread_id not in threads_cache:
+                thread = await gmail.get_thread(coordinator_email, thread_id)
+                threads_cache[thread_id] = thread.messages
+            thread_messages = threads_cache[thread_id]
+
+            # Classify
+            direction = classify_direction(message, coordinator_email)
+            prior_messages = [
+                m for m in thread_messages if m.id != message.id and m.date < message.date
+            ]
+            message_type, new_participants = classify_message_type(message, prior_messages)
+
+            # Build and fire event
+            event = EmailEvent(
+                message=message,
+                coordinator_email=coordinator_email,
+                direction=direction,
+                message_type=message_type,
+                new_participants=new_participants,
+            )
+            await hook.on_email(event)
+
+        except Exception:
+            logger.exception("failed to process message %s for %s", msg_id, coordinator_email)
+
+    # Advance cursor
+    new_history_id = history_response.get("historyId")
+    if new_history_id:
+        await token_store.update_history_id(coordinator_email, str(new_history_id))
+
+
+class WorkerSettings:
+    """arq worker configuration."""
+
+    functions = [process_gmail_push]  # noqa: RUF012
+    cron_jobs = [  # noqa: RUF012
+        cron(poll_gmail_history, second=0),  # every 60s
+        cron(renew_gmail_watches, hour={0, 6, 12, 18}, minute=0, second=0),
+        cron(cleanup_processed_messages, hour=3, minute=0, second=0),
+    ]
+    on_startup = startup
+    on_shutdown = shutdown
+    redis_settings = RedisSettings.from_dsn(REDIS_URL)
+    max_jobs = 50
+    job_timeout = 120

--- a/services/api/src/api/gmail/workers.py
+++ b/services/api/src/api/gmail/workers.py
@@ -10,15 +10,20 @@ from __future__ import annotations
 import logging
 import os
 from datetime import UTC, datetime
+from pathlib import Path
 
-from arq import cron
-from arq.connections import RedisSettings
-from psycopg_pool import AsyncConnectionPool
+from dotenv import load_dotenv
 
-from api.gmail.auth import TokenStore
-from api.gmail.client import GmailClient
-from api.gmail.exceptions import GmailNotFoundError, GmailScopeError
-from api.gmail.hooks import (
+load_dotenv(Path(__file__).resolve().parent.parent.parent.parent / ".env")
+
+from arq import cron  # noqa: E402
+from arq.connections import RedisSettings  # noqa: E402
+from psycopg_pool import AsyncConnectionPool  # noqa: E402
+
+from api.gmail.auth import TokenStore  # noqa: E402
+from api.gmail.client import GmailClient  # noqa: E402
+from api.gmail.exceptions import GmailNotFoundError, GmailScopeError  # noqa: E402
+from api.gmail.hooks import (  # noqa: E402
     EmailEvent,
     LoggingHook,
     classify_direction,
@@ -34,6 +39,7 @@ DEBOUNCE_TTL = 60  # seconds
 
 async def startup(ctx: dict) -> None:
     """Initialize shared resources for all worker jobs."""
+    logging.basicConfig(level=logging.INFO, format="%(levelname)s:%(name)s: %(message)s")
     database_url = os.environ.get("DATABASE_URL", "postgresql://dev:dev@localhost:5432/lrp_dev")
     pool = AsyncConnectionPool(conninfo=database_url)
     await pool.open()

--- a/services/api/src/api/main.py
+++ b/services/api/src/api/main.py
@@ -8,6 +8,8 @@ from dotenv import load_dotenv
 load_dotenv(Path(__file__).resolve().parent.parent.parent / ".env")
 
 import sentry_sdk  # noqa: E402
+from arq import create_pool  # noqa: E402
+from arq.connections import RedisSettings  # noqa: E402
 from fastapi import FastAPI  # noqa: E402
 from fastapi.staticfiles import StaticFiles  # noqa: E402
 from psycopg_pool import AsyncConnectionPool  # noqa: E402
@@ -17,6 +19,8 @@ from sentry_sdk.integrations.fastapi import FastApiIntegration  # noqa: E402
 from api.addon.routes import addon_router, oauth_router  # noqa: E402
 from api.gmail.auth import TokenStore  # noqa: E402
 from api.gmail.client import GmailClient  # noqa: E402
+from api.gmail.hooks import LoggingHook  # noqa: E402
+from api.gmail.webhook import webhook_router  # noqa: E402
 from api.scheduling.service import LoopService  # noqa: E402
 
 logger = logging.getLogger(__name__)
@@ -51,8 +55,24 @@ async def lifespan(app: FastAPI):
     app.state.scheduling = LoopService(db_pool=pool, gmail=gmail)
     logger.info("LoopService initialized")
 
+    # Redis for arq job queue (push pipeline)
+    redis_url = os.environ.get("REDIS_URL", "redis://localhost:6379")
+    try:
+        redis = await create_pool(RedisSettings.from_dsn(redis_url))
+        app.state.redis = redis
+        logger.info("Redis pool connected for push pipeline")
+    except Exception:
+        app.state.redis = None
+        logger.warning("Redis not available — push pipeline disabled, poll fallback only")
+
+    # Email hook — default is logging, replaced by agent in production
+    app.state.email_hook = LoggingHook()
+
     yield
 
+    redis = getattr(app.state, "redis", None)
+    if redis:
+        redis.close()
     await pool.close()
 
 
@@ -65,6 +85,7 @@ if static_dir.exists():
 
 app.include_router(addon_router)
 app.include_router(oauth_router)
+app.include_router(webhook_router)
 
 
 @app.get("/health")

--- a/services/api/src/api/main.py
+++ b/services/api/src/api/main.py
@@ -72,7 +72,7 @@ async def lifespan(app: FastAPI):
 
     redis = getattr(app.state, "redis", None)
     if redis:
-        redis.close()
+        await redis.close()
     await pool.close()
 
 

--- a/services/api/tests/test_gmail_hooks.py
+++ b/services/api/tests/test_gmail_hooks.py
@@ -1,0 +1,191 @@
+"""Unit tests for email event classification logic."""
+
+from datetime import UTC, datetime
+
+from api.gmail.hooks import (
+    EmailEvent,
+    LoggingHook,
+    MessageDirection,
+    MessageType,
+    classify_direction,
+    classify_message_type,
+)
+from api.gmail.models import EmailAddress, Message
+
+
+def _make_message(
+    *,
+    from_email: str = "sender@example.com",
+    to: list[str] | None = None,
+    cc: list[str] | None = None,
+    message_id_header: str | None = "msg-1",
+    msg_id: str = "m1",
+    thread_id: str = "t1",
+    date: datetime | None = None,
+) -> Message:
+    """Helper to build a Message for testing."""
+    return Message(
+        id=msg_id,
+        thread_id=thread_id,
+        subject="Test",
+        **{"from": EmailAddress(email=from_email)},
+        to=[EmailAddress(email=e) for e in (to or ["recipient@example.com"])],
+        cc=[EmailAddress(email=e) for e in (cc or [])],
+        date=date or datetime(2026, 1, 1, tzinfo=UTC),
+        body_text="test body",
+        message_id_header=message_id_header,
+    )
+
+
+class TestClassifyDirection:
+    def test_incoming_message(self):
+        msg = _make_message(from_email="external@example.com")
+        assert classify_direction(msg, "coordinator@lrp.com") == MessageDirection.INCOMING
+
+    def test_outgoing_message(self):
+        msg = _make_message(from_email="coordinator@lrp.com")
+        assert classify_direction(msg, "coordinator@lrp.com") == MessageDirection.OUTGOING
+
+    def test_case_insensitive(self):
+        msg = _make_message(from_email="Coordinator@LRP.com")
+        assert classify_direction(msg, "coordinator@lrp.com") == MessageDirection.OUTGOING
+
+
+class TestClassifyMessageType:
+    def test_new_thread_no_prior_messages(self):
+        msg = _make_message()
+        msg_type, new_participants = classify_message_type(msg, [])
+        assert msg_type == MessageType.NEW_THREAD
+        assert new_participants == []
+
+    def test_reply_same_participants(self):
+        prior = _make_message(
+            from_email="alice@example.com",
+            to=["bob@example.com"],
+            date=datetime(2026, 1, 1, tzinfo=UTC),
+        )
+        reply = _make_message(
+            from_email="bob@example.com",
+            to=["alice@example.com"],
+            msg_id="m2",
+            date=datetime(2026, 1, 2, tzinfo=UTC),
+        )
+        msg_type, new_participants = classify_message_type(reply, [prior])
+        assert msg_type == MessageType.REPLY
+        assert new_participants == []
+
+    def test_forward_adds_new_participant(self):
+        prior = _make_message(
+            from_email="alice@example.com",
+            to=["coordinator@lrp.com"],
+            date=datetime(2026, 1, 1, tzinfo=UTC),
+        )
+        forward = _make_message(
+            from_email="coordinator@lrp.com",
+            to=["recruiter@lrp.com"],
+            cc=["alice@example.com"],
+            msg_id="m2",
+            date=datetime(2026, 1, 2, tzinfo=UTC),
+        )
+        msg_type, new_participants = classify_message_type(forward, [prior])
+        assert msg_type == MessageType.FORWARD
+        assert len(new_participants) == 1
+        assert new_participants[0].email == "recruiter@lrp.com"
+
+    def test_reply_all_no_new_participants(self):
+        prior = _make_message(
+            from_email="alice@example.com",
+            to=["bob@example.com", "carol@example.com"],
+            date=datetime(2026, 1, 1, tzinfo=UTC),
+        )
+        reply = _make_message(
+            from_email="bob@example.com",
+            to=["alice@example.com", "carol@example.com"],
+            msg_id="m2",
+            date=datetime(2026, 1, 2, tzinfo=UTC),
+        )
+        msg_type, _new_participants = classify_message_type(reply, [prior])
+        assert msg_type == MessageType.REPLY
+
+    def test_case_insensitive_participant_matching(self):
+        prior = _make_message(
+            from_email="Alice@Example.com",
+            to=["Bob@Example.com"],
+            date=datetime(2026, 1, 1, tzinfo=UTC),
+        )
+        reply = _make_message(
+            from_email="bob@example.com",
+            to=["alice@example.com"],
+            msg_id="m2",
+            date=datetime(2026, 1, 2, tzinfo=UTC),
+        )
+        msg_type, _ = classify_message_type(reply, [prior])
+        assert msg_type == MessageType.REPLY
+
+    def test_forward_with_multiple_new_participants(self):
+        prior = _make_message(
+            from_email="alice@example.com",
+            to=["coordinator@lrp.com"],
+            date=datetime(2026, 1, 1, tzinfo=UTC),
+        )
+        forward = _make_message(
+            from_email="coordinator@lrp.com",
+            to=["new1@example.com", "new2@example.com"],
+            msg_id="m2",
+            date=datetime(2026, 1, 2, tzinfo=UTC),
+        )
+        msg_type, new_participants = classify_message_type(forward, [prior])
+        assert msg_type == MessageType.FORWARD
+        assert len(new_participants) == 2
+
+    def test_cumulative_participants_across_multiple_messages(self):
+        """Reply-all that includes someone from an earlier message is not a forward."""
+        msg1 = _make_message(
+            from_email="alice@example.com",
+            to=["coordinator@lrp.com"],
+            msg_id="m1",
+            date=datetime(2026, 1, 1, tzinfo=UTC),
+        )
+        msg2 = _make_message(
+            from_email="coordinator@lrp.com",
+            to=["alice@example.com"],
+            cc=["bob@example.com"],
+            msg_id="m2",
+            date=datetime(2026, 1, 2, tzinfo=UTC),
+        )
+        msg3 = _make_message(
+            from_email="alice@example.com",
+            to=["coordinator@lrp.com", "bob@example.com"],
+            msg_id="m3",
+            date=datetime(2026, 1, 3, tzinfo=UTC),
+        )
+        msg_type, _ = classify_message_type(msg3, [msg1, msg2])
+        assert msg_type == MessageType.REPLY
+
+
+class TestEmailEvent:
+    def test_event_serialization(self):
+        msg = _make_message()
+        event = EmailEvent(
+            message=msg,
+            coordinator_email="coordinator@lrp.com",
+            direction=MessageDirection.INCOMING,
+            message_type=MessageType.NEW_THREAD,
+            new_participants=[],
+        )
+        assert event.direction == MessageDirection.INCOMING
+        assert event.message_type == MessageType.NEW_THREAD
+
+
+class TestLoggingHook:
+    async def test_logging_hook_does_not_raise(self):
+        msg = _make_message()
+        event = EmailEvent(
+            message=msg,
+            coordinator_email="coordinator@lrp.com",
+            direction=MessageDirection.INCOMING,
+            message_type=MessageType.NEW_THREAD,
+            new_participants=[],
+        )
+        hook = LoggingHook()
+        await hook.on_email(event)  # Should not raise

--- a/services/api/tests/test_gmail_scope_validation.py
+++ b/services/api/tests/test_gmail_scope_validation.py
@@ -1,0 +1,33 @@
+"""Unit tests for OAuth scope validation in TokenStore."""
+
+from api.gmail.exceptions import GmailAuthError, GmailScopeError
+
+
+class TestScopeValidation:
+    def test_scope_error_has_missing_scopes(self):
+        err = GmailScopeError("missing scopes", missing_scopes=["scope1", "scope2"])
+        assert err.missing_scopes == ["scope1", "scope2"]
+        assert "missing scopes" in str(err)
+
+    def test_scope_error_is_auth_error(self):
+        """GmailScopeError inherits from GmailAuthError for catch-all handling."""
+        err = GmailScopeError("test", missing_scopes=[])
+        assert isinstance(err, GmailAuthError)
+
+    def test_scope_validation_with_matching_scopes(self):
+        """When stored scopes cover required scopes, no error is raised."""
+        stored_scopes = ["https://www.googleapis.com/auth/gmail.modify"]
+        required = set(stored_scopes)
+        granted = set(stored_scopes)
+        missing = required - granted
+        assert len(missing) == 0
+
+    def test_scope_validation_detects_missing_scopes(self):
+        """When stored scopes don't cover required scopes, missing are identified."""
+        required = {
+            "https://www.googleapis.com/auth/gmail.modify",
+            "https://www.googleapis.com/auth/calendar",
+        }
+        granted = {"https://www.googleapis.com/auth/gmail.modify"}
+        missing = required - granted
+        assert missing == {"https://www.googleapis.com/auth/calendar"}

--- a/services/api/tests/test_gmail_webhook.py
+++ b/services/api/tests/test_gmail_webhook.py
@@ -1,0 +1,101 @@
+"""Unit tests for the Gmail Pub/Sub webhook endpoint."""
+
+import base64
+import json
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from fastapi.testclient import TestClient
+
+
+@pytest.fixture
+def _mock_verify():
+    """Patch OIDC verification to always succeed."""
+    with patch("api.gmail.webhook._verify_pubsub_token", new_callable=AsyncMock) as mock:
+        mock.return_value = {"email": "gmail-api-push@system.gserviceaccount.com"}
+        yield mock
+
+
+@pytest.fixture
+def _mock_verify_fail():
+    """Patch OIDC verification to always fail."""
+    with patch("api.gmail.webhook._verify_pubsub_token", new_callable=AsyncMock) as mock:
+        mock.side_effect = ValueError("Invalid token")
+        yield mock
+
+
+def _make_pubsub_body(email: str = "coordinator@lrp.com", history_id: str = "12345") -> dict:
+    """Build a Pub/Sub push notification body."""
+    data = base64.b64encode(
+        json.dumps({"emailAddress": email, "historyId": history_id}).encode()
+    ).decode()
+    return {"message": {"data": data}}
+
+
+@pytest.fixture
+def app():
+    """Create a test app with mocked state."""
+    from api.main import app as real_app
+
+    # Mock Gmail client with token store
+    mock_token_store = AsyncMock()
+    mock_token_store.has_token = AsyncMock(return_value=True)
+    mock_gmail = MagicMock()
+    mock_gmail._token_store = mock_token_store
+    real_app.state.gmail = mock_gmail
+
+    # Mock Redis
+    mock_redis = AsyncMock()
+    mock_redis.enqueue_job = AsyncMock()
+    real_app.state.redis = mock_redis
+
+    return real_app
+
+
+class TestWebhook:
+    def test_valid_push_enqueues_job(self, app, _mock_verify):
+        client = TestClient(app, raise_server_exceptions=False)
+        response = client.post("/webhook/gmail", json=_make_pubsub_body())
+        assert response.status_code == 200
+        app.state.redis.enqueue_job.assert_called_once_with(
+            "process_gmail_push",
+            "coordinator@lrp.com",
+            "12345",
+        )
+
+    def test_auth_failure_returns_200(self, app, _mock_verify_fail):
+        """Auth failures still return 200 to prevent Pub/Sub retries."""
+        client = TestClient(app, raise_server_exceptions=False)
+        response = client.post("/webhook/gmail", json=_make_pubsub_body())
+        assert response.status_code == 200
+        app.state.redis.enqueue_job.assert_not_called()
+
+    def test_unknown_coordinator_skips(self, app, _mock_verify):
+        """Push for unknown coordinator is silently ignored."""
+        app.state.gmail._token_store.has_token = AsyncMock(return_value=False)
+        client = TestClient(app, raise_server_exceptions=False)
+        response = client.post("/webhook/gmail", json=_make_pubsub_body())
+        assert response.status_code == 200
+        app.state.redis.enqueue_job.assert_not_called()
+
+    def test_malformed_body_returns_200(self, app, _mock_verify):
+        """Malformed data still returns 200 to prevent Pub/Sub retries."""
+        client = TestClient(app, raise_server_exceptions=False)
+        response = client.post("/webhook/gmail", json={"message": {"data": "not-base64!!!"}})
+        assert response.status_code == 200
+
+    def test_missing_redis_returns_200(self, app, _mock_verify):
+        """If Redis is down, we log and return 200."""
+        app.state.redis = None
+        client = TestClient(app, raise_server_exceptions=False)
+        response = client.post("/webhook/gmail", json=_make_pubsub_body())
+        assert response.status_code == 200
+
+    def test_missing_email_or_history_id_returns_200(self, app, _mock_verify):
+        """Missing fields in notification are handled gracefully."""
+        data = base64.b64encode(json.dumps({}).encode()).decode()
+        body = {"message": {"data": data}}
+        client = TestClient(app, raise_server_exceptions=False)
+        response = client.post("/webhook/gmail", json=body)
+        assert response.status_code == 200
+        app.state.redis.enqueue_job.assert_not_called()


### PR DESCRIPTION
## Summary

Implements the Gmail async push pipeline RFC (#7, closes #6). This is a **decoupled infrastructure layer** in `api/gmail/` that watches coordinator inboxes via Gmail Pub/Sub push notifications and fires an async hook for downstream consumers (the scheduling agent).

- **Webhook**: OIDC-authenticated Pub/Sub endpoint (fixes PR #4's unauthenticated webhook bug)
- **Workers**: arq background jobs for push handling, 60s fallback poll, watch renewal, dedup cleanup
- **Hook interface**: `EmailHook` protocol with `LoggingHook` default — agent subscribes later
- **Classification**: Deterministic direction (incoming/outgoing) and type (new/reply/forward) via participant set diff
- **Scope validation**: Reads required scopes from `REQUIRED_SCOPES` env var, raises `GmailScopeError` on mismatch
- **Graceful degradation**: Works without Redis (poll-only) or Pub/Sub (manual watch registration)

### Files changed

| Area | Files | What |
|------|-------|------|
| Core pipeline | `hooks.py`, `webhook.py`, `workers.py` | Event model, OIDC webhook, arq workers |
| Gmail extensions | `client.py`, `auth.py`, `exceptions.py` | watch/history/profile methods, scope validation |
| Schema | `0003_gmail_push_pipeline.py`, `gmail_push.sql` | History tracking + dedup table |
| App wiring | `main.py` | Redis pool, webhook router, default hook |
| Dev scripts | `dev-worker.sh`, `dev-all.sh` | Worker process for local dev |
| Tests | `test_gmail_hooks.py`, `test_gmail_webhook.py`, `test_gmail_scope_validation.py` | 28 new tests |
| Docs | `references/gmail-push-setup.md` | Complete Pub/Sub + Railway setup guide |
| E2E test | `scripts/test_push_pipeline.py` | Self-send + cross-account incoming test |

## Deployment Steps (Railway)

### 1. Add Redis to Railway
- Railway project > **+ New** > **Database** > **Redis**
- Reference the Redis URL in the API service: `${{Redis.REDIS_URL}}`

### 2. Deploy the arq Worker
- Railway project > **+ New** > **Service** (same repo)
- Start command: `cd services/api && PYTHONPATH=src python -m arq api.gmail.workers.WorkerSettings`
- Add same env vars as API service (DATABASE_URL, REDIS_URL, GMAIL_TOKEN_ENCRYPTION_KEY, etc.)
- Worker does NOT need a public domain

### 3. Set Environment Variables
Add to both API and Worker services:

| Variable | Value |
|----------|-------|
| `PUBSUB_TOPIC` | `projects/ai-agents-dev-492713/topics/gmail-push` |
| `REDIS_URL` | `${{Redis.REDIS_URL}}` |
| `PUBSUB_WEBHOOK_AUDIENCE` | `https://api-staging-545f.up.railway.app/webhook/gmail` |
| `PUBSUB_SERVICE_ACCOUNT` | `pubsub-push@ai-agents-dev-492713.iam.gserviceaccount.com` |
| `REQUIRED_SCOPES` | `https://www.googleapis.com/auth/gmail.modify` |

### 4. Run Migration
```bash
railway run --service=api -- python -m yoyo apply --batch --database "$DATABASE_URL" ./migrations
```

### 5. Create Pub/Sub Subscription (if not done)
See `references/gmail-push-setup.md` for full instructions.

## Staging Test Plan

Run these tests in staging before promoting to production:

- [ ] **Migration**: Verify `processed_messages` table exists and `gmail_tokens` has `last_history_id`/`watch_expiry` columns
- [ ] **Worker startup**: Confirm arq worker logs show "Starting worker for 4 functions" and connects to Redis
- [ ] **Health check**: `curl https://api-staging-545f.up.railway.app/health` returns `{"status": "ok"}`
- [ ] **Webhook endpoint**: `curl -X POST https://api-staging-545f.up.railway.app/webhook/gmail` returns 200 (auth failure is logged, not returned)
- [ ] **Poll fallback**: Worker logs show `cron:poll_gmail_history` running every 60s without errors
- [ ] **Watch renewal**: Worker logs show `cron:renew_gmail_watches` running (every 6h, or trigger manually via test script)
- [ ] **E2E outgoing**: Run `test_push_pipeline.py --user nim@longridgepartners.com` — verify OUTGOING/NEW_THREAD classification
- [ ] **E2E incoming**: Send email from external account to coordinator — verify INCOMING/NEW_THREAD classification in worker logs
- [ ] **Forward detection**: Forward a thread email to a new recipient — verify FORWARD classification with correct `new_participants`
- [ ] **Reply detection**: Reply to an existing thread — verify REPLY classification
- [ ] **Dedup**: Send same email through both push and poll — verify only processed once (check `processed_messages` table)
- [ ] **Scope validation**: Temporarily add a fake scope to `REQUIRED_SCOPES` — verify `GmailScopeError` logged and coordinator skipped
- [ ] **Graceful degradation**: Stop Redis — verify API still starts (with warning) and poll runs without enqueueing
- [ ] **Existing tests**: Run `pytest tests/ --ignore=tests/test_scheduling_integration.py --ignore=tests/test_addon.py` — all 98 pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)