### PR TITLE
Dedupe contacts on loop creation (fix #32)

### DIFF
--- a/services/api/queries/scheduling.sql
+++ b/services/api/queries/scheduling.sql
@@ -32,6 +32,14 @@ RETURNING id, name, email, role, company, created_at;
 SELECT id, name, email, role, company, created_at
 FROM contacts WHERE id = :id;
 
+-- name: get_contact_by_email_and_role^
+-- Used to dedupe on loop creation: reuse an existing contact if the
+-- (email, role) pair already exists instead of inserting a duplicate.
+SELECT id, name, email, role, company, created_at
+FROM contacts
+WHERE email = :email AND role = :role
+LIMIT 1;
+
 -- name: search_contacts_by_prefix
 -- Autocomplete: search contacts by name prefix, optionally filtered by role.
 SELECT id, name, email, role, company, created_at
@@ -53,6 +61,14 @@ RETURNING id, name, email, company, created_at;
 -- name: get_client_contact^
 SELECT id, name, email, company, created_at
 FROM client_contacts WHERE id = :id;
+
+-- name: get_client_contact_by_email^
+-- Used to dedupe on loop creation: reuse an existing client contact if
+-- the email already exists instead of inserting a duplicate.
+SELECT id, name, email, company, created_at
+FROM client_contacts
+WHERE email = :email
+LIMIT 1;
 
 -- name: search_client_contacts_by_prefix
 SELECT id, name, email, company, created_at

--- a/services/api/src/api/addon/routes.py
+++ b/services/api/src/api/addon/routes.py
@@ -362,6 +362,28 @@ async def _handle_show_create_form(body: AddonRequest, svc: LoopService, email: 
         except Exception:
             logger.warning("Could not fetch message %s for pre-fill", message_id, exc_info=True)
 
+    # If a pre-filled email matches an existing contact, prefer the stored
+    # name/company so the form shows what will actually be persisted on
+    # submit — the dedup logic in find_or_create_contact keeps the stored
+    # row untouched, so showing the classifier-suggested name here would
+    # mislead the coordinator.
+    if prefill_client_email:
+        existing_client = await svc.get_client_contact_by_email(prefill_client_email)
+        if existing_client is not None:
+            prefill_client_name = existing_client.name
+            if existing_client.company:
+                prefill_client_company = existing_client.company
+    if prefill_recruiter_email:
+        existing_recruiter = await svc.get_contact_by_email(
+            prefill_recruiter_email, role="recruiter"
+        )
+        if existing_recruiter is not None:
+            prefill_recruiter_name = existing_recruiter.name
+    if prefill_cm_email:
+        existing_cm = await svc.get_contact_by_email(prefill_cm_email, role="client_manager")
+        if existing_cm is not None:
+            prefill_cm_name = existing_cm.name
+
     # Pass suggestion_id through so create_loop can resolve it
     suggestion_id = _get_param(body, "suggestion_id")
 

--- a/services/api/src/api/scheduling/service.py
+++ b/services/api/src/api/scheduling/service.py
@@ -114,6 +114,12 @@ class LoopService:
         self, name: str, email: str, role: str, company: str | None = None
     ) -> Contact:
         async with self._pool.connection() as conn, conn.transaction():
+            existing = await queries.get_contact_by_email_and_role(conn, email=email, role=role)
+            if existing is not None:
+                # Keep the stored row untouched — different loops may have
+                # typed different names for the same person; we must not
+                # silently clobber another coordinator's name.
+                return _row_to_contact(existing)
             row = await queries.create_contact(
                 conn, id=make_id("con"), name=name, email=email, role=role, company=company
             )
@@ -123,9 +129,26 @@ class LoopService:
         self, name: str, email: str, company: str
     ) -> ClientContact:
         async with self._pool.connection() as conn, conn.transaction():
+            existing = await queries.get_client_contact_by_email(conn, email=email)
+            if existing is not None:
+                return _row_to_client_contact(existing)
             row = await queries.create_client_contact(
                 conn, id=make_id("cli"), name=name, email=email, company=company
             )
