### PR TITLE
fix(worker): right-size DB pool and concurrency to stop arq timeouts

### DIFF
--- a/services/api/src/api/gmail/workers.py
+++ b/services/api/src/api/gmail/workers.py
@@ -41,7 +41,7 @@ async def startup(ctx: dict) -> None:
     logging.basicConfig(level=logging.INFO, format="%(levelname)s:%(name)s: %(message)s")
     init_sentry(service="worker")
     database_url = os.environ.get("DATABASE_URL", "postgresql://dev:dev@localhost:5432/lrp_dev")
-    pool = AsyncConnectionPool(conninfo=database_url)
+    pool = AsyncConnectionPool(conninfo=database_url, min_size=10, max_size=25)
     await pool.open()
 
     encryption_key = os.environ.get("GMAIL_TOKEN_ENCRYPTION_KEY", "")
@@ -419,5 +419,5 @@ class WorkerSettings:
     on_job_start = on_job_start
     on_job_end = on_job_end
     redis_settings = RedisSettings.from_dsn(REDIS_URL)
-    max_jobs = 50
+    max_jobs = 20
     job_timeout = 180


### PR DESCRIPTION
## Summary
- Worker arq jobs were hitting \`TimeoutError\` because the psycopg \`AsyncConnectionPool\` used library defaults while \`max_jobs=50\` ran concurrently — connection demand far outstripped supply, and any job holding a connection across an LLM classifier call starved the rest. Prod symptom: jobs delayed 400+ seconds in the queue then failing inside \`pool.getconn()\`'s \`wait_timeout\`.
- Cap the worker pool: \`min_size=10, max_size=25\`.
- Drop worker concurrency: \`max_jobs = 20\` (kept under the pool ceiling with headroom for the connections briefly held by \`get_loop\`'s sequential queries).
- Web pool intentionally untouched — FastAPI routes acquire/query/release in milliseconds and don't hold connections across LLM calls, so they don't exhibit the same starvation pattern.

## Trade-offs / things to know
- Total connection budget after this change: worker pool ≤ 25 + web pool (defaults) per process. Worth confirming Railway Postgres \`max_connections\` leaves headroom for both services plus any other clients (psql sessions, migrations).
- If worker queue depth grows, the right next step is to bump \`max_jobs\` and \`max_size\` in lockstep — not to raise just one.

## Test plan
- [ ] Deploy to staging and watch worker logs for \`TimeoutError\` from \`pool.getconn()\` — should disappear.
- [ ] Watch arq queue depth / \`delayed=\` values for \`reclassify_after_loop_creation\` — should stay near zero under normal load.
- [ ] Confirm no new \`PoolTimeout\` errors surface (would indicate \`max_size=25\` is still too tight).

🤖 Generated with [Claude Code](https://claude.com/claude-code)