### PR TITLE
feat(addon): infer create-loop fields via LLM extractor on manual path

### DIFF
--- a/services/api/src/api/addon/models.py
+++ b/services/api/src/api/addon/models.py
@@ -120,6 +120,11 @@ class OnClickAction(BaseModel):
     parameters: list[ActionParameter] | None = None
     required_widgets: list[str] | None = Field(default=None, alias="requiredWidgets")
     all_widgets_are_required: bool | None = Field(default=None, alias="allWidgetsAreRequired")
+    # Card v2 load indicator — "SPINNER" dims the button and shows a spinning
+    # icon while the action's HTTP round-trip is in flight. Use for actions
+    # known to take >1s (e.g., LLM-backed handlers). "NONE" suppresses the
+    # default indicator.
+    load_indicator: str | None = Field(default=None, alias="loadIndicator")
 
 
 class OpenLink(BaseModel):

--- a/services/api/src/api/addon/routes.py
+++ b/services/api/src/api/addon/routes.py
@@ -6,6 +6,7 @@ Token verification is applied at the router level via Depends().
 
 from __future__ import annotations
 
+import asyncio
 import logging
 import os
 import re
@@ -24,7 +25,21 @@ from api.addon.models import (
     SuggestionsResponse,
     UpdateCard,
 )
