### PR TITLE
fix(gmail-worker): demote GmailNotFoundError per-message to INFO

### DIFF
--- a/services/api/src/api/gmail/workers.py
+++ b/services/api/src/api/gmail/workers.py
@@ -325,6 +325,12 @@ async def _process_history(ctx: dict, coordinator_email: str, start_history_id: 
             )
             await hook.on_email(event)
 
+        except GmailNotFoundError:
+            logger.info(
+                "message %s not fetchable for %s (likely spam/filter/delete)",
+                msg_id,
+                coordinator_email,
+            )
         except Exception:
             logger.exception("failed to process message %s for %s", msg_id, coordinator_email)
 


### PR DESCRIPTION
## Summary

- Per-message `GmailNotFoundError` failures inside `_process_history` are now logged at INFO instead of ERROR, so they no longer page on Sentry.
- All other exception types (5xx, 429, auth, parser, network, hook bugs) continue to hit the broad `except Exception` with `logger.exception` and remain captured normally.

## Why

We were seeing recurring "failed to process message …" ERROR events on the arq worker for the call at `services/api/src/api/gmail/workers.py:301`. Sentry breadcrumbs from a captured event show the underlying cause unambiguously:

> `<HttpError 404 when requesting https://gmail.googleapis.com/gmail/v1/users/me/messages/<id>?format=full&alt=json returned "Requested entity was not found.". Details: "[{'message': 'Requested entity was not found.', 'domain': 'global', 'reason': 'notFound'}]">`

Three consecutive 404s landed for the same coordinator in ~530ms from a single `history.list` batch — the fingerprint of a Gmail-side rule (spam filter / auto-archive / user delete) firing on a batch between when a message appears in the history feed and when our worker calls `messages.get`. The dedup INSERT at `workers.py:290-298` runs before the fetch, so these messages are correctly never retried — the previous behavior was right on substance, just shouldn't have been ERROR-level.

## What changes for observability

- The existing "failed to process message …" Sentry issue should stop receiving 404 events. Anything still showing up is a non-404 — i.e. a genuine bug or operational concern, which is the signal we want to preserve.
- Railway worker logs gain a new INFO line: `message <id> not fetchable for <email> (likely spam/filter/delete)` — useful for sanity-checking volume post-deploy and easy to grep if we later want to add a counter.

## Test plan

- [x] `ruff check` and `ruff format --check` clean on the modified file.
- [x] `uv run pytest tests/test_gmail_webhook.py` — 6/6 pass.
- [ ] Post-deploy: confirm the existing Sentry "failed to process message" issue stops accumulating 404 events; eyeball Railway worker logs for the new INFO line at a rate comparable to the prior error rate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)