### PR TITLE
fix(llm): hard-timeout each litellm call with asyncio.wait_for

### DIFF
--- a/services/api/src/api/ai/llm_service.py
+++ b/services/api/src/api/ai/llm_service.py
@@ -4,12 +4,17 @@ Uses litellm.acompletion() with a simple primary → secondary → tertiary
 failover chain configured via environment variables.
 
 Latency budget:
-- Primary attempt: 25s timeout, 1 retry (50s max)
-- Secondary attempt: 20s timeout, 0 retries
-- Tertiary attempt: 20s timeout, 0 retries
-- Total budget: ~90s max wall-clock time
+- Primary attempt: 25s timeout, 1 retry (~60s max with hard-timeout buffer)
+- Secondary attempt: 20s timeout, 0 retries (~25s with hard-timeout buffer)
+- Tertiary attempt: 20s timeout, 0 retries (~25s with hard-timeout buffer)
+- Total budget: ~110s max wall-clock time
+
+Each attempt is wrapped in asyncio.wait_for with a +5s buffer over the
+LiteLLM timeout, to guard against the LiteLLM aiohttp transport not
+honoring stream-read timeouts.
 """
 
+import asyncio
 import logging
 import os
 import time
@@ -216,7 +221,16 @@ class LLMService:
                 span.set_data("ai.attempt", i)
                 span.set_data("ai.is_failover", i > 0)
                 try:
-                    response = await litellm.acompletion(**kwargs)
+                    # Belt-and-suspenders timeout: LiteLLM's `timeout` param is
+                    # not always honored by its aiohttp transport on stream
+                    # reads, so we enforce a hard ceiling at the asyncio layer.
+                    # The +5s buffer lets LiteLLM's own timeout fire first with
+                    # a clean error in the normal case; this only kicks in if
+                    # the underlying socket is actually stuck.
+                    response = await asyncio.wait_for(
+                        litellm.acompletion(**kwargs),
+                        timeout=timeout + 5.0,
+                    )
                 except Exception as exc:
                     elapsed_ms = (time.monotonic() - start) * 1000
                     span.set_data("ai.latency_ms", elapsed_ms)


### PR DESCRIPTION
## Summary
Followup to #53. The pool fix stopped DB-pool starvation but exposed the next layer: arq jobs were still hitting the 180s \`job_timeout\` because LiteLLM's custom aiohttp transport wasn't honoring its own \`timeout=\` parameter on stream reads. Symptom in prod: traceback hung at \`aiohttp/streams.py:707 await self._waiter\` until arq killed the whole job.

Wrap each \`litellm.acompletion()\` in \`asyncio.wait_for\` with a +5s buffer over LiteLLM's own timeout. In the normal case LiteLLM fires first and nothing changes; only when the underlying transport hangs does our wrapper enforce a hard ceiling, raising \`TimeoutError\` which is caught by the existing \`except Exception\` failover path so we just continue down the chain.

Worst-case wall-clock budget: ~110s (primary 60 + secondary 25 + tertiary 25), still well under arq's 180s \`job_timeout\`.

## Why a buffer?
The +5s asymmetry is intentional. When LiteLLM's own timeout *is* working, it fires first and emits a clean \`litellm.exceptions.Timeout\` — preserves existing error messages and telemetry. Our \`wait_for\` only kicks in when LiteLLM fails to honor its own timeout (the bug case).

## Test plan
- [ ] Deploy to staging, watch worker logs — no more bare \`TimeoutError\` from \`asyncio/timeouts.py\` after 180s.
- [ ] Confirm \`reclassify_after_loop_creation\` jobs complete within ~30s in the slow-Gemini case (asyncio.wait_for fires, failover happens).
- [ ] Verify normal-path \`litellm.exceptions.Timeout\` errors still appear in Sentry as before — wrapper should be invisible when LiteLLM behaves.

🤖 Generated with [Claude Code](https://claude.com/claude-code)