### PR TITLE
fix(addon): add userinfo.email scope to prod deployment descriptors

### DIFF
--- a/services/api/deployment.json
+++ b/services/api/deployment.json
@@ -1,7 +1,8 @@
 {
   "oauthScopes": [
     "https://www.googleapis.com/auth/gmail.addons.execute",
-    "https://www.googleapis.com/auth/gmail.addons.current.message.metadata"
+    "https://www.googleapis.com/auth/gmail.addons.current.message.metadata",
+    "https://www.googleapis.com/auth/userinfo.email"
   ],
   "addOns": {
     "common": {

--- a/services/api/deployment.prod.json
+++ b/services/api/deployment.prod.json
@@ -1,7 +1,8 @@
 {
   "oauthScopes": [
     "https://www.googleapis.com/auth/gmail.addons.execute",
-    "https://www.googleapis.com/auth/gmail.addons.current.message.metadata"
+    "https://www.googleapis.com/auth/gmail.addons.current.message.metadata",
+    "https://www.googleapis.com/auth/userinfo.email"
   ],
   "addOns": {
     "common": {


### PR DESCRIPTION
## Summary

Production coordinators were hitting a 500 on the sidebar homepage:

\`\`\`
ValueError: Could not determine coordinator email from add-on request
  at addon/routes.py:307 in addon_homepage
  at addon/routes.py:150 in _get_user_email
\`\`\`

Root cause: \`services/api/deployment.prod.json\` was missing \`https://www.googleapis.com/auth/userinfo.email\` from its \`oauthScopes\`. Without that scope declared in the GCP add-on manifest, Google does not include the \`email\` claim in \`userIdToken\` when calling the sidebar endpoints — so [\_get\_user\_email](services/api/src/api/addon/routes.py:71) has no email to decode from any token and raises.

Staging already had the scope. Only prod was broken.

## What changed

- [services/api/deployment.prod.json](services/api/deployment.prod.json) — added \`userinfo.email\` scope.
- [services/api/deployment.json](services/api/deployment.json) — synced the same scope (this file was byte-identical to \`deployment.prod.json\`, but is currently referenced by no code — kept in sync to avoid perpetuating the drift).

## Why this drifted in the first place

Three parallel descriptor files:
- \`deployment.staging.json\` — used by \`deploy.sh staging\`
- \`deployment.prod.json\` — used by \`deploy.sh production\`
- \`deployment.json\` — used by nothing, but looks authoritative

No test catches divergence on \`oauthScopes\` between staging and prod. Someone added \`userinfo.email\` to staging at some point (and probably to \`deployment.json\`, then later diverged). Prod never got it.

## Deploy steps after merge

1. \`./scripts/deploy.sh production api\` — deploys the api container **and** pushes the new descriptor to Google via \`gcloud workspace-add-ons deployments replace\`. That's the step that actually registers the new scope with the GCP add-on.
2. **Coordinators who already have the prod add-on installed must re-authorize it in Gmail** (Extensions → Manage add-ons → LRP Scheduling Agent → re-accept). Google caches the old scope list on the existing grant; new scopes don't take effect until the coordinator re-consents.

## Follow-ups (not in this PR)

- Delete \`deployment.json\` — unreferenced, and its existence is what made it possible to edit \"the wrong file\" when syncing staging.
- Add a tiny CI check that diffs the \`oauthScopes\` arrays in \`deployment.{staging,prod}.json\` and fails if they diverge. URLs, names, and homepage triggers differ between envs by design; the scope set should not.

## Test plan

- [ ] \`./scripts/deploy.sh production api\` — confirm it completes and the add-on descriptor update succeeds (\`gcloud workspace-add-ons deployments describe lrp-scheduling-prod\` should show the new scope)
- [ ] Re-authorize the add-on in Gmail as a prod coordinator
- [ ] Open the sidebar on any email → homepage renders without 500
- [ ] Confirm staging still works (no regression from touching \`deployment.json\`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)