### PR TITLE
fix: add missing migration for email_drafts.is_forward

### DIFF
--- a/services/api/migrations/0007_email_draft_is_forward.py
+++ b/services/api/migrations/0007_email_draft_is_forward.py
@@ -1,0 +1,22 @@
+"""Add is_forward boolean to email_drafts.
+
+Distinguishes forward drafts (new recipients, optional note) from reply
+drafts (same thread, required message body). Populated by the drafter at
+generation time; read by the sidebar to choose Send vs Forward UI.
+
+Backfills existing rows as false — the prior behavior treated everything
+as a reply, so false preserves that semantic for pre-existing drafts.
+"""
+
+from yoyo import step
+
+step(
+    """
+    ALTER TABLE email_drafts
+    ADD COLUMN is_forward BOOLEAN NOT NULL DEFAULT false;
+    """,
+    """
+    ALTER TABLE email_drafts
+    DROP COLUMN IF EXISTS is_forward;
+    """,
+)


### PR DESCRIPTION
## Summary

Adds migration `0007_email_draft_is_forward.py` to introduce the `is_forward` boolean column on `email_drafts`.

Commit [3c13f9b](https://github.com/nsadeh/lrp-scheduling-agent/commit/3c13f9b) (\"state change cleanup\") added `is_forward` references across the codebase — Pydantic model, service layer, INSERT/SELECT queries in `drafts.sql`/`suggestions.sql`, tests, and the overview card builder — but shipped without the schema change. Any fresh DB (or any environment that started from scratch since that commit) hits a `psycopg.errors.UndefinedColumn: column d.is_forward` 500 on the addon homepage.

Discovered while debugging issue [#29](https://github.com/nsadeh/lrp-scheduling-agent/issues/29) — the coordinator couldn't boot the sidebar locally, which is context worth noting there.

## Design choice: keep the column, don't compute at render

Considered dropping the column and computing `is_forward` at render time, but rejected it. The write-time logic (`_is_forward_draft` at [drafts/service.py:34](https://github.com/nsadeh/lrp-scheduling-agent/blob/main/services/api/src/api/drafts/service.py#L34)) requires the full thread-participant set, which the sidebar render path doesn't have. Faithful render-time computation would need a Gmail `threads.get` per draft card per sidebar open — hot path, unnecessary latency, new failure mode. The denormalization is justified: write-time context (fresh Gmail thread) is richer than read-time context (just the draft row).

## Migration details

- `ALTER TABLE email_drafts ADD COLUMN is_forward BOOLEAN NOT NULL DEFAULT false;`
- Backfills existing rows as `false` (pre-feature drafts were all treated as replies; `false` preserves that semantic).
- Rollback drops the column with `IF EXISTS`.
- No index — low-cardinality boolean, always read alongside other draft fields.

## Test plan

- [ ] `docker compose up -d postgres redis`
- [ ] `./scripts/dev-api.sh` — migration runs on startup, server boots without `UndefinedColumn`
- [ ] Open sidebar in Gmail (or curl the addon homepage endpoint) — 200 response, no exception
- [ ] Generate a forward draft (NEW stage → recruiter) and verify `is_forward=true` persists
- [ ] Generate a reply draft (AWAITING_* stage → client) and verify `is_forward=false`
- [ ] Existing tests pass: `uv run pytest services/api/tests/test_draft_service.py services/api/tests/test_overview_cards.py`