### PR TITLE
Quote thread history when forwarding to new recipients (fix #36)

### DIFF
--- a/services/api/src/api/addon/routes.py
+++ b/services/api/src/api/addon/routes.py
@@ -580,8 +580,14 @@ async def _handle_send_draft(body: AddonRequest, svc: LoopService, email: str, *
     if edited_body is not None and edited_body != draft.body:
         await draft_svc.update_draft_body(draft.id, send_body)
 
-    # Fetch the thread once — needed for threading headers and, on forwards, for
-    # quoting the prior history into the body.
+    # Fetch the thread once, up-front. Two downstream blocks consume it:
+    #   (1) the RFC 2822 threading headers immediately below, and
+    #   (2) build_forwarded_body() for forwards (issue #36).
+    # Keeping the fetch separate from its consumers also lets the error policy
+    # branch on is_forward: replies soft-fallback (warn + send with no
+    # threading headers — the recipient is already on the thread, so Gmail
+    # shows them context regardless); forwards raise, because a forward
+    # without quoted history is exactly the bug we're fixing.
     thread = None
     gmail = getattr(request.app.state, "gmail", None) if request else None
     if gmail and draft.gmail_thread_id:
@@ -589,9 +595,6 @@ async def _handle_send_draft(body: AddonRequest, svc: LoopService, email: str, *
             thread = await gmail.get_thread(email, draft.gmail_thread_id)
         except Exception:
             if draft.is_forward:
-                # A forward without quoted history leaves the new recipient with
-                # no context (issue #36). Fail loudly rather than silently send
-                # a bare note.
                 logger.exception(
                     "Failed to fetch thread %s for forward — aborting send",
                     draft.gmail_thread_id,
@@ -603,9 +606,15 @@ async def _handle_send_draft(body: AddonRequest, svc: LoopService, email: str, *
                 exc_info=True,
             )
 
-    # Resolve threading headers so the recipient sees this in the same thread.
-    # In-Reply-To + References are RFC 2822 headers that tell the recipient's
-    # email client to display this as a reply (or forward) in the thread.
+    # RFC 2822 threading headers so the recipient's Gmail stitches this message
+    # into the existing conversation rather than showing it as a new thread.
+    #   In-Reply-To: the Message-ID of the message we're directly replying to
+    #     (i.e. the last one in the thread).
+    #   References: a space-separated chain of every prior Message-ID in the
+    #     thread — lets Gmail place this message at the right node in the
+    #     thread tree even if some intermediate messages went missing.
+    # Without these, Gmail renders the outgoing message as a standalone
+    # conversation in the recipient's inbox.
     in_reply_to = None
     references = None
     if thread and thread.messages:

--- a/services/api/src/api/addon/routes.py
+++ b/services/api/src/api/addon/routes.py
@@ -22,6 +22,7 @@ from api.addon.models import (
 )
 from api.classifier.models import SuggestedAction, SuggestionStatus
 from api.gmail.exceptions import GmailScopeError, GmailValidationError
+from api.gmail.forward import build_forwarded_body, prefix_forward_subject
 from api.overview.cards import build_overview
 from api.overview.service import OverviewService
 from api.scheduling.cards import (
@@ -579,28 +580,52 @@ async def _handle_send_draft(body: AddonRequest, svc: LoopService, email: str, *
     if edited_body is not None and edited_body != draft.body:
         await draft_svc.update_draft_body(draft.id, send_body)
 
-    # Resolve threading headers so the recipient sees this in the same thread.
-    # In-Reply-To + References are RFC 2822 headers that tell the recipient's
-    # email client to display this as a reply (or forward) in the thread.
-    in_reply_to = None
-    references = None
+    # Fetch the thread once — needed for threading headers and, on forwards, for
+    # quoting the prior history into the body.
+    thread = None
     gmail = getattr(request.app.state, "gmail", None) if request else None
     if gmail and draft.gmail_thread_id:
         try:
             thread = await gmail.get_thread(email, draft.gmail_thread_id)
-            if thread.messages:
-                last_msg = thread.messages[-1]
-                in_reply_to = last_msg.message_id_header
-                # Build References chain from all messages in thread
-                ref_ids = [m.message_id_header for m in thread.messages if m.message_id_header]
-                if ref_ids:
-                    references = " ".join(ref_ids)
         except Exception:
+            if draft.is_forward:
+                # A forward without quoted history leaves the new recipient with
+                # no context (issue #36). Fail loudly rather than silently send
+                # a bare note.
+                logger.exception(
+                    "Failed to fetch thread %s for forward — aborting send",
+                    draft.gmail_thread_id,
+                )
+                raise
             logger.warning(
                 "Could not fetch thread %s for reply headers — sending without threading",
                 draft.gmail_thread_id,
                 exc_info=True,
             )
+
+    # Resolve threading headers so the recipient sees this in the same thread.
+    # In-Reply-To + References are RFC 2822 headers that tell the recipient's
+    # email client to display this as a reply (or forward) in the thread.
+    in_reply_to = None
+    references = None
+    if thread and thread.messages:
+        last_msg = thread.messages[-1]
+        in_reply_to = last_msg.message_id_header
+        ref_ids = [m.message_id_header for m in thread.messages if m.message_id_header]
+        if ref_ids:
+            references = " ".join(ref_ids)
+
+    # Forwards: quote the prior thread into the body and prefix "Fwd:" on the
+    # subject. Applied only on the wire — the persisted draft body stays short
+    # so the sidebar view remains compact.
+    send_subject = draft.subject
+    if draft.is_forward:
+        if not thread or not thread.messages:
+            raise RuntimeError(
+                f"Cannot forward draft {draft.id}: no thread history available to quote"
+            )
+        send_body = build_forwarded_body(send_body, thread)
+        send_subject = prefix_forward_subject(draft.subject)
 
     # Send email via existing LoopService path
     await svc.send_email(
@@ -608,7 +633,7 @@ async def _handle_send_draft(body: AddonRequest, svc: LoopService, email: str, *
         stage_id=draft.stage_id,
         coordinator_email=email,
         to=draft.to_emails,
-        subject=draft.subject,
+        subject=send_subject,
         body=send_body,
         cc=draft.cc_emails or None,
         gmail_thread_id=draft.gmail_thread_id,

--- a/services/api/src/api/gmail/forward.py
+++ b/services/api/src/api/gmail/forward.py
@@ -1,0 +1,65 @@
+"""Build forwarded email bodies — Gmail-style quoted thread history.
+
+When the scheduling agent forwards an email to a recipient who is new to the
+thread (e.g. a recruiter), Gmail's per-participant thread view won't give that
+recipient any context: they see only the new message. We fix this by building a
+plain-text quoted history body server-side at send time, matching Gmail's native
+"Forwarded message" block format.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from api.gmail.models import EmailAddress, Message, Thread
+
+_FORWARD_SEPARATOR = "---------- Forwarded message ----------"
+
+
+def _format_address(addr: EmailAddress) -> str:
+    if addr.name:
+        return f"{addr.name} <{addr.email}>"
+    return addr.email
+
+
+def _format_addresses(addrs: list[EmailAddress]) -> str:
+    return ", ".join(_format_address(a) for a in addrs)
+
+
+def _format_message_block(msg: Message) -> str:
+    # "%-d" / "%-I" drop leading zeros (GNU/BSD strftime — works on macOS + Linux).
+    date_str = msg.date.strftime("%a, %b %-d, %Y at %-I:%M %p")
+    lines = [
+        _FORWARD_SEPARATOR,
+        f"From: {_format_address(msg.from_)}",
+        f"Date: {date_str}",
+        f"Subject: {msg.subject}",
+        f"To: {_format_addresses(msg.to)}",
+    ]
+    if msg.cc:
+        lines.append(f"Cc: {_format_addresses(msg.cc)}")
+    lines.append("")
+    lines.append(msg.body_text.rstrip())
+    return "\n".join(lines)
+
+
+def build_forwarded_body(note: str, thread: Thread) -> str:
+    """Append Gmail-style quoted history of `thread` below `note`.
+
+    Messages are emitted in chronological order (oldest first), matching the
+    order already provided by `Thread.messages`. Each message is wrapped in a
+    "---------- Forwarded message ----------" header block.
+    """
+    note_trimmed = note.rstrip()
+    if not thread.messages:
+        return note_trimmed
+    blocks = [_format_message_block(m) for m in thread.messages]
+    return "\n\n".join([note_trimmed, *blocks])
+
+
+def prefix_forward_subject(subject: str) -> str:
+    """Prefix ``Fwd:`` unless the subject already begins with one (case-insensitive)."""
+    if subject.lstrip().lower().startswith("fwd:"):
+        return subject
+    return f"Fwd: {subject}"

--- a/services/api/tests/test_addon_send_draft.py
+++ b/services/api/tests/test_addon_send_draft.py
@@ -1,0 +1,175 @@
+"""Tests for _handle_send_draft's forward behavior (issue #36).
+
+The draft-send path is where quoted-history injection happens on the wire. These
+tests verify that:
+  - `is_forward=True` drafts get the prior thread quoted into the body and a
+    "Fwd:" subject prefix on send.
+  - `is_forward=False` drafts (replies) are sent unchanged — no quote, no prefix.
+  - A forward whose thread fetch fails raises instead of silently sending a
+    context-less note.
+"""
+
+from datetime import UTC, datetime
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from api.addon.models import AddonRequest, CommonEventObject
+from api.addon.routes import _handle_send_draft
+from api.drafts.models import DraftStatus, EmailDraft
+from api.gmail.models import EmailAddress, Message, Thread
+
+
+def _make_message(
+    *,
+    msg_id: str = "m1",
+    from_email: str = "alice@client.com",
+    from_name: str | None = "Alice Client",
+    body_text: str = "Original ask: share availability for Claire.",
+    subject: str = "Phone screen for Claire Cao",
+    message_id_header: str | None = "<m1@mail.gmail.com>",
+) -> Message:
+    return Message(
+        id=msg_id,
+        thread_id="t1",
+        subject=subject,
+        **{"from": EmailAddress(name=from_name, email=from_email)},
+        to=[EmailAddress(name="Coord", email="coord@longridgepartners.com")],
+        cc=[],
+        date=datetime(2026, 4, 20, 9, 42, tzinfo=UTC),
+        body_text=body_text,
+        message_id_header=message_id_header,
+    )
+
+
+def _make_draft(*, is_forward: bool, draft_id: str = "drft_1") -> EmailDraft:
+    return EmailDraft(
+        id=draft_id,
+        suggestion_id="sug_1",
+        loop_id="lup_1",
+        stage_id="stg_1",
+        coordinator_email="coord@longridgepartners.com",
+        to_emails=["recruiter@external.com"] if is_forward else ["alice@client.com"],
+        cc_emails=[],
+        subject="Phone screen for Claire Cao",
+        body="Please share availability.",
+        gmail_thread_id="t1",
+        is_forward=is_forward,
+        status=DraftStatus.GENERATED,
+    )
+
+
+def _build_context(*, thread: Thread | None, thread_fetch_raises: bool = False):
+    """Build (body, svc, email, request_ctx, draft_svc, expected_pool) for the call."""
+    body = AddonRequest(common_event_object=CommonEventObject(parameters={"draft_id": "drft_1"}))
+
+    draft_svc = SimpleNamespace(
+        get_draft=AsyncMock(),  # test sets .return_value
+        update_draft_body=AsyncMock(),
+        mark_sent=AsyncMock(),
+    )
+
+    gmail = SimpleNamespace()
+    if thread_fetch_raises:
+        gmail.get_thread = AsyncMock(side_effect=RuntimeError("gmail down"))
+    else:
+        gmail.get_thread = AsyncMock(return_value=thread)
+
+    app_state = SimpleNamespace(
+        draft_service=draft_svc,
+        gmail=gmail,
+        overview_service=SimpleNamespace(),  # not used because we patch _build_refreshed_overview
+    )
+    request = SimpleNamespace(app=SimpleNamespace(state=app_state))
+
+    # _pool is only read to build a SuggestionService, which we patch.
+    svc = SimpleNamespace(send_email=AsyncMock(), _pool=SimpleNamespace())
+
+    return body, svc, "coord@longridgepartners.com", request, draft_svc
+
+
+@pytest.mark.asyncio
+async def test_forward_draft_quotes_thread_and_prefixes_subject():
+    thread = Thread(id="t1", messages=[_make_message()])
+    body, svc, email, request, draft_svc = _build_context(thread=thread)
+    draft = _make_draft(is_forward=True)
+    draft_svc.get_draft.return_value = draft
+
+    with (
+        patch("api.classifier.service.SuggestionService") as sug_cls,
+        patch("api.addon.routes._build_refreshed_overview", new=AsyncMock(return_value=None)),
+    ):
+        sug_cls.return_value.resolve = AsyncMock()
+        await _handle_send_draft(body, svc, email, request=request)
+
+    svc.send_email.assert_awaited_once()
+    call = svc.send_email.await_args.kwargs
+    assert call["subject"] == "Fwd: Phone screen for Claire Cao"
+    assert call["body"].startswith("Please share availability.\n\n")
+    assert "---------- Forwarded message ----------" in call["body"]
+    assert "From: Alice Client <alice@client.com>" in call["body"]
+    assert "Original ask: share availability for Claire." in call["body"]
+    # Threading headers still wired up for same-thread display when possible.
+    assert call["in_reply_to"] == "<m1@mail.gmail.com>"
+    assert call["references"] == "<m1@mail.gmail.com>"
+
+
+@pytest.mark.asyncio
+async def test_reply_draft_is_sent_unchanged():
+    thread = Thread(id="t1", messages=[_make_message()])
+    body, svc, email, request, draft_svc = _build_context(thread=thread)
+    draft = _make_draft(is_forward=False)
+    draft_svc.get_draft.return_value = draft
+
+    with (
+        patch("api.classifier.service.SuggestionService") as sug_cls,
+        patch("api.addon.routes._build_refreshed_overview", new=AsyncMock(return_value=None)),
+    ):
+        sug_cls.return_value.resolve = AsyncMock()
+        await _handle_send_draft(body, svc, email, request=request)
+
+    call = svc.send_email.await_args.kwargs
+    # Subject untouched — no Fwd: prefix.
+    assert call["subject"] == "Phone screen for Claire Cao"
+    # Body is exactly the draft body — no quoted history appended.
+    assert call["body"] == "Please share availability."
+    assert "Forwarded message" not in call["body"]
+
+
+@pytest.mark.asyncio
+async def test_forward_raises_when_thread_fetch_fails():
+    """A forward without its quoted history is actively harmful — fail loudly."""
+    body, svc, email, request, draft_svc = _build_context(thread=None, thread_fetch_raises=True)
+    draft = _make_draft(is_forward=True)
+    draft_svc.get_draft.return_value = draft
+
+    with (
+        patch("api.classifier.service.SuggestionService"),
+        patch("api.addon.routes._build_refreshed_overview", new=AsyncMock(return_value=None)),
+        pytest.raises(RuntimeError),
+    ):
+        await _handle_send_draft(body, svc, email, request=request)
+
+    svc.send_email.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_reply_still_sends_when_thread_fetch_fails():
+    """Regression guard: replies keep the soft-fallback behavior."""
+    body, svc, email, request, draft_svc = _build_context(thread=None, thread_fetch_raises=True)
+    draft = _make_draft(is_forward=False)
+    draft_svc.get_draft.return_value = draft
+
+    with (
+        patch("api.classifier.service.SuggestionService") as sug_cls,
+        patch("api.addon.routes._build_refreshed_overview", new=AsyncMock(return_value=None)),
+    ):
+        sug_cls.return_value.resolve = AsyncMock()
+        await _handle_send_draft(body, svc, email, request=request)
+
+    # Sent despite thread fetch failure, but without threading headers.
+    call = svc.send_email.await_args.kwargs
+    assert call["in_reply_to"] is None
+    assert call["references"] is None
+    assert call["body"] == "Please share availability."

--- a/services/api/tests/test_gmail_forward.py
+++ b/services/api/tests/test_gmail_forward.py
@@ -1,0 +1,120 @@
+"""Unit tests for Gmail forward-body formatting (issue #36)."""
+
+from datetime import UTC, datetime
+
+from api.gmail.forward import (
+    build_forwarded_body,
+    prefix_forward_subject,
+)
+from api.gmail.models import EmailAddress, Message, Thread
+
+
+def _msg(
+    *,
+    msg_id: str = "m1",
+    thread_id: str = "t1",
+    subject: str = "Phone screen for Claire Cao",
+    from_name: str | None = "Alice Client",
+    from_email: str = "alice@client.com",
+    to: list[tuple[str | None, str]] | None = None,
+    cc: list[tuple[str | None, str]] | None = None,
+    date: datetime | None = None,
+    body_text: str = "Hi — are you free Tuesday at 3pm?",
+) -> Message:
+    to = to or [("Coord", "coord@longridgepartners.com")]
+    cc = cc or []
+    return Message(
+        id=msg_id,
+        thread_id=thread_id,
+        subject=subject,
+        **{"from": EmailAddress(name=from_name, email=from_email)},
+        to=[EmailAddress(name=n, email=e) for n, e in to],
+        cc=[EmailAddress(name=n, email=e) for n, e in cc],
+        date=date or datetime(2026, 4, 20, 9, 42, tzinfo=UTC),
+        body_text=body_text,
+    )
+
+
+class TestBuildForwardedBody:
+    def test_single_message_thread_formats_header_block(self):
+        thread = Thread(id="t1", messages=[_msg()])
+        result = build_forwarded_body("Please share availability.", thread)
+
+        assert result.startswith("Please share availability.\n\n")
+        assert "---------- Forwarded message ----------" in result
+        assert "From: Alice Client <alice@client.com>" in result
+        assert "Subject: Phone screen for Claire Cao" in result
+        assert "To: Coord <coord@longridgepartners.com>" in result
+        assert "Hi — are you free Tuesday at 3pm?" in result
+
+    def test_multi_message_thread_chronological_with_separators(self):
+        earlier = _msg(
+            msg_id="m1",
+            body_text="Original request body",
+            date=datetime(2026, 4, 20, 9, 42, tzinfo=UTC),
+        )
+        later = _msg(
+            msg_id="m2",
+            body_text="Reply from coordinator",
+            from_name="Coord",
+            from_email="coord@longridgepartners.com",
+            to=[("Alice Client", "alice@client.com")],
+            date=datetime(2026, 4, 20, 10, 15, tzinfo=UTC),
+        )
+        thread = Thread(id="t1", messages=[earlier, later])
+        result = build_forwarded_body("FYI", thread)
+
+        # Order preserved: earlier body appears before later body.
+        assert result.index("Original request body") < result.index("Reply from coordinator")
+        # Two forward-header blocks.
+        assert result.count("---------- Forwarded message ----------") == 2
+        # Separator blank line between blocks.
+        assert "Original request body\n\n---------- Forwarded message ----------" in result
+
+    def test_note_preserved_on_top_with_blank_line_before_block(self):
+        thread = Thread(id="t1", messages=[_msg()])
+        result = build_forwarded_body("Short note.  \n\n", thread)
+
+        # Note's trailing whitespace/newlines are trimmed, then exactly one blank line.
+        assert result.startswith("Short note.\n\n---------- Forwarded message ----------")
+
+    def test_omits_cc_line_when_empty(self):
+        thread = Thread(id="t1", messages=[_msg(cc=[])])
+        result = build_forwarded_body("", thread)
+        assert "Cc:" not in result
+
+    def test_includes_cc_line_when_present(self):
+        thread = Thread(
+            id="t1",
+            messages=[_msg(cc=[("Bob", "bob@client.com"), (None, "carol@client.com")])],
+        )
+        result = build_forwarded_body("", thread)
+        assert "Cc: Bob <bob@client.com>, carol@client.com" in result
+
+    def test_empty_thread_returns_note_only(self):
+        thread = Thread(id="t1", messages=[])
+        assert build_forwarded_body("Just a note", thread) == "Just a note"
+
+    def test_from_without_name_uses_bare_email(self):
+        thread = Thread(id="t1", messages=[_msg(from_name=None)])
+        result = build_forwarded_body("", thread)
+        assert "From: alice@client.com" in result
+        assert "<alice@client.com>" not in result
+
+
+class TestPrefixForwardSubject:
+    def test_adds_prefix_to_plain_subject(self):
+        assert prefix_forward_subject("Phone screen") == "Fwd: Phone screen"
+
+    def test_idempotent_for_fwd_prefix(self):
+        assert prefix_forward_subject("Fwd: Phone screen") == "Fwd: Phone screen"
+
+    def test_case_insensitive_dedupe(self):
+        assert prefix_forward_subject("FWD: phone") == "FWD: phone"
+        assert prefix_forward_subject("fwd: phone") == "fwd: phone"
+
+    def test_leading_whitespace_still_dedupes(self):
+        assert prefix_forward_subject("   Fwd: phone") == "   Fwd: phone"
+
+    def test_re_prefix_is_not_treated_as_forward(self):
+        assert prefix_forward_subject("Re: Phone screen") == "Fwd: Re: Phone screen"


### PR DESCRIPTION
## Summary

Closes #36. When the agent forwarded a scheduling thread to a recruiter, the recruiter received a bare note with no conversation context — Gmail only shows thread history to participants who were already on the thread, and the prior code only set `In-Reply-To` / `References` headers without quoting prior messages into the body.

**Fix:** build a Gmail-style quoted-history body server-side at send time, and prefix the subject with `Fwd:`. Applied only when `email_drafts.is_forward=True` (replies are untouched).

## What changed

- **New** `services/api/src/api/gmail/forward.py`
  - `build_forwarded_body(note, thread)` — appends chronological `---------- Forwarded message ----------` blocks below the coordinator's note.
  - `prefix_forward_subject(subject)` — idempotent, case-insensitive `Fwd:` prefix.
- **`services/api/src/api/addon/routes.py`** — `_handle_send_draft`:
  - Thread is fetched once and reused for both threading headers and forward-body construction.
  - On `is_forward=True`: body is rewritten with `build_forwarded_body` and subject gets `Fwd:`. The **persisted** draft body stays short — quoting only happens on the wire, so the sidebar view remains compact.
  - On `is_forward=True` with a failed thread fetch: raise. Silently sending a forward without context is the bug we're fixing; the pre-existing soft-fallback is kept for replies only.
- **Tests** (16 new, all passing):
  - `tests/test_gmail_forward.py` — formatting correctness, Cc omission, subject prefix idempotence.
  - `tests/test_addon_send_draft.py` — forward rewrites body/subject, reply path is unchanged, forward raises on fetch failure, reply still sends on fetch failure.

## Test plan

- [x] `uv run pytest` from `services/api` — **261 passed** (the 10 `test_ai_endpoint.py` failures are pre-existing Langfuse mock issues on `main`, unrelated to this PR).
- [x] `uv run ruff check` clean on changed files.
- [ ] **Manual end-to-end (recommended before merge):** run `./scripts/dev-all.sh`, create a loop that triggers the "forward to recruiter" suggestion, approve the draft, and confirm the recruiter's inbox shows the coordinator's note on top with the quoted `---------- Forwarded message ----------` history below and subject prefixed `Fwd:`.
- [ ] Regression manual check: send a non-forward reply and confirm body/subject are unchanged.

## Notes for reviewer

- `%-d` / `%-I` in `_format_message_block` are GNU/BSD strftime extensions — fine for macOS dev + Linux on Railway; would break on Windows.
- Subject prefix: matches Gmail's `Fwd:` dedupe. `Re:` is not stripped — a forwarded reply correctly becomes `Fwd: Re: ...`.
- Pre-existing failures in `tests/test_ai_endpoint.py` (Langfuse mock `AttributeError: name`) should be tracked separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)