### PR TITLE
Sentry instrumentation across API + Arq worker

### DIFF
--- a/references/sentry-setup.md
+++ b/references/sentry-setup.md
@@ -1,0 +1,189 @@
+# Sentry setup guide (ops)
+
+This guide walks through the manual Sentry UI setup for the LRP scheduling
+agent. It's written for the ops team and assumes you have admin access to the
+Sentry organization. It does **not** cover code changes — those live in the API
+and worker codebases and are handled separately.
+
+Estimated time: 30–45 minutes first time.
+
+## 0. Prerequisites
+
+- Owner-level access to a Sentry organization at https://sentry.io (or our
+  self-hosted instance, if applicable).
+- Railway access for the scheduling-agent project (to set env vars).
+- The environments we're going to set up: `production`, `staging`, `local`
+  (local is optional — most devs skip Sentry locally).
+
+If you do not have a Sentry org yet, create one at
+https://sentry.io/signup/ — pick the **Developer (free)** plan. The free plan
+is 1 seat, 5k errors/mo, 10k spans/mo, 30-day retention. That is enough for
+one engineer running the app in production.
+
+## 1. Create the project
+
+1. In Sentry, click **Projects → Create Project**.
+2. Platform: **Python → FastAPI**.
+3. Alert frequency: **Alert me on every new issue** (we'll refine in step 5).
+4. Project name: `lrp-scheduling-agent`.
+5. Team: create a team called `lrp` if one doesn't exist, and assign the
+   project to it.
+6. Click **Create Project**. Sentry will show a DSN — copy it somewhere safe
+   for step 3. It looks like `https://<key>@o<org>.ingest.sentry.io/<id>`.
+
+> We are deliberately creating **one project**, not one per service. The API
+> and the Arq worker share a database and deployment; separating them in
+> Sentry makes correlating a request across them harder. We distinguish them
+> via the `service` tag instead (set in code).
+
+## 2. Configure environments
+
+1. Go to **Settings → Projects → lrp-scheduling-agent → Environments**.
+2. Make sure `production` and `staging` appear. If you don't see them yet,
+   they'll populate automatically the first time each environment sends an
+   event. You can also pre-create them here.
+3. Hide any noisy environments you don't want in the default view (e.g.
+   `local`) via the "Hidden environments" list.
+
+## 3. Set the DSN in Railway
+
+1. In Railway, open the scheduling-agent project.
+2. For **each service** (`api` and any worker service), set these env vars:
+   - `SENTRY_DSN` — the DSN from step 1.
+   - `ENVIRONMENT` — `production` or `staging` depending on the service
+     environment. (This is what the code reads to tag events.)
+3. Redeploy the service. You should see the first events appear in Sentry
+   within a minute.
+
+## 4. Configure data scrubbing (important — privacy)
+
+We handle candidate and coordinator emails, thread subjects, and sometimes
+email body snippets. We must make sure Sentry does not retain this data.
+
+1. Go to **Settings → Security & Privacy** at the **organization** level
+   (scrubbing is configured org-wide).
+2. Under **Data Scrubber**, toggle **ON**:
+   - Require Data Scrubber: **on**
+   - Use Default Scrubbers: **on**
+   - Scrub IP Addresses: **on**
+3. Under **Advanced Data Scrubbing**, add rules for PII we specifically want
+   to mask. At minimum:
+   - Method: **Mask** · Data Type: **Email Address** · Source: `**`
+   - Method: **Mask** · Data Type: **Credit Card Number** · Source: `**`
+     (defensive — we don't handle these, but belt and suspenders)
+   - Method: **Remove** · Data Type: **Anything** · Source:
+     `$frame.vars.candidate_email`
+     (and any other var names we find that carry PII — update this list as
+     the codebase grows)
+4. Under **Allowed Domains**, leave empty (we accept events from anywhere —
+   Railway hostnames change).
+
+## 5. Set up alert rules
+
+We want two classes of alerts:
+
+### 5a. Issue alert: any new error in production
+
+1. **Alerts → Create Alert → Issues**.
+2. **When:** a new issue is created.
+3. **If:** `event.environment` equals `production`.
+4. **Then:** send a notification to an email (the ops on-call address) **and**
+   to Slack if we have the Slack integration installed (Settings →
+   Integrations → Slack).
+5. Rate limit: 1 notification per issue per hour (prevents alert storms).
+6. Name it: `prod: new issue`.
+
+### 5b. Metric alert: error spike
+
+1. **Alerts → Create Alert → Number of Errors**.
+2. Filter: `environment:production`.
+3. Condition: `errors > 20 in any 5 minute window`.
+4. Action: same notification targets as 5a.
+5. Name it: `prod: error spike`.
+
+### 5c. (Optional) WhatsApp
+
+Sentry has **no native WhatsApp integration**. If WhatsApp alerts are
+required:
+
+- Option A: Add a Sentry **Webhook** alert action pointing at a
+  Twilio-backed endpoint we host. This is custom code, not a UI-only setup.
+- Option B: Use Zapier's Sentry → WhatsApp zap. Lower engineering cost but
+  adds a third-party dependency and latency.
+
+Recommend we start with email + Slack and defer WhatsApp.
+
+## 6. Performance monitoring
+
+1. Go to **Performance** in the left nav — confirm events are coming in. The
+   API is configured with `traces_sample_rate=0.2` (20% of transactions).
+2. Star the most important transactions (e.g. `POST /addon/draft-email`,
+   `worker.poll_gmail_history`) so they appear on the project dashboard.
+3. Set a **performance alert** for transaction duration regressions:
+   - **Alerts → Create Alert → Transaction Duration**.
+   - Filter: `environment:production`.
+   - Condition: `p95 > 5s over 10 minutes`.
+   - Notification: same as 5a.
+
+## 7. Quotas and spend controls
+
+The free plan is 5k errors / 10k performance spans per month. If we exceed
+these, Sentry drops events silently — we should be alerted *before* that
+happens.
+
+1. **Settings → Subscription → Usage & Billing**.
+2. Under **On-Demand Budget**, leave at **$0** to guarantee no surprise
+   charges. This means quota-exhausted events are dropped rather than billed.
+3. Under **Usage Alerts**, set:
+   - Alert at **80%** of monthly error quota → ops email.
+   - Alert at **80%** of monthly performance quota → ops email.
+4. If we start hitting 80% regularly, upgrade to the Team plan ($26/mo at
+   time of writing) or tighten `traces_sample_rate` in the API code.
+
+## 8. Team access
+
+Free plan = 1 seat. If more than one engineer needs access:
+
+- Option A: share a single login (not recommended — no audit trail).
+- Option B: upgrade to the Team plan, then **Settings → Members → Invite
+  Member** with role `Member` (not `Owner`) for additional engineers.
+
+## 9. Integrations worth installing
+
+Under **Settings → Integrations**:
+
+- **GitHub** — links stack-traces to source code, lets issues reference
+  commits. Install and link to the `lrp-scheduling-agent` repo.
+- **Slack** — for alert delivery. Install at the workspace level, then
+  connect the `#lrp-alerts` channel (create it first in Slack).
+- **Railway** — there's no native Railway integration. Release tracking can
+  be done by calling the Sentry CLI from Railway's deploy hook; ask eng
+  before enabling.
+
+## 10. Sanity check
+
+Trigger a test event to confirm the pipeline works end-to-end:
+
+1. In Railway, connect to the API service shell.
+2. Run: `python -c "import sentry_sdk; sentry_sdk.capture_message('sentry test from ops', level='error')"`
+3. In Sentry, check **Issues** — the test message should appear within ~30s
+   tagged with `environment:production`.
+4. Click through to confirm data scrubbing is applied (no raw emails in the
+   breadcrumbs or stack locals).
+5. Acknowledge the test issue and mark resolved.
+
+## 11. Document the DSN
+
+Once verified, record the DSN (not the secret — the DSN is considered
+semi-public) in the team's password manager under `lrp-scheduling-agent /
+sentry / DSN`. The code never logs the DSN, so rotating it requires only
+updating the Railway env var and redeploying.
+
+## What is NOT covered by this guide
+
+- Adding structured logs / INFO log forwarding to Sentry Logs — handled in
+  code when/if we decide to ship logs (see issue #25 discussion).
+- Setting up a second project for multi-customer routing — we are explicitly
+  single-project today.
+- PagerDuty / Opsgenie — PRD non-goals.
+- LLM tracing — handled by LangFuse, not Sentry.

--- a/services/api/src/api/ai/llm_service.py
+++ b/services/api/src/api/ai/llm_service.py
@@ -17,6 +17,7 @@ from dataclasses import dataclass, field
 from typing import Any
 
 import litellm
+import sentry_sdk
 
 from api.ai.errors import LLMBudgetExceededError, LLMUnavailableError
 
@@ -206,30 +207,41 @@ class LLMService:
                 kwargs["response_format"] = response_format
 
             start = time.monotonic()
-            try:
-                response = await litellm.acompletion(**kwargs)
-            except Exception as exc:
+            with sentry_sdk.start_span(op="ai.llm", name=candidate_model) as span:
+                span.set_data("ai.attempt", i)
+                span.set_data("ai.is_failover", i > 0)
+                try:
+                    response = await litellm.acompletion(**kwargs)
+                except Exception as exc:
+                    elapsed_ms = (time.monotonic() - start) * 1000
+                    span.set_data("ai.latency_ms", elapsed_ms)
+                    span.set_status("internal_error")
+                    error_msg = str(exc).lower()
+
+                    if "budget" in error_msg or "spend" in error_msg:
+                        raise LLMBudgetExceededError(str(exc)) from exc
+
+                    # 400-level client errors don't failover (caller's fault)
+                    if "400" in error_msg or "bad request" in error_msg:
+                        raise LLMUnavailableError(
+                            f"Bad request to '{candidate_model}': {exc}"
+                        ) from exc
+
+                    errors.append(f"{candidate_model}: {exc} ({elapsed_ms:.0f}ms)")
+                    if i < len(chain) - 1:
+                        logger.warning(
+                            "Provider failed for '%s' (%.0fms), failing over: %s",
+                            candidate_model,
+                            elapsed_ms,
+                            exc,
+                        )
+                    continue
+
                 elapsed_ms = (time.monotonic() - start) * 1000
-                error_msg = str(exc).lower()
-
-                if "budget" in error_msg or "spend" in error_msg:
-                    raise LLMBudgetExceededError(str(exc)) from exc
-
-                # 400-level client errors don't failover (caller's fault)
-                if "400" in error_msg or "bad request" in error_msg:
-                    raise LLMUnavailableError(f"Bad request to '{candidate_model}': {exc}") from exc
-
-                errors.append(f"{candidate_model}: {exc} ({elapsed_ms:.0f}ms)")
-                if i < len(chain) - 1:
-                    logger.warning(
-                        "Provider failed for '%s' (%.0fms), failing over: %s",
-                        candidate_model,
-                        elapsed_ms,
-                        exc,
-                    )
-                continue
-
-            elapsed_ms = (time.monotonic() - start) * 1000
+                span.set_data("ai.latency_ms", elapsed_ms)
+                if response.usage:
+                    span.set_data("ai.prompt_tokens", response.usage.prompt_tokens or 0)
+                    span.set_data("ai.completion_tokens", response.usage.completion_tokens or 0)
 
             # Log if we had to failover
             if i > 0:

--- a/services/api/src/api/classifier/queries.py
+++ b/services/api/src/api/classifier/queries.py
@@ -4,6 +4,10 @@ from pathlib import Path
 
 import aiosql
 
+from api.observability import TracedQueries
+
 _SQL_DIR = Path(__file__).resolve().parent.parent.parent.parent / "queries"
 
-queries = aiosql.from_path(_SQL_DIR / "suggestions.sql", "apsycopg", mandatory_parameters=False)
+queries = TracedQueries(
+    aiosql.from_path(_SQL_DIR / "suggestions.sql", "apsycopg", mandatory_parameters=False)
+)

--- a/services/api/src/api/drafts/queries.py
+++ b/services/api/src/api/drafts/queries.py
@@ -4,6 +4,10 @@ from pathlib import Path
 
 import aiosql
 
+from api.observability import TracedQueries
+
 _SQL_DIR = Path(__file__).resolve().parent.parent.parent.parent / "queries"
 
-queries = aiosql.from_path(_SQL_DIR / "drafts.sql", "apsycopg", mandatory_parameters=False)
+queries = TracedQueries(
+    aiosql.from_path(_SQL_DIR / "drafts.sql", "apsycopg", mandatory_parameters=False)
+)

--- a/services/api/src/api/gmail/_transport.py
+++ b/services/api/src/api/gmail/_transport.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 import asyncio
 from typing import TYPE_CHECKING, Any
 
+import sentry_sdk
 from googleapiclient.discovery import build
 
 if TYPE_CHECKING:
@@ -26,12 +27,16 @@ def _execute_sync(credentials: Credentials, fn) -> Any:
     return fn(service)
 
 
-async def execute(credentials: Credentials, fn) -> Any:
+async def execute(credentials: Credentials, fn, *, op_name: str = "gmail") -> Any:
     """Run a Gmail API call in a thread pool.
 
     Usage:
         result = await execute(creds, lambda svc: svc.users().messages().get(
             userId="me", id=msg_id, format="full"
         ).execute())
+
+    ``op_name`` is surfaced on the Sentry span so one transaction can show
+    distinct messages.get vs messages.send vs history.list calls.
     """
-    return await asyncio.to_thread(_execute_sync, credentials, fn)
+    with sentry_sdk.start_span(op="http.client", name=f"gmail:{op_name}"):
+        return await asyncio.to_thread(_execute_sync, credentials, fn)

--- a/services/api/src/api/gmail/client.py
+++ b/services/api/src/api/gmail/client.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import base64
 import logging
+import sys
 from email.mime.text import MIMEText
 from typing import TYPE_CHECKING
 
@@ -75,10 +76,17 @@ class GmailClient:
         return await self._token_store.load_credentials(user_email)
 
     async def _exec(self, user_email: str, fn):
-        """Load credentials and execute a Gmail API call."""
+        """Load credentials and execute a Gmail API call.
+
+        The calling public method's name (e.g. ``watch``, ``send_message``) is
+        forwarded to ``_transport.execute`` as the Sentry span ``op_name`` so
+        traces distinguish individual Gmail operations without threading the
+        name through every call site.
+        """
+        caller_name = sys._getframe(1).f_code.co_name
         creds = await self._get_creds(user_email)
         try:
-            return await _transport.execute(creds, fn)
+            return await _transport.execute(creds, fn, op_name=caller_name)
         except HttpError as exc:
             raise _map_http_error(exc) from exc
 

--- a/services/api/src/api/gmail/workers.py
+++ b/services/api/src/api/gmail/workers.py
@@ -11,6 +11,7 @@ import logging
 import os
 from datetime import UTC, datetime
 
+import sentry_sdk
 from arq import cron
 from arq.connections import RedisSettings
 from psycopg_pool import AsyncConnectionPool
@@ -24,6 +25,7 @@ from api.gmail.hooks import (
     classify_direction,
     classify_message_type,
 )
+from api.observability import init_sentry
 
 logger = logging.getLogger(__name__)
 
@@ -38,6 +40,7 @@ CLASSIFIER_ENABLED = os.environ.get("CLASSIFIER_ENABLED", "false").lower() == "t
 async def startup(ctx: dict) -> None:
     """Initialize shared resources for all worker jobs."""
     logging.basicConfig(level=logging.INFO, format="%(levelname)s:%(name)s: %(message)s")
+    init_sentry(service="worker")
     database_url = os.environ.get("DATABASE_URL", "postgresql://dev:dev@localhost:5432/lrp_dev")
     pool = AsyncConnectionPool(conninfo=database_url)
     await pool.open()
@@ -104,6 +107,28 @@ async def shutdown(ctx: dict) -> None:
     if pool:
         await pool.close()
     logger.info("worker shutdown complete")
+
+
+async def on_job_start(ctx: dict) -> None:
+    """Open a fresh Sentry scope tagged with arq job metadata.
+
+    Arq reuses a single process for many jobs, so without per-job isolation the
+    scope accumulates tags across jobs and errors get attributed to whichever
+    job happened to run last.
+    """
+    scope = sentry_sdk.Scope.get_current_scope()
+    scope.clear()
+    scope.set_tag("service", "worker")
+    scope.set_tag("arq.job_id", ctx.get("job_id"))
+    scope.set_tag("arq.job_try", ctx.get("job_try"))
+    scope.set_tag("arq.function", ctx.get("enqueue_job", {}).get("function", ""))
+
+
+async def on_job_end(ctx: dict) -> None:
+    """Flush buffered events before arq moves on to the next job."""
+    client = sentry_sdk.get_client()
+    if client is not None:
+        client.flush(timeout=2.0)
 
 
 async def process_gmail_push(ctx: dict, coordinator_email: str, history_id: str) -> None:
@@ -337,6 +362,8 @@ class WorkerSettings:
     ]
     on_startup = startup
     on_shutdown = shutdown
+    on_job_start = on_job_start
+    on_job_end = on_job_end
     redis_settings = RedisSettings.from_dsn(REDIS_URL)
     max_jobs = 50
     job_timeout = 120

--- a/services/api/src/api/main.py
+++ b/services/api/src/api/main.py
@@ -7,14 +7,11 @@ from dotenv import load_dotenv
 
 load_dotenv(Path(__file__).resolve().parent.parent.parent / ".env")
 
-import sentry_sdk  # noqa: E402
 from arq import create_pool  # noqa: E402
 from arq.connections import RedisSettings  # noqa: E402
 from fastapi import FastAPI, Request  # noqa: E402
 from fastapi.staticfiles import StaticFiles  # noqa: E402
 from psycopg_pool import AsyncConnectionPool  # noqa: E402
-from sentry_sdk.integrations.asyncio import AsyncioIntegration  # noqa: E402
-from sentry_sdk.integrations.fastapi import FastApiIntegration  # noqa: E402
 
 from api.addon.routes import addon_router, oauth_router  # noqa: E402
 from api.ai import init_langfuse, init_llm_service  # noqa: E402
@@ -22,19 +19,12 @@ from api.gmail.auth import TokenStore  # noqa: E402
 from api.gmail.client import GmailClient  # noqa: E402
 from api.gmail.hooks import LoggingHook  # noqa: E402
 from api.gmail.webhook import webhook_router  # noqa: E402
+from api.observability import RequestIdMiddleware, init_sentry  # noqa: E402
 from api.scheduling.service import LoopService  # noqa: E402
 
 logger = logging.getLogger(__name__)
 
-sentry_sdk.init(
-    dsn=os.environ.get("SENTRY_DSN"),
-    environment=os.environ.get("ENVIRONMENT", "development"),
-    traces_sample_rate=0.2,
-    integrations=[
-        FastApiIntegration(),
-        AsyncioIntegration(),
-    ],
-)
+init_sentry(service="api")
 
 
 @asynccontextmanager
@@ -118,6 +108,7 @@ async def lifespan(app: FastAPI):
 
 
 app = FastAPI(title="LRP Scheduling Agent", lifespan=lifespan)
+app.add_middleware(RequestIdMiddleware)
 
 # Static files (logo, etc.) — directory relative to working directory (services/api/)
 static_dir = Path(__file__).resolve().parent.parent.parent / "static"

--- a/services/api/src/api/observability/__init__.py
+++ b/services/api/src/api/observability/__init__.py
@@ -1,0 +1,9 @@
+"""Observability primitives — shared Sentry init, request-ID middleware,
+and aiosql span wrapping. Imported by both the FastAPI app and the Arq worker
+so error/performance data converges on a single Sentry project.
+"""
+
+from api.observability.db_spans import TracedQueries
+from api.observability.sentry import RequestIdMiddleware, init_sentry
+
+__all__ = ["RequestIdMiddleware", "TracedQueries", "init_sentry"]

--- a/services/api/src/api/observability/db_spans.py
+++ b/services/api/src/api/observability/db_spans.py
@@ -1,0 +1,52 @@
+"""aiosql span wrapper.
+
+Captures query name, duration, and row count for every aiosql call without
+shipping parameters or result rows to Sentry — parameters include
+candidate/coordinator emails and subject lines that must not leak.
+"""
+
+from __future__ import annotations
+
+import functools
+import inspect
+from typing import Any
+
+import sentry_sdk
+
+
+class TracedQueries:
+    """Proxy around an aiosql ``Queries`` object.
+
+    Each async attribute access returns a wrapper that opens a ``db.query``
+    span named after the query and records the returned row count.
+    Non-callable attributes pass through unchanged.
+    """
+
+    def __init__(self, inner: Any) -> None:
+        self._inner = inner
+        self._wrapped: dict[str, Any] = {}
+
+    def __getattr__(self, name: str) -> Any:
+        if name.startswith("_"):
+            raise AttributeError(name)
+        if name in self._wrapped:
+            return self._wrapped[name]
+
+        attr = getattr(self._inner, name)
+        if not inspect.iscoroutinefunction(attr):
+            return attr
+
+        @functools.wraps(attr)
+        async def traced(*args: Any, **kwargs: Any) -> Any:
+            with sentry_sdk.start_span(op="db.query", name=name) as span:
+                result = await attr(*args, **kwargs)
+                if isinstance(result, list):
+                    span.set_data("db.rows_returned", len(result))
+                elif result is None:
+                    span.set_data("db.rows_returned", 0)
+                else:
+                    span.set_data("db.rows_returned", 1)
+                return result
+
+        self._wrapped[name] = traced
+        return traced

--- a/services/api/src/api/observability/sentry.py
+++ b/services/api/src/api/observability/sentry.py
@@ -1,0 +1,77 @@
+"""Shared Sentry initialization and request-ID middleware.
+
+Both the FastAPI app and the Arq worker call ``init_sentry`` on startup with
+their ``service`` tag. A single Sentry project collects events from both; the
+``service`` tag distinguishes API vs worker without splitting projects (keeps
+cross-component request traces intact).
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+import uuid
+from typing import TYPE_CHECKING
+
+import sentry_sdk
+from sentry_sdk.integrations.asyncio import AsyncioIntegration
+from sentry_sdk.integrations.fastapi import FastApiIntegration
+from sentry_sdk.integrations.logging import LoggingIntegration
+from starlette.middleware.base import BaseHTTPMiddleware
+
+if TYPE_CHECKING:
+    from collections.abc import Awaitable, Callable
+
+    from starlette.requests import Request
+    from starlette.responses import Response
+
+REQUEST_ID_HEADER = "X-Request-Id"
+
+
+def init_sentry(*, service: str) -> None:
+    """Initialize Sentry for a service.
+
+    INFO logs are captured as breadcrumbs automatically (attached to any later
+    error event) and also forwarded to Sentry Logs for retention beyond
+    Railway's log-drain window — that preserves the "where did the good path
+    stop" debugging trail without making INFO events burn the error quota.
+    """
+    dsn = os.environ.get("SENTRY_DSN")
+    if not dsn:
+        logging.getLogger(__name__).info("SENTRY_DSN not set — Sentry disabled for %s", service)
+        return
+
+    sentry_sdk.init(
+        dsn=dsn,
+        environment=os.environ.get("ENVIRONMENT", "development"),
+        release=os.environ.get("RAILWAY_GIT_COMMIT_SHA") or None,
+        traces_sample_rate=float(os.environ.get("SENTRY_TRACES_SAMPLE_RATE", "0.2")),
+        send_default_pii=False,
+        integrations=[
+            FastApiIntegration(),
+            AsyncioIntegration(),
+            LoggingIntegration(level=logging.INFO, event_level=logging.ERROR),
+        ],
+        _experiments={"enable_logs": True},
+    )
+    sentry_sdk.set_tag("service", service)
+
+
+class RequestIdMiddleware(BaseHTTPMiddleware):
+    """Honor incoming X-Request-Id or mint one, expose as Sentry tag + header.
+
+    The same id propagates into any Arq job enqueued during the request when
+    callers forward ``request.state.request_id`` as a job arg.
+    """
+
+    async def dispatch(
+        self,
+        request: Request,
+        call_next: Callable[[Request], Awaitable[Response]],
+    ) -> Response:
+        request_id = request.headers.get(REQUEST_ID_HEADER) or uuid.uuid4().hex
+        request.state.request_id = request_id
+        sentry_sdk.set_tag("request_id", request_id)
+        response = await call_next(request)
+        response.headers[REQUEST_ID_HEADER] = request_id
+        return response

--- a/services/api/src/api/scheduling/queries.py
+++ b/services/api/src/api/scheduling/queries.py
@@ -4,6 +4,10 @@ from pathlib import Path
 
 import aiosql
 
+from api.observability import TracedQueries
+
 _SQL_DIR = Path(__file__).resolve().parent.parent.parent.parent / "queries"
 
-queries = aiosql.from_path(_SQL_DIR / "scheduling.sql", "apsycopg", mandatory_parameters=False)
+queries = TracedQueries(
+    aiosql.from_path(_SQL_DIR / "scheduling.sql", "apsycopg", mandatory_parameters=False)
+)

--- a/services/api/src/api/scheduling/service.py
+++ b/services/api/src/api/scheduling/service.py
@@ -7,8 +7,11 @@ contact management, and email sending.
 from __future__ import annotations
 
 import json
+import os
 from datetime import datetime  # noqa: TC003
 from typing import TYPE_CHECKING, Any
+
+import sentry_sdk
 
 from api.ids import make_id
 from api.scheduling.models import (
@@ -39,6 +42,41 @@ if TYPE_CHECKING:
 async def _collect(async_gen) -> list:
     """Collect all rows from an aiosql async generator into a list."""
     return [row async for row in async_gen]
+
+
+def _email_domain(address: str) -> str:
+    """Return the lowercase domain from an email address, or empty string."""
+    _, _, domain = address.rpartition("@")
+    return domain.strip().lower()
+
+
+def _classify_recipients(
+    *, recipients: list[str], coordinator_email: str
+) -> tuple[list[str], bool]:
+    """Return (unique recipient domains, is_internal).
+
+    A send is internal when every recipient's domain is in
+    ``INTERNAL_EMAIL_DOMAINS`` (comma-separated env var). When the env var is
+    unset we fall back to the coordinator's own domain — coordinators are
+    always LRP employees, so this is a safe default for reporting.
+    """
+    configured = os.environ.get("INTERNAL_EMAIL_DOMAINS", "")
+    internal = {d.strip().lower() for d in configured.split(",") if d.strip()}
+    if not internal:
+        fallback = _email_domain(coordinator_email)
+        if fallback:
+            internal = {fallback}
+
+    domains: list[str] = []
+    seen: set[str] = set()
+    for address in recipients:
+        domain = _email_domain(address)
+        if domain and domain not in seen:
+            seen.add(domain)
+            domains.append(domain)
+
+    is_internal = bool(domains) and all(d in internal for d in domains)
+    return domains, is_internal
 
 
 class InvalidTransitionError(Exception):
@@ -445,6 +483,13 @@ class LoopService:
         auto_advance_to: StageState | None = None,
     ) -> None:
         """Send an email via Gmail and record the event. Optionally advance the stage."""
+        recipient_domains, is_internal = _classify_recipients(
+            recipients=to, coordinator_email=coordinator_email
+        )
+        scope = sentry_sdk.Scope.get_current_scope()
+        scope.set_tag("email.is_internal", is_internal)
+        scope.set_tag("email.recipient_domain", ",".join(recipient_domains))
+
         gmail_message_id = None
         if self._gmail:
             sent = await self._gmail.send_message(
@@ -468,6 +513,8 @@ class LoopService:
                     "subject": subject,
                     "gmail_message_id": gmail_message_id,
                     "gmail_thread_id": gmail_thread_id,
+                    "recipient_domains": recipient_domains,
+                    "is_internal": is_internal,
                 },
                 actor_email=coordinator_email,
             )


### PR DESCRIPTION
## Summary

Wires Sentry as the single pane of glass for observability across the API and the Arq worker, resolving the scope agreed on #25. One project receives events from both services, distinguished via a `service` tag.

## What changed

**New `api.observability` package** (`services/api/src/api/observability/`)
- `init_sentry(service)` — shared init with `LoggingIntegration` (INFO → breadcrumbs, ERROR → events), Sentry Logs experiment enabled, `send_default_pii=False`, release read from `RAILWAY_GIT_COMMIT_SHA`.
- `RequestIdMiddleware` — accepts or mints `X-Request-Id`, tags Sentry scope, echoes on response.
- `TracedQueries` — proxy around aiosql Queries that opens a `db.query` span per call with **name + duration + row count only** — no SQL params or row data are shipped to Sentry (candidate/coordinator emails must not leak).

**Instrumentation**
- `ai/llm_service.py` — each failover attempt wrapped in an `ai.llm` span, tagged with model, prompt/completion tokens, latency, and `is_failover`.
- `gmail/_transport.py` + `gmail/client.py` — `http.client` span per Gmail call. The public client method name (`watch`, `send_message`, etc.) is auto-captured via frame introspection in `_exec` so every call is distinguishable in Sentry without threading `op_name` through ~12 call sites.
- `gmail/workers.py` — `init_sentry(service="worker")` in startup, `on_job_start` clears the scope and tags `arq.job_id` / `arq.job_try` / `arq.function`, `on_job_end` flushes. Critical because arq reuses one process across jobs — without `scope.clear()`, tags from one job would bleed into the next.
- `scheduling/service.py` — `send_email()` classifies recipients via `INTERNAL_EMAIL_DOMAINS` env var (falls back to the coordinator's own domain), tags `email.is_internal` + `email.recipient_domain` on the span, and persists `recipient_domains` + `is_internal` into `loop_events.data` JSONB.

**Ops documentation**
- `references/sentry-setup.md` — manual Sentry UI guide for the ops team: project creation, Railway DSN wiring, org-wide PII scrubbing, alert rules, quota guards, sanity-check script.

## Why

Per the #25 PRD discussion:
- INFO logs as Sentry events would blow the free quota and leak PII → instead use LoggingIntegration breadcrumbs + Sentry Logs.
- DB query input/output logging would leak candidate/coordinator emails and exceed event size limits → spans with metadata only.
- Email metric "internal vs external" reporting belongs in Postgres (`loop_events`), not Sentry — but also tagged on spans for eng debugging.
- One project (with service tags) preserves cross-component request traces vs splitting api/worker into separate projects.

## No schema migration

Recipient domain + internal flag are stored in the existing `loop_events.data` JSONB column. `WHERE data->>'is_internal' = 'true'` is fine at LRP email volume; a generated column can land later if reporting needs index speed.

## Env vars to set in Railway before this is useful

On **both** api and worker services:
- `SENTRY_DSN` — from the Sentry project (see `references/sentry-setup.md` §1–3)
- `ENVIRONMENT` — `production` or `staging`
- `SENTRY_TRACES_SAMPLE_RATE` — optional, defaults to `0.2`
- `INTERNAL_EMAIL_DOMAINS` — optional, comma-separated. When unset, coordinator's own domain is treated as internal.

## Test plan

- [x] `uv run ruff check src/` — clean
- [x] `uv run pytest` — 230 passed, 10 pre-existing failures (confirmed identical on `main` pre-change; unrelated to this PR)
- [x] Smoke-tested `init_sentry`, `TracedQueries` proxy semantics, `_classify_recipients` internal/external/mixed cases
- [ ] Manual: set `SENTRY_DSN` in staging Railway, trigger a handled error, confirm it lands in Sentry with `service` + `environment` tags
- [ ] Manual: trigger a scheduling loop, confirm `db.query`, `http.client gmail:*`, and `ai.llm` spans all appear under one transaction
- [ ] Manual: send an external email, confirm `email.is_internal=false` tag on the span and `is_internal: false` in `loop_events.data`
- [ ] Manual: verify PII data scrubbing rules from §4 of the ops guide hide email addresses in a test event

🤖 Generated with [Claude Code](https://claude.com/claude-code)