### PR TITLE
debug(addon): log authorizedScopes and userinfo rejection status

### DIFF
--- a/services/api/src/api/addon/routes.py
+++ b/services/api/src/api/addon/routes.py
@@ -140,6 +140,13 @@ def _get_user_email(body: AddonRequest) -> str:
                 if email:
                     logger.info("Got user email from userinfo endpoint: %s", email)
                     return email
+                logger.warning("userinfo 200 but no email in body: %s", resp.text[:500])
+            else:
+                logger.warning(
+                    "userinfo rejected userOAuthToken: status=%s body=%s",
+                    resp.status_code,
+                    resp.text[:500],
+                )
         except Exception:
             logger.warning("Failed to fetch userinfo", exc_info=True)
 
@@ -296,10 +303,11 @@ async def addon_homepage(body: AddonRequest, request: Request) -> dict:
         has_id = body.authorization_event_object.user_id_token is not None
         has_oauth = body.authorization_event_object.user_oauth_token is not None
         logger.info(
-            "Homepage auth keys: %s, userIdToken: %s, userOAuthToken: %s",
+            "Homepage auth keys: %s, userIdToken: %s, userOAuthToken: %s, authorizedScopes: %s",
             list(auth_dump.keys()),
             has_id,
             has_oauth,
+            auth_dump.get("authorizedScopes") or auth_dump.get("authorized_scopes"),
         )
     else:
         logger.warning("Homepage request has NO authorizationEventObject")


### PR DESCRIPTION
## Summary

Prod is stuck in a 500 loop on \`/addon/homepage\` with:

\`\`\`
ValueError: Could not determine coordinator email from add-on request
\`\`\`

Current log output:

\`\`\`
Homepage auth keys: ['user_oauth_token', 'system_id_token', 'authorizedScopes'],
  userIdToken: False, userOAuthToken: True
Available tokens in request: user-identifying=[], systemIdToken_present=True
ERROR: No email found in any token.
\`\`\`

Google is suppressing \`userIdToken\` entirely, and the \`userOAuthToken\` → userinfo endpoint fallback silently returns non-200 — but the existing code's \`if resp.ok:\` branch swallows the failure with no logging, so we can't tell whether the token was rejected with 401, 403, or something else.

This PR adds **two diagnostic log lines only** — no behavior change — so the next failed request tells us exactly what Google is doing.

## Changes

[services/api/src/api/addon/routes.py](services/api/src/api/addon/routes.py):

1. **Homepage debug log now includes \`authorizedScopes\`** — the request body already carries this field (per the existing log's \`auth keys\`), we just weren't reading its value. That alone may resolve the mystery: if \`authorizedScopes\` doesn't contain \`userinfo.email\`, we know Google hasn't propagated the scope grant to per-user tokens despite admin approval.
2. **\`_get_user_email\`'s userinfo fallback logs rejection details** — on non-2xx, we now log \`status=XXX body=...\`. On 200 with a missing email claim, we log that too (separate case).

Still raises \`ValueError\` at the end of the function — no behavior change for the caller.

## Context from the broader debugging session

Already ruled out:
- \`deployment.prod.json\` manifest scopes (✓ has \`userinfo.email\`)
- GCP descriptor (\`gcloud workspace-add-ons deployments describe\` confirms the scope is live)
- Admin console grant status (screenshot confirms \`userinfo.email\` and \`userinfo.profile\` both show \"Granted\")
- User re-auth via myaccount.google.com → Remove access → reopen Gmail

Notable artifacts discovered in GCP during debugging but NOT addressed in this PR:
- A stale third deployment \`scheduling-agent\` exists with the same display name as \`lrp-scheduling-prod\` but with old scopes and a dead ngrok URL (\`fb50-71-104-78-246.ngrok-free.app\`). Possibly confusing the install flow — but leaving alone until we have data from these log lines to confirm it's related.
- \`appsmarket-component.googleapis.com\` / Workspace Marketplace SDK is not enabled on the \`long-ridge-partners\` GCP project — likely why the admin console struggles to find the private add-on under Marketplace apps.

## Deploy steps

No need to merge to get the diagnostic deployed — \`railway up\` uploads local source:

\`\`\`
./scripts/deploy.sh production api
\`\`\`

Then trigger a homepage request and \`railway logs -s prod-api -e production | grep -iE \"authorizedScopes|userinfo\"\` will reveal the root cause.

## Test plan

- [ ] Deploy to prod-api
- [ ] Have a coordinator open the Gmail sidebar
- [ ] Confirm the new log line shows \`authorizedScopes: [...]\` with the actual granted scope list
- [ ] Confirm the userinfo rejection log shows a status code and body
- [ ] Once root cause is identified, open a follow-up PR with the actual fix
- [ ] (Optional, later) revert these log lines if the noise is not useful long-term

🤖 Generated with [Claude Code](https://claude.com/claude-code)