-from api.classifier.models import SuggestedAction, SuggestionStatus
+from api.app_state import (
+    get_draft_service,
+    get_gmail,
+    get_langfuse,
+    get_llm,
+    get_overview_service,
+    get_redis,
+    get_scheduling,
+)
+from api.classifier.create_loop_extractor import (
+    ExtractCreateLoopInput,
+    extract_create_loop_fields,
+)
+from api.classifier.formatters import format_thread_history
+from api.classifier.models import CreateLoopExtraction, SuggestedAction, SuggestionStatus
 from api.gmail.exceptions import (
     GmailScopeError,
     GmailUserNotAuthorizedError,
@@ -50,12 +65,8 @@ addon_router = APIRouter(
 )
 
 
-def _get_scheduling(request: Request) -> LoopService:
-    return request.app.state.scheduling
-
-
 def _get_overview_service(request: Request) -> OverviewService:
-    svc = getattr(request.app.state, "overview_service", None)
+    svc = get_overview_service(request)
     if svc is None:
         # Lazily create from the db pool
         svc = OverviewService(request.app.state.db)
@@ -253,7 +264,7 @@ async def _check_gmail_auth(request: Request, user_email: str) -> CardResponse |
 
     Returns an auth-required card if not, or None if authorized.
     """
-    gmail = getattr(request.app.state, "gmail", None)
+    gmail = get_gmail(request)
     if not gmail:
         return None  # GmailClient not configured — skip auth check
     has = await gmail.has_token(user_email)
@@ -368,7 +379,7 @@ async def addon_on_message(body: AddonRequest, request: Request) -> dict:
         card = build_overview(groups, base_url=base_url)
     else:
         # No suggestions for this thread — check if it's linked to a loop
-        svc = _get_scheduling(request)
+        svc = get_scheduling(request)
         loop = await svc.find_loop_by_thread(thread_id)
         logger.info(
             "on-message: thread_id=%s, linked_loop=%s",
@@ -393,7 +404,7 @@ async def addon_action(body: AddonRequest, request: Request) -> dict:
     """
     _ensure_action_url(request)
 
-    svc = _get_scheduling(request)
+    svc = get_scheduling(request)
     email = _get_user_email(body)
 
     # Read action name from parameters (set by our card builders)
@@ -441,7 +452,7 @@ async def addon_directory_search(body: AddonRequest, request: Request) -> dict:
     if not query:
         return _empty_suggestions().model_dump(by_alias=True, exclude_none=True)
 
-    gmail = getattr(request.app.state, "gmail", None)
+    gmail = get_gmail(request)
     if gmail is None:
         logger.warning("directory/search: no gmail client configured")
         return _empty_suggestions().model_dump(by_alias=True, exclude_none=True)
@@ -517,7 +528,7 @@ async def _fetch_recruiter_photo_url(
 
     if request is None:
         return None
-    gmail = getattr(request.app.state, "gmail", None)
+    gmail = get_gmail(request)
     if gmail is None:
         return None
     try:
@@ -538,6 +549,84 @@ async def _fetch_recruiter_photo_url(
     return match.photo_url if match else None
 
 
+# Hard cap on the create-loop extractor round-trip. Beyond this we give up
+# and render the form with deterministic prefill only (RFC R1).
+_EXTRACTOR_TIMEOUT_SECONDS = 10.0
+
+_CREATE_LOOP_BANNER = "Filled in from the thread — please review before creating."
+
+
+def _merge_prefill(
+    deterministic: CreateLoopExtraction, extracted: CreateLoopExtraction
+) -> CreateLoopExtraction:
+    """Overlay extractor values on top of deterministic prefill.
+
+    Deterministic values (from the current message's ``from_`` / ``cc[0]``)
+    win for any field they populate — the model should never overwrite a
+    signal we already have. Extractor fills the blanks, including fields
+    with no deterministic counterpart (candidate_name, client_company).
+    """
+    return CreateLoopExtraction(
+        candidate_name=deterministic.candidate_name or extracted.candidate_name,
+        client_name=deterministic.client_name or extracted.client_name,
+        client_email=deterministic.client_email or extracted.client_email,
+        client_company=deterministic.client_company or extracted.client_company,
+        cm_name=deterministic.cm_name or extracted.cm_name,
+        cm_email=deterministic.cm_email or extracted.cm_email,
+        recruiter_name=deterministic.recruiter_name or extracted.recruiter_name,
+        recruiter_email=deterministic.recruiter_email or extracted.recruiter_email,
+    )
+
+
+async def _run_create_loop_extractor(
+    *,
+    request: Request | None,
+    svc: LoopService,
+    email: str,
+    gmail_thread_id: str | None,
+    message_id: str | None,
+) -> CreateLoopExtraction | None:
+    """Invoke the typed LLM extractor with a hard timeout.
+
+    Returns None on timeout, error, or when prerequisites (request state,
+    Gmail client, thread id) are missing. Callers fall back to deterministic
+    prefill when this returns None.
+    """
+    if request is None or not gmail_thread_id or svc._gmail is None:
+        return None
+
+    llm = get_llm(request)
+    langfuse = get_langfuse(request)
+    if llm is None or langfuse is None:
+        return None
+
+    try:
+        thread = await svc._gmail.get_thread(email, gmail_thread_id)
+        # Pass "" for current_message_id so NO message is excluded — the
+        # extractor prompt has no separate {{email}} section, so it must see
+        # every message in the thread, including the one the coordinator is
+        # looking at (which is usually THE message we want to extract from).
+        formatted = format_thread_history(thread.messages, current_message_id="")
+        return await asyncio.wait_for(
+            extract_create_loop_fields(
+                llm=llm,
+                langfuse=langfuse,
+                data=ExtractCreateLoopInput(
+                    thread_history=formatted,
+                    coordinator_email=email,
+                ),
+            ),
+            timeout=_EXTRACTOR_TIMEOUT_SECONDS,
+        )
+    except Exception:
+        logger.warning(
+            "create-loop extractor failed for thread %s — falling back to deterministic prefill",
+            gmail_thread_id,
+            exc_info=True,
+        )
+        return None
+
+
 async def _handle_show_create_form(body: AddonRequest, svc: LoopService, email: str, **kwargs):
     request = kwargs.get("request")
     # Pre-check coordinator's directory.readonly scope here, BEFORE the
@@ -547,59 +636,94 @@ async def _handle_show_create_form(body: AddonRequest, svc: LoopService, email: 
     # GmailScopeError (existing token missing scopes) and
     # GmailUserNotAuthorizedError (no token at all) and shows
     # build_auth_required, so we let either propagate.
-    gmail = getattr(request.app.state, "gmail", None) if request else None
+    gmail = get_gmail(request) if request else None
     if gmail is not None:
         await gmail._token_store.load_credentials(email)
 
     gmail_thread_id = _get_param(body, "gmail_thread_id")
     message_id = _get_param(body, "message_id")
 
-    # Check for prefill params from suggestion entities (passed by overview card)
-    prefill_candidate_name = _get_param(body, "prefill_candidate_name")
-    prefill_client_name = _get_param(body, "prefill_client_name")
-    prefill_client_email = _get_param(body, "prefill_client_email")
-    prefill_client_company = _get_param(body, "prefill_client_company")
-    prefill_recruiter_name = _get_param(body, "prefill_recruiter_name")
-    prefill_recruiter_email = _get_param(body, "prefill_recruiter_email")
-    prefill_cm_name = _get_param(body, "prefill_cm_name")
-    prefill_cm_email = _get_param(body, "prefill_cm_email")
+    # Prefill params passed from the overview suggestion card (classifier path)
+    # short-circuit AI extraction — the classifier already did this work and
+    # its output is on action_data/extracted_entities.
+    has_suggestion_prefill = any(
+        _get_param(body, f"prefill_{field}")
+        for field in (
+            "candidate_name",
+            "client_name",
+            "client_email",
+            "client_company",
+            "recruiter_name",
+            "recruiter_email",
+            "cm_name",
+            "cm_email",
+        )
+    )
+    prefill = CreateLoopExtraction(
+        candidate_name=_get_param(body, "prefill_candidate_name") or None,
+        client_name=_get_param(body, "prefill_client_name") or None,
+        client_email=_get_param(body, "prefill_client_email") or None,
+        client_company=_get_param(body, "prefill_client_company") or None,
+        recruiter_name=_get_param(body, "prefill_recruiter_name") or None,
+        recruiter_email=_get_param(body, "prefill_recruiter_email") or None,
+        cm_name=_get_param(body, "prefill_cm_name") or None,
+        cm_email=_get_param(body, "prefill_cm_email") or None,
+    )
     gmail_subject = None
+    banner: str | None = None
 
-    # If no prefill from suggestion, try Gmail message metadata
-    if not prefill_client_email and message_id and svc._gmail:
+    # Deterministic prefill from the current message: from_ → client contact,
+    # cc[0] → client manager. Only applies on the manual path (no prefill
+    # from a suggestion).
+    if not has_suggestion_prefill and message_id and svc._gmail:
         try:
             msg = await svc._gmail.get_message(email, message_id)
             if msg.from_:
-                prefill_client_name = prefill_client_name or msg.from_.name or ""
-                prefill_client_email = msg.from_.email
+                prefill.client_name = prefill.client_name or (msg.from_.name or None)
+                prefill.client_email = prefill.client_email or msg.from_.email
             if msg.cc:
-                prefill_cm_name = prefill_cm_name or msg.cc[0].name or ""
-                prefill_cm_email = prefill_cm_email or msg.cc[0].email
+                prefill.cm_name = prefill.cm_name or (msg.cc[0].name or None)
+                prefill.cm_email = prefill.cm_email or msg.cc[0].email
             gmail_subject = msg.subject
         except Exception:
             logger.warning("Could not fetch message %s for pre-fill", message_id, exc_info=True)
+
+    # AI extraction: only on the manual path. When the user arrived from a
+    # classifier suggestion, that suggestion's extracted_entities already
+    # populated prefill_* — re-running extraction wastes LLM cost.
+    if not has_suggestion_prefill:
+        extracted = await _run_create_loop_extractor(
+            request=request,
+            svc=svc,
+            email=email,
+            gmail_thread_id=gmail_thread_id,
+            message_id=message_id,
+        )
+        if extracted is not None:
+            prefill = _merge_prefill(deterministic=prefill, extracted=extracted)
+            banner = _CREATE_LOOP_BANNER
 
     # If a pre-filled email matches an existing contact, prefer the stored
     # name/company so the form shows what will actually be persisted on
     # submit — the dedup logic in find_or_create_contact keeps the stored
     # row untouched, so showing the classifier-suggested name here would
     # mislead the coordinator.
-    if prefill_client_email:
-        existing_client = await svc.get_client_contact_by_email(prefill_client_email)
+    if prefill.client_email:
+        existing_client = await svc.get_client_contact_by_email(prefill.client_email)
         if existing_client is not None:
-            prefill_client_name = existing_client.name
+            prefill.client_name = existing_client.name
             if existing_client.company:
-                prefill_client_company = existing_client.company
-    if prefill_recruiter_email:
+                prefill.client_company = existing_client.company
+    if prefill.recruiter_email:
         existing_recruiter = await svc.get_contact_by_email(
-            prefill_recruiter_email, role="recruiter"
+            prefill.recruiter_email, role="recruiter"
         )
         if existing_recruiter is not None:
-            prefill_recruiter_name = existing_recruiter.name
-    if prefill_cm_email:
-        existing_cm = await svc.get_contact_by_email(prefill_cm_email, role="client_manager")
+            prefill.recruiter_name = existing_recruiter.name
+    if prefill.cm_email:
+        existing_cm = await svc.get_contact_by_email(prefill.cm_email, role="client_manager")
         if existing_cm is not None:
-            prefill_cm_name = existing_cm.name
+            prefill.cm_name = existing_cm.name
 
     # Pass suggestion_id through so create_loop can resolve it
     suggestion_id = _get_param(body, "suggestion_id")
@@ -608,14 +732,15 @@ async def _handle_show_create_form(body: AddonRequest, svc: LoopService, email: 
         gmail_thread_id=gmail_thread_id,
         gmail_subject=gmail_subject,
         gmail_message_id=message_id,
-        prefill_candidate_name=prefill_candidate_name,
-        prefill_client_name=prefill_client_name,
-        prefill_client_email=prefill_client_email,
-        prefill_client_company=prefill_client_company,
-        prefill_recruiter_name=prefill_recruiter_name,
-        prefill_recruiter_email=prefill_recruiter_email,
-        prefill_cm_name=prefill_cm_name,
-        prefill_cm_email=prefill_cm_email,
+        prefill_candidate_name=prefill.candidate_name,
+        prefill_client_name=prefill.client_name,
+        prefill_client_email=prefill.client_email,
+        prefill_client_company=prefill.client_company,
+        prefill_recruiter_name=prefill.recruiter_name,
+        prefill_recruiter_email=prefill.recruiter_email,
+        prefill_cm_name=prefill.cm_name,
+        prefill_cm_email=prefill.cm_email,
+        banner=banner,
         suggestion_id=suggestion_id,
     )
 
@@ -778,7 +903,7 @@ async def _handle_create_loop(body: AddonRequest, svc: LoopService, email: str, 
     # (e.g. DRAFT_EMAIL to recruiter). Runs async so the UI returns instantly.
     gmail_message_id = _get_param(body, "gmail_message_id")
     if gmail_thread_id and request:
-        redis = getattr(request.app.state, "redis", None)
+        redis = get_redis(request)
         if redis:
             try:
                 await redis.enqueue_job(
@@ -811,10 +936,10 @@ async def _handle_create_loop(body: AddonRequest, svc: LoopService, email: str, 
 
 
 def _get_draft_service(request: Request | None):
-    """Get DraftService from app state, or None if not available."""
+    """Get DraftService from app state, or None when request is missing."""
     if request is None:
         return None
-    return getattr(request.app.state, "draft_service", None)
+    return get_draft_service(request)
 
 
 async def _handle_view_draft(body: AddonRequest, svc: LoopService, email: str, **kwargs):
@@ -875,7 +1000,7 @@ async def _handle_send_draft(body: AddonRequest, svc: LoopService, email: str, *
     # shows them context regardless); forwards raise, because a forward
     # without quoted history is exactly the bug we're fixing.
     thread = None
-    gmail = getattr(request.app.state, "gmail", None) if request else None
+    gmail = get_gmail(request) if request else None
     if gmail and draft.gmail_thread_id:
         try:
             thread = await gmail.get_thread(email, draft.gmail_thread_id)
@@ -1182,7 +1307,11 @@ async def oauth_callback(code: str, state: str, request: Request):
         )
 
     # Store the refresh token
-    gmail = request.app.state.gmail
+    gmail = get_gmail(request)
+    if gmail is None:
+        return HTMLResponse(
+            "<html><body>Server misconfigured: Gmail not available.</body></html>", status_code=503
+        )
     await gmail._token_store.store_token(
         user_email=user_email,
         refresh_token=refresh_token,

--- a/services/api/src/api/app_state.py
+++ b/services/api/src/api/app_state.py
@@ -1,0 +1,76 @@
+"""Typed getters for ``app.state`` attributes.
+
+Rather than scattering ``getattr(request.app.state, "gmail", None)`` calls
+across route handlers, every consumer goes through a helper here. Each
+getter is typed for IDE / pyright use and consistent about None semantics:
+
+- **Required state** (always populated during lifespan): direct accessor, no
+  Optional return. Raises ``AttributeError`` if not set — a bug.
+- **Optional state** (may be skipped when deps are missing, e.g. Redis when
+  disabled, GmailClient when the encryption key is absent): returns ``None``.
+
+The split matches what ``api.main.lifespan`` actually does — see there for
+which services are always wired up vs. conditionally initialized.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from arq.connections import ArqRedis
+    from fastapi import Request
+    from langfuse import Langfuse
+    from psycopg_pool import AsyncConnectionPool
+
+    from api.ai.llm_service import LLMService
+    from api.drafts.service import DraftService
+    from api.gmail.client import GmailClient
+    from api.overview.service import OverviewService
+    from api.scheduling.service import LoopService
+
+
+# -- Required: set by lifespan, always available in production ------------
+
+
+def get_db(request: Request) -> AsyncConnectionPool:
+    return request.app.state.db
+
+
+def get_scheduling(request: Request) -> LoopService:
+    return request.app.state.scheduling
+
+
+# -- Optional: may be None when the dep is disabled OR the test harness ---
+# doesn't wire it up. Production lifespan sets all of these — callers should
+# handle None as "feature unavailable, degrade gracefully".
+
+
+def get_gmail(request: Request) -> GmailClient | None:
+    """GmailClient, or None if ``GMAIL_TOKEN_ENCRYPTION_KEY`` is unset."""
+    return getattr(request.app.state, "gmail", None)
+
+
+def get_redis(request: Request) -> ArqRedis | None:
+    """Arq Redis pool, or None if Redis is unreachable at startup."""
+    return getattr(request.app.state, "redis", None)
+
+
+def get_llm(request: Request) -> LLMService | None:
+    return getattr(request.app.state, "llm_service", None)
+
+
+def get_langfuse(request: Request) -> Langfuse | None:
+    return getattr(request.app.state, "langfuse", None)
+
+
+def get_draft_service(request: Request) -> DraftService | None:
+    return getattr(request.app.state, "draft_service", None)
+
+
+def get_overview_service(request: Request) -> OverviewService | None:
+    """OverviewService if one has been set. Route code that needs a
+    lazily-instantiated service should use ``addon.routes._get_overview_service``
+    which constructs one from the db pool on first access.
+    """
+    return getattr(request.app.state, "overview_service", None)

--- a/services/api/src/api/classifier/create_loop_extractor.py
+++ b/services/api/src/api/classifier/create_loop_extractor.py
@@ -1,0 +1,28 @@
+"""Typed LLM endpoint for on-demand create-loop field extraction.
+
+Runs against a formatted Gmail thread when the coordinator clicks
+"Create New Loop" on a thread the classifier did not flag as
+CREATE_LOOP. Emits the same CreateLoopExtraction shape the classifier
+writes into action_data, so downstream form-prefill code handles both
+paths uniformly. See rfcs/rfc-infer-create-loop-fields.md.
+"""
+
+from pydantic import BaseModel
+
+from api.ai import llm_endpoint
+from api.classifier.models import CreateLoopExtraction
+
+
+class ExtractCreateLoopInput(BaseModel):
+    """Template variables for scheduling-create-loop-extractor-v1."""
+
+    thread_history: str
+    coordinator_email: str
+
+
+extract_create_loop_fields = llm_endpoint(
+    name="extract_create_loop_fields",
+    prompt_name="scheduling-create-loop-extractor-v1",
+    input_type=ExtractCreateLoopInput,
+    output_type=CreateLoopExtraction,
+)

--- a/services/api/src/api/classifier/hook.py
+++ b/services/api/src/api/classifier/hook.py
@@ -26,6 +26,7 @@ from api.classifier.formatters import (
 )
 from api.classifier.models import (
     ClassificationResult,
+    CreateLoopExtraction,
     SuggestedAction,
     SuggestionItem,
 )
@@ -49,6 +50,48 @@ LINK_THREAD_MIN_CONFIDENCE = 0.9
 
 # Rate limit: max classifications per coordinator per hour
 MAX_CLASSIFICATIONS_PER_HOUR = 100
+
+
+# Fields lifted from the loose extracted_entities dict into the typed
+# CreateLoopExtraction payload on action_data. Kept in sync with
+# classifier/models.py:CreateLoopExtraction.
+_CREATE_LOOP_FIELDS = (
+    "candidate_name",
+    "client_name",
+    "client_email",
+    "client_company",
+    "cm_name",
+    "cm_email",
+    "recruiter_name",
+    "recruiter_email",
+)
+
+
+def _coerce_create_loop_action_data(item: SuggestionItem) -> SuggestionItem:
+    """Parallel-write typed CreateLoopExtraction into action_data for CREATE_LOOP.
+
+    The classifier emits CREATE_LOOP fields into extracted_entities (loose
+    dict). Downstream readers (overview card, show_create_form handler)
+    prefer action_data over extracted_entities via _val(). This coercion
+    populates action_data with the same values as a typed
+    CreateLoopExtraction dump so both paths see a consistent shape.
+
+    We keep writing extracted_entities for one release as a compat shim
+    — per rfcs/rfc-infer-create-loop-fields.md §Rollout.
+    """
+    if item.action != SuggestedAction.CREATE_LOOP:
+        return item
+    if item.action_data:
+        # Classifier already produced typed data — trust it.
+        return item
+
+    values: dict[str, str | None] = {}
+    for field in _CREATE_LOOP_FIELDS:
+        raw = item.extracted_entities.get(field)
+        values[field] = raw if isinstance(raw, str) and raw else None
+
+    extraction = CreateLoopExtraction(**values)
+    return item.model_copy(update={"action_data": extraction.model_dump()})
 
 
 class ClassifierHook:
@@ -148,6 +191,7 @@ class ClassifierHook:
                 continue
 
             item = self._apply_guardrails(item, linked_loop)
+            item = _coerce_create_loop_action_data(item)
             suggestion = await self._suggestions.create_suggestion(
                 coordinator_email=event.coordinator_email,
                 gmail_message_id=msg.id,

--- a/services/api/src/api/classifier/models.py
+++ b/services/api/src/api/classifier/models.py
@@ -68,6 +68,26 @@ class DraftEmailData(BaseModel):
     recipient_type: str  # "client" or "recruiter"
 
 
+class CreateLoopExtraction(BaseModel):
+    """Typed payload for CREATE_LOOP action_data.
+
+    Emitted by the classifier's CREATE_LOOP suggestions AND by the on-demand
+    manual-path extractor (``extract_create_loop_fields``). Every field is
+    optional — the consumer (the create-loop form) tolerates any subset and
+    falls back to deterministic prefill / stored contact rows when a field
+    is null. See rfcs/rfc-infer-create-loop-fields.md.
+    """
+
+    candidate_name: str | None = None
+    client_name: str | None = None
+    client_email: str | None = None
+    client_company: str | None = None
+    cm_name: str | None = None
+    cm_email: str | None = None
+    recruiter_name: str | None = None
+    recruiter_email: str | None = None
+
+
 # -- LLM output schema --
 
 

--- a/services/api/src/api/gmail/webhook.py
+++ b/services/api/src/api/gmail/webhook.py
@@ -16,6 +16,8 @@ from fastapi import APIRouter, Request, Response
 from google.auth.transport import requests as google_requests
 from google.oauth2 import id_token
 
+from api.app_state import get_gmail, get_redis
+
 logger = logging.getLogger(__name__)
 
 webhook_router = APIRouter(tags=["gmail-push"])
@@ -97,7 +99,7 @@ async def gmail_webhook(request: Request) -> Response:
         return Response(status_code=200)
 
     # Check if we have credentials for this coordinator
-    gmail = getattr(request.app.state, "gmail", None)
+    gmail = get_gmail(request)
     if not gmail:
         logger.warning("GmailClient not initialized — cannot process webhook")
         return Response(status_code=200)
@@ -106,7 +108,7 @@ async def gmail_webhook(request: Request) -> Response:
         return Response(status_code=200)
 
     # Enqueue background job
-    redis = getattr(request.app.state, "redis", None)
+    redis = get_redis(request)
     if redis is None:
         logger.warning("redis not available — cannot enqueue push job")
         return Response(status_code=200)

--- a/services/api/src/api/scheduling/cards.py
+++ b/services/api/src/api/scheduling/cards.py
@@ -76,6 +76,7 @@ LRP_HEADER = CardHeader(
 def _action(
     action_name: str,
     required_widgets: list[str] | None = None,
+    load_indicator: str | None = None,
     **params: str,
 ) -> OnClick:
     """Build an OnClick that POSTs to our /addon/action endpoint.
@@ -90,6 +91,7 @@ def _action(
             function=_action_url,
             parameters=parameters,
             required_widgets=required_widgets,
+            load_indicator=load_indicator,
         )
     )
 
@@ -98,11 +100,17 @@ def _button(
     text: str,
     action_name: str,
     required_widgets: list[str] | None = None,
+    load_indicator: str | None = None,
     **params: str,
 ) -> Button:
     return Button(
         text=text,
-        on_click=_action(action_name, required_widgets=required_widgets, **params),
+        on_click=_action(
+            action_name,
+            required_widgets=required_widgets,
+            load_indicator=load_indicator,
+            **params,
+        ),
     )
 
 
@@ -199,7 +207,12 @@ def build_contextual_unlinked(gmail_thread_id: str, message_id: str | None = Non
                     widgets=[
                         _text("This thread is not linked to a scheduling loop."),
                         _buttons(
-                            _button("Create New Loop", "show_create_form", **btn_params),
+                            _button(
+                                "Create New Loop",
+                                "show_create_form",
+                                load_indicator="SPINNER",
+                                **btn_params,
+                            ),
                         ),
                     ]
                 ),
@@ -237,9 +250,21 @@ def build_create_loop_form(
     prefill_client_company: str | None = None,
     prefill_first_stage: str | None = None,
     error_message: str | None = None,
+    banner: str | None = None,
     suggestion_id: str | None = None,
 ) -> CardResponse:
     sections = []
+
+    # Informational banner (when the AI extractor contributed prefills).
+    # Rendered above any error banner so the coordinator sees context first.
+    if banner:
+        sections.append(
+            Section(
+                widgets=[
+                    TextParagraphWidget(text_paragraph=TextParagraph(text=f"<i>{banner}</i>")),
+                ]
+            )
+        )
 
     # Error banner (if any)
     if error_message:

--- a/services/api/tests/test_create_loop_extractor.py
+++ b/services/api/tests/test_create_loop_extractor.py
@@ -1,0 +1,310 @@
+"""Tests for the manual-path create-loop field extractor.
+
+Covers the three building blocks from rfcs/rfc-infer-create-loop-fields.md:
+  - _merge_prefill: extractor overlays deterministic prefill (never overwrites).
+  - _coerce_create_loop_action_data: classifier hook parallel-writes typed
+    CreateLoopExtraction to action_data for CREATE_LOOP suggestions.
+  - _handle_show_create_form: banner + prefill on extractor success;
+    deterministic-only fallback on extractor error.
+"""
+
+import base64
+import json
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from httpx import ASGITransport, AsyncClient
+
+from api.addon.routes import _merge_prefill
+from api.classifier.hook import _coerce_create_loop_action_data
+from api.classifier.models import (
+    CreateLoopExtraction,
+    EmailClassification,
+    SuggestedAction,
+    SuggestionItem,
+)
+from api.main import app
+from api.scheduling.models import StatusBoard
+
+_TEST_EMAIL = "coordinator@longridgepartners.com"
+_jwt_payload = base64.urlsafe_b64encode(json.dumps({"email": _TEST_EMAIL}).encode()).decode()
+_FAKE_USER_ID_TOKEN = f"header.{_jwt_payload}.signature"
+
+
+# ---------------------------------------------------------------------------
+# _merge_prefill
+# ---------------------------------------------------------------------------
+
+
+class TestMergePrefill:
+    def test_extractor_fills_nulls_only(self):
+        deterministic = CreateLoopExtraction(
+            client_name="Jane Deterministic",
+            client_email="jane@acme.com",
+            cm_name="Cecil CM",
+            cm_email="cecil@acme.com",
+        )
+        extracted = CreateLoopExtraction(
+            candidate_name="Claire Candidate",
+            client_name="Jane Extracted",  # should lose to deterministic
+            client_email="other@acme.com",  # should lose to deterministic
+            client_company="Acme Capital",
+            recruiter_name="Ruth Recruiter",
+        )
+        merged = _merge_prefill(deterministic, extracted)
+
+        # Deterministic wins where set
+        assert merged.client_name == "Jane Deterministic"
+        assert merged.client_email == "jane@acme.com"
+        assert merged.cm_name == "Cecil CM"
+        assert merged.cm_email == "cecil@acme.com"
+        # Extractor fills fields with no deterministic counterpart
+        assert merged.candidate_name == "Claire Candidate"
+        assert merged.client_company == "Acme Capital"
+        # Extractor fills blanks where deterministic was null
+        assert merged.recruiter_name == "Ruth Recruiter"
+        assert merged.recruiter_email is None
+
+    def test_both_empty(self):
+        merged = _merge_prefill(CreateLoopExtraction(), CreateLoopExtraction())
+        assert merged.model_dump() == CreateLoopExtraction().model_dump()
+
+    def test_extractor_null_preserves_deterministic(self):
+        deterministic = CreateLoopExtraction(client_email="jane@acme.com")
+        extracted = CreateLoopExtraction()  # all None
+        merged = _merge_prefill(deterministic, extracted)
+        assert merged.client_email == "jane@acme.com"
+
+
+# ---------------------------------------------------------------------------
+# _coerce_create_loop_action_data (classifier hook parallel-write)
+# ---------------------------------------------------------------------------
+
+
+def _create_loop_item(**entities) -> SuggestionItem:
+    return SuggestionItem(
+        classification=EmailClassification.NEW_INTERVIEW_REQUEST,
+        action=SuggestedAction.CREATE_LOOP,
+        confidence=0.9,
+        summary="Schedule Claire for the Acme intro round",
+        extracted_entities=entities,
+    )
+
+
+class TestCoerceCreateLoopActionData:
+    def test_copies_fields_into_action_data(self):
+        item = _create_loop_item(
+            candidate_name="Claire Candidate",
+            client_name="Jane Doe",
+            client_email="jane@acme.com",
+            client_company="Acme Capital",
+            phone="+1-555-0100",  # extra field — should not appear in typed payload
+        )
+        coerced = _coerce_create_loop_action_data(item)
+
+        assert coerced.action_data["candidate_name"] == "Claire Candidate"
+        assert coerced.action_data["client_name"] == "Jane Doe"
+        assert coerced.action_data["client_email"] == "jane@acme.com"
+        assert coerced.action_data["client_company"] == "Acme Capital"
+        # Fields not populated remain null
+        assert coerced.action_data["recruiter_name"] is None
+        assert coerced.action_data["recruiter_email"] is None
+        # Typed payload must not contain the extra field
+        assert "phone" not in coerced.action_data
+        # Compat shim: extracted_entities kept untouched for one release
+        assert coerced.extracted_entities["candidate_name"] == "Claire Candidate"
+        assert coerced.extracted_entities["phone"] == "+1-555-0100"
+
+    def test_respects_existing_action_data(self):
+        item = _create_loop_item(candidate_name="Claire").model_copy(
+            update={"action_data": {"candidate_name": "Already Set", "custom": 1}},
+        )
+        coerced = _coerce_create_loop_action_data(item)
+        assert coerced.action_data == {"candidate_name": "Already Set", "custom": 1}
+
+    def test_ignores_non_create_loop_actions(self):
+        item = SuggestionItem(
+            classification=EmailClassification.AVAILABILITY_RESPONSE,
+            action=SuggestedAction.DRAFT_EMAIL,
+            confidence=0.9,
+            summary="Share availability with client",
+            extracted_entities={"candidate_name": "Claire"},
+        )
+        coerced = _coerce_create_loop_action_data(item)
+        assert coerced.action_data == {}
+
+    def test_empty_string_treated_as_null(self):
+        item = _create_loop_item(candidate_name="", client_name="Jane")
+        coerced = _coerce_create_loop_action_data(item)
+        assert coerced.action_data["candidate_name"] is None
+        assert coerced.action_data["client_name"] == "Jane"
+
+
+# ---------------------------------------------------------------------------
+# _handle_show_create_form end-to-end (extractor wiring)
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def mock_scheduling():
+    svc = AsyncMock()
+    svc.get_status_board = AsyncMock(return_value=StatusBoard())
+    svc.find_loop_by_thread = AsyncMock(return_value=None)
+    svc.get_contact_by_email = AsyncMock(return_value=None)
+    svc.get_client_contact_by_email = AsyncMock(return_value=None)
+    # _handle_show_create_form pokes svc._gmail for get_message/get_thread.
+    # MagicMock auto-creates attributes, including `.name`, which is truthy —
+    # so set `.name = ""` explicitly on `from_` (otherwise `msg.from_.name or None`
+    # captures the MagicMock as the value).
+    from_ = MagicMock()
+    from_.name = ""
+    from_.email = "jane@acme.com"
+    msg = MagicMock()
+    msg.from_ = from_
+    msg.cc = []
+    msg.subject = "Intro with Claire"
+    thread = MagicMock()
+    thread_msg = MagicMock()
+    thread_msg.id = "msg-1"
+    thread.messages = [thread_msg]
+    gmail = AsyncMock()
+    gmail.get_message = AsyncMock(return_value=msg)
+    gmail.get_thread = AsyncMock(return_value=thread)
+    svc._gmail = gmail
+    return svc
+
+
+@pytest.fixture
+def mock_overview():
+    from api.overview.service import OverviewService
+
+    svc = AsyncMock(spec=OverviewService)
+    svc.get_overview_data = AsyncMock(return_value=[])
+    svc.get_thread_overview_data = AsyncMock(return_value=[])
+    return svc
+
+
+@pytest.fixture
+async def client(mock_scheduling, mock_overview):
+    app.state.scheduling = mock_scheduling
+    app.state.overview_service = mock_overview
+    # Extractor prereqs: both must be non-None for extraction to run.
+    app.state.llm_service = MagicMock()
+    app.state.langfuse = MagicMock()
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as c:
+        yield c
+
+
+def _show_create_form_event(**extra_params):
+    params = {
+        "action_name": "show_create_form",
+        "gmail_thread_id": "thread-xyz",
+        "message_id": "msg-1",
+        **extra_params,
+    }
+    return {
+        "commonEventObject": {
+            "hostApp": "GMAIL",
+            "platform": "WEB",
+            "parameters": params,
+        },
+        "authorizationEventObject": {"userIdToken": _FAKE_USER_ID_TOKEN},
+    }
+
+
+def _form_inputs(card: dict) -> dict[str, str | None]:
+    inputs: dict[str, str | None] = {}
+    for section in card["sections"]:
+        for widget in section["widgets"]:
+            ti = widget.get("textInput")
+            if ti:
+                inputs[ti["name"]] = ti.get("value")
+    return inputs
+
+
+def _banner_text(card: dict) -> str | None:
+    """Return the first informational banner's raw text, if present."""
+    if not card["sections"]:
+        return None
+    first = card["sections"][0]
+    widget = first["widgets"][0]
+    tp = widget.get("textParagraph")
+    if tp and tp["text"].startswith("<i>"):
+        return tp["text"]
+    return None
+
+
+class TestShowCreateFormExtractor:
+    async def test_happy_path_renders_banner_and_prefills(
+        self, client: AsyncClient, mock_scheduling
+    ):
+        extracted = CreateLoopExtraction(
+            candidate_name="Claire Candidate",
+            client_company="Acme Capital",
+            recruiter_name="Ruth Recruiter",
+            recruiter_email="ruth@lrp.com",
+        )
+        with patch(
+            "api.addon.routes.extract_create_loop_fields",
+            new=AsyncMock(return_value=extracted),
+        ):
+            resp = await client.post("/addon/action", json=_show_create_form_event())
+
+        assert resp.status_code == 200
+        card = resp.json()["action"]["navigations"][0]["updateCard"]
+        inputs = _form_inputs(card)
+
+        # Extractor fields present
+        assert inputs["candidate_name"] == "Claire Candidate"
+        assert inputs["client_company"] == "Acme Capital"
+        assert inputs["recruiter_name"] == "Ruth Recruiter"
+        assert inputs["recruiter_email"] == "ruth@lrp.com"
+        # Deterministic field (from get_message mock) is preserved
+        assert inputs["client_email"] == "jane@acme.com"
+        # Banner rendered
+        banner = _banner_text(card)
+        assert banner is not None and "thread" in banner.lower()
+
+    async def test_error_falls_back_to_deterministic_no_banner(
+        self, client: AsyncClient, mock_scheduling
+    ):
+        with patch(
+            "api.addon.routes.extract_create_loop_fields",
+            new=AsyncMock(side_effect=RuntimeError("boom")),
+        ):
+            resp = await client.post("/addon/action", json=_show_create_form_event())
+
+        assert resp.status_code == 200
+        card = resp.json()["action"]["navigations"][0]["updateCard"]
+        inputs = _form_inputs(card)
+        # Deterministic prefill still works
+        assert inputs["client_email"] == "jane@acme.com"
+        # Candidate came only from the extractor — must be empty on fallback
+        assert not inputs.get("candidate_name")
+        # No informational banner on failure
+        assert _banner_text(card) is None
+
+    async def test_classifier_prefill_skips_extractor(self, client: AsyncClient, mock_scheduling):
+        """When the overview suggestion card passes prefill_* params, we must
+        not re-run extraction — the classifier already did the work.
+        """
+        extractor = AsyncMock(return_value=CreateLoopExtraction(candidate_name="Should-Not-Use"))
+        with patch("api.addon.routes.extract_create_loop_fields", new=extractor):
+            resp = await client.post(
+                "/addon/action",
+                json=_show_create_form_event(
+                    prefill_candidate_name="Classifier Claire",
+                    prefill_client_email="classifier@acme.com",
+                ),
+            )
+
+        assert resp.status_code == 200
+        card = resp.json()["action"]["navigations"][0]["updateCard"]
+        inputs = _form_inputs(card)
+        assert inputs["candidate_name"] == "Classifier Claire"
+        assert inputs["client_email"] == "classifier@acme.com"
+        # Extractor should NOT have been called — classifier data is authoritative
+        extractor.assert_not_called()
+        # No banner either — banner is reserved for the manual AI-assisted path
+        assert _banner_text(card) is None


### PR DESCRIPTION
Implements [rfcs/rfc-infer-create-loop-fields.md](https://github.com/nsadeh/lrp-scheduling-agent/pull/44) from #44. When the coordinator clicks **"Create New Loop"** on a thread the classifier didn't flag as CREATE_LOOP, the sidebar now pre-fills candidate / client / client-company / CM / recruiter fields by running a Haiku-backed typed extractor against the Gmail thread — instead of rendering a nearly-empty form.

## Summary

- **Shared typed payload** `CreateLoopExtraction` on `SuggestionItem.action_data`. Classifier parallel-writes it via `_coerce_create_loop_action_data` alongside the legacy `extracted_entities` dict (compat shim for one release).
- **New llm_endpoint** `extract_create_loop_fields` → LangFuse prompt `scheduling-create-loop-extractor-v1`. Prompt lives in LangFuse, not in-repo.
- **Handler wiring** in `_handle_show_create_form`:
  - Runs the extractor behind a 10s timeout with graceful degradation to today's deterministic `from_` / `cc[0]` prefill on any failure.
  - **Skips extraction** when the overview suggestion card already provided `prefill_*` params (classifier path keeps its output).
  - Renders an informational `<i>Filled in from the thread…</i>` banner above the form when the AI contributed prefills.
- **Spinner** — `OnClickAction.load_indicator="SPINNER"` on the Create New Loop button, so the button dims during the ~2s round-trip.
- **`api/app_state.py`** — typed getters (`get_gmail`, `get_llm`, `get_langfuse`, `get_redis`, `get_draft_service`, `get_overview_service`, `get_scheduling`, `get_db`) replacing 11+ `getattr(request.app.state, ...)` call sites across `addon/routes.py` and `gmail/webhook.py`.

## Scope — deliberately *not* done

- No supervised eval (`services/api/tests/evals/`). RFC R2 ship criteria deferred until a labeled dataset exists.
- No two-phase card rendering, no background pre-extraction, no caching — all rejected alternatives in the RFC.
- `extracted_entities` is still written by the classifier (compat shim). Dropping it is a follow-up release per the RFC's rollout plan.
- `first_stage_name` extraction omitted per RFC OQ1.

## Required follow-up before this is visible to users

The extractor fetches its prompt by the `production` label. **A human needs to promote the prompt version in LangFuse before the extractor can resolve.** Until then, the handler silently falls back to deterministic prefill (not a user-visible break).

1. Open LangFuse → Prompts → `scheduling-create-loop-extractor-v1`.
2. Add the `production` label to the latest version.

## Test plan

- [x] `uv run pytest tests/test_create_loop_extractor.py` — 10 tests for merge policy, classifier hook parallel-write, handler happy/error/classifier-prefill paths
- [x] `uv run pytest tests/test_addon.py tests/test_classifier_hook.py tests/test_gmail_webhook.py` — no regressions (23 tests)
- [x] `uv run ruff check` clean on all touched files
- [ ] Smoke-test end-to-end in dev: click "Create New Loop" on an unclassified thread → spinner → populated form + banner within ~3s
- [ ] Disconnect LangFuse (bad key) → form still renders with deterministic prefill only, no banner, no error

🤖 Generated with [Claude Code](https://claude.com/claude-code)