### PR TITLE
fix: record LLM output on LangFuse spans

### DIFF
--- a/services/api/src/api/ai/endpoint.py
+++ b/services/api/src/api/ai/endpoint.py
@@ -163,6 +163,7 @@ class LLMEndpoint:
                 response.provider,
                 response.latency_ms,
             )
+            langfuse.update_current_span(output=parsed.model_dump())
             return parsed
 
         # 6. Retry once with "fix your JSON" follow-up
@@ -189,6 +190,7 @@ class LLMEndpoint:
                 retry_response.model,
                 retry_response.latency_ms,
             )
+            langfuse.update_current_span(output=parsed.model_dump())
             return parsed
 
         raise LLMParseError(

--- a/services/api/tests/test_ai_endpoint.py
+++ b/services/api/tests/test_ai_endpoint.py
@@ -280,3 +280,42 @@ class TestLLMEndpointCall:
         mock_langfuse.start_as_current_observation.assert_called_once()
         call_kwargs = mock_langfuse.start_as_current_observation.call_args.kwargs
         assert call_kwargs["name"] == "classify_email"
+
+    async def test_observation_output_is_set(self, endpoint, mock_langfuse, mock_llm):
+        """Verify the parsed output is recorded on the LangFuse observation."""
+        mock_llm.complete.return_value = LLMResponse(
+            content=json.dumps({"classification": "scheduling", "confidence": 0.95}),
+            model="test",
+            provider="test",
+        )
+
+        await endpoint(
+            llm=mock_llm,
+            langfuse=mock_langfuse,
+            data=SampleInput(subject="Test", body="Test"),
+        )
+
+        mock_langfuse.update_current_span.assert_called_once_with(
+            output={"classification": "scheduling", "confidence": 0.95},
+        )
+
+    async def test_observation_output_set_on_retry(self, endpoint, mock_langfuse, mock_llm):
+        """Verify the output is recorded even when the first parse fails and retry succeeds."""
+        mock_llm.complete.side_effect = [
+            LLMResponse(content="not json", model="test", provider="test"),
+            LLMResponse(
+                content=json.dumps({"classification": "other", "confidence": 0.7}),
+                model="test",
+                provider="test",
+            ),
+        ]
+
+        await endpoint(
+            llm=mock_llm,
+            langfuse=mock_langfuse,
+            data=SampleInput(subject="Test", body="Test"),
+        )
+
+        mock_langfuse.update_current_span.assert_called_once_with(
+            output={"classification": "other", "confidence": 0.7},
+        )


### PR DESCRIPTION
## Summary

- Fixes #19 — LangFuse traces were showing `undefined` output for all LLM endpoint calls
- Root cause: `start_as_current_observation()` set `input=` but never called `update_current_span(output=...)` before the span closed
- Added `langfuse.update_current_span(output=parsed.model_dump())` on both the first-try and retry-success paths in `LLMEndpoint._execute()`

## Test plan

- [x] New test: `test_observation_output_is_set` — verifies output is recorded on successful first parse
- [x] New test: `test_observation_output_set_on_retry` — verifies output is recorded when retry succeeds
- [x] All 12 endpoint tests pass
- [ ] Deploy and verify traces show output in LangFuse dashboard

🤖 Generated with [Claude Code](https://claude.com/claude-code)