### PR TITLE
Fix: establish Gmail history baseline at OAuth time

### DIFF
--- a/services/api/src/api/addon/routes.py
+++ b/services/api/src/api/addon/routes.py
@@ -877,6 +877,16 @@ async def oauth_callback(code: str, state: str, request: Request):
     )
     logger.info("Stored OAuth token for %s", user_email)
 
+    # Establish Gmail history baseline immediately so no messages are missed.
+    # Any email arriving after this point will have a historyId > baseline.
+    try:
+        profile = await gmail.get_profile(user_email)
+        history_id = str(profile["historyId"])
+        await gmail._token_store.update_history_id(user_email, history_id)
+        logger.info("Established baseline for %s at history_id=%s", user_email, history_id)
+    except Exception:
+        logger.exception("Failed to establish baseline for %s during OAuth", user_email)
+
     return HTMLResponse(
         "<html><body><h2>Gmail access authorized.</h2>"
         "<p>You can close this tab and return to Gmail.</p>"

--- a/services/api/src/api/gmail/workers.py
+++ b/services/api/src/api/gmail/workers.py
@@ -130,9 +130,11 @@ async def process_gmail_push(ctx: dict, coordinator_email: str, history_id: str)
     # Use our stored cursor, not the push notification's history_id
     stored_history_id = await token_store.get_history_id(coordinator_email)
     if not stored_history_id:
-        # First push — establish baseline
-        logger.info("first push for %s, establishing baseline", coordinator_email)
-        await _establish_baseline(ctx, coordinator_email)
+        # No baseline yet (OAuth callback didn't set one, or legacy user).
+        # Use the push notification's history_id so we don't skip any messages.
+        logger.info("no baseline for %s, using push history_id=%s", coordinator_email, history_id)
+        await token_store.update_history_id(coordinator_email, history_id)
+        await _process_history(ctx, coordinator_email, history_id)
         return
 
     await _process_history(ctx, coordinator_email, stored_history_id)


### PR DESCRIPTION
## Summary

- **Root cause:** The Gmail history baseline (`historyId`) was established on the first push notification by calling `get_profile()`, which returns the *current* historyId at time of call. Any messages arriving between OAuth completion and the first push were silently skipped — they had a historyId lower than the baseline.
- **Fix:** Capture the baseline historyId in the OAuth callback immediately after storing the refresh token. This guarantees no messages after authentication are missed.
- **Fallback:** The push handler now uses the push notification's own historyId (instead of calling `get_profile()`) for legacy users or if the OAuth baseline failed to set.

## Changed files

- `services/api/src/api/addon/routes.py` — Add `get_profile()` + `update_history_id()` call after token storage in `oauth_callback`
- `services/api/src/api/gmail/workers.py` — Replace `_establish_baseline()` with push historyId usage + `_process_history()` in the no-baseline path

## Test plan

- [ ] Authenticate a new coordinator via OAuth
- [ ] Send a test email immediately after auth
- [ ] Verify the email is classified (LoggingHook output or ClassifierHook trace)
- [ ] Verify subsequent emails continue to be processed normally
- [ ] Verify re-authentication (re-OAuth) doesn't cause duplicate processing

🤖 Generated with [Claude Code](https://claude.com/claude-code)