+            return _row_to_client_contact(row)
+
+    async def get_contact_by_email(self, email: str, role: str) -> Contact | None:
+        async with self._pool.connection() as conn:
+            row = await queries.get_contact_by_email_and_role(conn, email=email, role=role)
+            if row is None:
+                return None
+            return _row_to_contact(row)
+
+    async def get_client_contact_by_email(self, email: str) -> ClientContact | None:
+        async with self._pool.connection() as conn:
+            row = await queries.get_client_contact_by_email(conn, email=email)
+            if row is None:
+                return None
             return _row_to_client_contact(row)
 
     async def find_or_create_candidate(self, name: str, notes: str | None = None) -> Candidate:

--- a/services/api/tests/test_addon.py
+++ b/services/api/tests/test_addon.py
@@ -2,13 +2,14 @@
 
 import base64
 import json
+from datetime import UTC, datetime
 from unittest.mock import AsyncMock
 
 import pytest
 from httpx import ASGITransport, AsyncClient
 
 from api.main import app
-from api.scheduling.models import StatusBoard
+from api.scheduling.models import ClientContact, Contact, StatusBoard
 
 # Build a fake JWT with an email claim for test requests
 _TEST_EMAIL = "test@longridgepartners.com"
@@ -22,6 +23,10 @@ def mock_scheduling():
     svc = AsyncMock()
     svc.get_status_board = AsyncMock(return_value=StatusBoard())
     svc.find_loop_by_thread = AsyncMock(return_value=None)
+    # Default to "no existing contact" so the pre-fill override is a no-op
+    # unless a test explicitly overrides these.
+    svc.get_contact_by_email = AsyncMock(return_value=None)
+    svc.get_client_contact_by_email = AsyncMock(return_value=None)
     return svc
 
 
@@ -125,6 +130,92 @@ class TestAction:
         data = resp.json()
         card = data["action"]["navigations"][0]["updateCard"]
         assert card["header"]["title"] == "New Scheduling Loop"
