### PR TITLE
docs: clarify loop = one candidate (not one round)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -23,6 +23,7 @@ In a call, I showed them the Cursor "tab" button that is a gag gift for develope
 - **Candidate**: Person being interviewed. Identified by email address.
 - **Encore**: LRP's ATS/CRM system (accessed via Cluein Data Connector). Source of truth for candidate/recruiter records.
 - **Scheduling thread**: One Gmail thread per interview request, tracked through states: new request → awaiting availability → awaiting confirmation → confirmed → systems updated.
+- **Loop = one candidate**: A scheduling loop tracks ONE candidate's journey with a client, regardless of how many interview rounds there are. Multiple rounds for the same candidate belong to the SAME loop. Multiple loops are only created when an email involves multiple CANDIDATES (one loop per candidate). Never create N loops for N rounds of the same candidate.
 
 ## Critical Constraints
 


### PR DESCRIPTION
## Summary

- Adds a clear definition of the **loop-per-candidate rule** to `CLAUDE.md`: a scheduling loop tracks one candidate's full journey with a client, regardless of how many interview rounds there are. Multiple loops are only created for multiple distinct candidates.

## Context

During prompt optimization for `scheduling-classifier-v3` (V26–V30), the classifier prompt contained a wrong rule: *"one loop per interview round for staged multi-round processes."* This caused:
- The model to emit 4 `create_loop` suggestions for a 4-round single-candidate email (item `9fed59db` in the Loop creation eval dataset)
- The eval dataset's expected output for that item to have 4 loops — compounding the error

**Fixes in LangFuse (not tracked in git):**
- `scheduling-classifier-v3` V30: removed the "one loop per round" rule and the same-day-panel vs staged-rounds cheatsheet; replaced with "one loop = one candidate"
- Eval dataset item `9fed59db` (Marcus Webb, 4-round full process at Marshall Wace): corrected expected output from 4 `create_loop` + 1 `draft_email` → 1 `create_loop` + 1 `draft_email`
- Additional improvements carried from V29: scoped the application-cycle-update NOTE to client-side events only (prevents over-emission on internal LRP submittal threads); added ATS no-reply exception to `client_name`/`client_email` population rules

## Test plan

- [ ] `scheduling-classifier-v3` V30 in LangFuse scores correctly on a multi-round single-candidate email (emits exactly 1 `create_loop`)
- [ ] No regression on EBMS eval dataset
- [ ] Prompt correctly emits N `create_loop` for N-candidate emails (multi-candidate behavior unchanged)

🤖 Generated with [Claude Code](https://claude.com/claude-code)