+
+    async def test_show_create_form_prefers_stored_contact_name(
+        self, client: AsyncClient, mock_scheduling
+    ):
+        """When a pre-filled email matches an existing contact, the form should
+        show the stored name, not the classifier-suggested one — so the coordinator
+        isn't surprised when submit silently reuses the existing row."""
+        mock_scheduling.get_contact_by_email.return_value = Contact(
+            id="con_test",
+            name="Alice Adams",
+            email="alice@lrp.com",
+            role="recruiter",
+            company=None,
+            created_at=datetime.now(UTC),
+        )
+        mock_scheduling.get_client_contact_by_email.return_value = ClientContact(
+            id="cli_test",
+            name="Jane Doe",
+            email="jane@acme.com",
+            company="Acme Capital",
+            created_at=datetime.now(UTC),
+        )
+        event = {
+            "commonEventObject": {
+                "hostApp": "GMAIL",
+                "platform": "WEB",
+                "parameters": {
+                    "action_name": "show_create_form",
+                    "prefill_recruiter_name": "Alice A.",
+                    "prefill_recruiter_email": "alice@lrp.com",
+                    "prefill_client_name": "Jane D.",
+                    "prefill_client_email": "jane@acme.com",
+                    "prefill_client_company": "Different Co",
+                },
+            },
+            "authorizationEventObject": {
+                "userIdToken": _FAKE_USER_ID_TOKEN,
+            },
+        }
+        resp = await client.post("/addon/action", json=event)
+        assert resp.status_code == 200
+        card = resp.json()["action"]["navigations"][0]["updateCard"]
+
+        inputs = {}
+        for section in card["sections"]:
+            for widget in section["widgets"]:
+                ti = widget.get("textInput")
+                if ti:
+                    inputs[ti["name"]] = ti.get("value")
+
+        assert inputs["recruiter_name"] == "Alice Adams"
+        assert inputs["recruiter_email"] == "alice@lrp.com"
+        assert inputs["client_name"] == "Jane Doe"
+        assert inputs["client_email"] == "jane@acme.com"
+        assert inputs["client_company"] == "Acme Capital"
+
+    async def test_show_create_form_keeps_prefill_when_contact_not_found(
+        self, client: AsyncClient, mock_scheduling
+    ):
+        """If no contact matches the pre-filled email, the classifier-suggested
+        name is shown as-is — the lookup is a no-op."""
+        # mock_scheduling already defaults to returning None for get_*_by_email
+        event = {
+            "commonEventObject": {
+                "hostApp": "GMAIL",
+                "platform": "WEB",
+                "parameters": {
+                    "action_name": "show_create_form",
+                    "prefill_recruiter_name": "Brand New Recruiter",
+                    "prefill_recruiter_email": "new@lrp.com",
+                },
+            },
+            "authorizationEventObject": {
+                "userIdToken": _FAKE_USER_ID_TOKEN,
+            },
+        }
+        resp = await client.post("/addon/action", json=event)
+        assert resp.status_code == 200
+        card = resp.json()["action"]["navigations"][0]["updateCard"]
+        inputs = {}
+        for section in card["sections"]:
+            for widget in section["widgets"]:
+                ti = widget.get("textInput")
+                if ti:
+                    inputs[ti["name"]] = ti.get("value")
+        assert inputs["recruiter_name"] == "Brand New Recruiter"
 
     async def test_unknown_function_returns_status_board(self, client: AsyncClient):
         event = {

--- a/services/api/tests/test_scheduling_integration.py
+++ b/services/api/tests/test_scheduling_integration.py
@@ -143,6 +143,91 @@ class TestContacts:
         assert len(results) == 1
         assert results[0].name == "Jane Doe"
 
+    async def test_find_or_create_contact_reuses_existing_by_email_and_role(
+        self, svc: LoopService, pool
+    ):
+        first = await svc.find_or_create_contact(
+            name="Alice Adams", email="alice@lrp.com", role="recruiter"
+        )
+        # Second call with same (email, role) but a different typed name —
+        # must reuse the existing row and must NOT overwrite the name.
+        second = await svc.find_or_create_contact(
+            name="Alice A.", email="alice@lrp.com", role="recruiter"
+        )
+        assert second.id == first.id
+        assert second.name == "Alice Adams"
+
+        async with pool.connection() as conn:
+            row = await (
+                await conn.execute(
+                    "SELECT count(*), max(name) FROM contacts WHERE email = %s",
+                    ("alice@lrp.com",),
+                )
+            ).fetchone()
+        assert row[0] == 1
+        assert row[1] == "Alice Adams"
+
+    async def test_find_or_create_contact_same_email_different_role_creates_new(
+        self, svc: LoopService
+    ):
+        recruiter = await svc.find_or_create_contact(
+            name="Alex", email="alex@lrp.com", role="recruiter"
+        )
+        cm = await svc.find_or_create_contact(
+            name="Alex", email="alex@lrp.com", role="client_manager"
+        )
+        # Same email but different role = different logical contact.
+        assert recruiter.id != cm.id
+
+    async def test_find_or_create_contact_creates_new_when_email_differs(self, svc: LoopService):
+        a = await svc.find_or_create_contact(name="Alice", email="alice@lrp.com", role="recruiter")
+        b = await svc.find_or_create_contact(name="Bob", email="bob@lrp.com", role="recruiter")
+        assert a.id != b.id
+
+    async def test_find_or_create_client_contact_reuses_existing_by_email(
+        self, svc: LoopService, pool
+    ):
+        first = await svc.find_or_create_client_contact(
+            name="Jane Doe", email="jane@acme.com", company="Acme"
+        )
+        second = await svc.find_or_create_client_contact(
+            name="Jane D.", email="jane@acme.com", company="Different Co"
+        )
+        assert second.id == first.id
+        assert second.name == "Jane Doe"
+        assert second.company == "Acme"
+
+        async with pool.connection() as conn:
+            row = await (
+                await conn.execute(
+                    "SELECT count(*) FROM client_contacts WHERE email = %s",
+                    ("jane@acme.com",),
+                )
+            ).fetchone()
+        assert row[0] == 1
+
+    async def test_get_contact_by_email(self, svc: LoopService):
+        created = await svc.find_or_create_contact(
+            name="Alice", email="alice@lrp.com", role="recruiter"
+        )
+        found = await svc.get_contact_by_email("alice@lrp.com", role="recruiter")
+        assert found is not None
+        assert found.id == created.id
+
+        # Wrong role — no match.
+        assert await svc.get_contact_by_email("alice@lrp.com", role="client_manager") is None
+        # Unknown email — no match.
+        assert await svc.get_contact_by_email("nobody@lrp.com", role="recruiter") is None
+
+    async def test_get_client_contact_by_email(self, svc: LoopService):
+        created = await svc.find_or_create_client_contact(
+            name="Jane", email="jane@acme.com", company="Acme"
+        )
+        found = await svc.get_client_contact_by_email("jane@acme.com")
+        assert found is not None
+        assert found.id == created.id
+        assert await svc.get_client_contact_by_email("nobody@acme.com") is None
+
 
 class TestCreateLoop:
     async def test_creates_loop_with_stage_and_events(self, svc: LoopService):


### PR DESCRIPTION
## Summary

Fixes [#32](https://github.com/nsadeh/lrp-scheduling-agent/issues/32) — every loop creation was inserting a fresh row into `contacts` / `client_contacts` even when the same recruiter / CM / client already existed. After N loops with the same recruiter, there were N contact rows.

**Root cause:** `LoopService.find_or_create_contact()` and `find_or_create_client_contact()` were mis-named — they always `INSERT`ed, never searched. The SQL had no `ON CONFLICT` and there's no `UNIQUE` constraint on `contacts.email`.

## What changed

- **Find-first logic** in `LoopService.find_or_create_contact` / `find_or_create_client_contact`: look up by `(email, role)` / `email` first. On hit, return the existing row **untouched** (no name/company overwrite — the issue author's concern about clobbering other loops' names stands). On miss, insert as before.
- **Pre-fill override** in `_handle_show_create_form`: if a pre-filled email matches an existing contact, show that contact's stored name (and company) in the form so what the coordinator sees matches what submit will persist. Without this, the classifier's suggested name would appear in the form but the stored name would silently be used on save.
- New thin lookup service methods (`get_contact_by_email`, `get_client_contact_by_email`) + matching SQL queries.

No UI/widget changes, no schema changes.

## Accepted tradeoff

If a coordinator *manually* edits the name field after pre-fill and the email still matches an existing contact, the loop persists against the existing row (stored name wins). A bit confusing, but acceptable for now per the issue discussion.

## Follow-ups (not in this PR)

- Dedup existing duplicate rows in prod (one-shot script that re-points `loops.recruiter_id` / `loops.client_manager_id` to the canonical id, then deletes dupes).
- Add `UNIQUE (email, role)` on `contacts` and `UNIQUE (email)` on `client_contacts` — only after the cleanup.
- Autocomplete UI for the case where the classifier picks a different-but-related email for a known person (this fix can only dedup exact email matches).

## Test plan

- [x] `uv run pytest tests/test_scheduling_integration.py::TestContacts` — 11/11 pass (6 new dedup/lookup tests).
- [x] `uv run pytest tests/test_addon.py` — 10/10 pass (2 new pre-fill override tests).
- [x] `uv run ruff check` clean on all modified files.
- [ ] Manual: create two loops with the same recruiter email; confirm `SELECT count(*) FROM contacts WHERE email = …` stays at 1 and both loops reference the same `con_…` id.
- [ ] Manual: on second loop, type a different name for the same email; confirm the form overrides to the stored name and the DB row remains unchanged.

The 14 pre-existing failures on this branch (`test_ai_endpoint.py`, `TestRouteIntegration::test_*` — missing `is_forward` column) are unrelated and present on `main` too.

🤖 Generated with [Claude Code](https://claude.com/claude-code)