### PR TITLE
fix(worker): eliminate Postgres connection pool starvation

### DIFF
--- a/services/api/src/api/classifier/hook.py
+++ b/services/api/src/api/classifier/hook.py
@@ -401,20 +401,7 @@ class ClassifierHook:
 
     async def _get_active_loops(self, coordinator_id: str) -> list[Loop]:
         """Load coordinator's active loops for thread matching context."""
-        from api.scheduling.queries import queries as sched_queries
-
-        async with self._loops._pool.connection() as conn:
-            rows = []
-            async for row in sched_queries.get_loops_for_coordinator(
-                conn, coordinator_id=coordinator_id
-            ):
-                rows.append(row)
-
-        loops = []
-        for row in rows:
-            loop = await self._loops.get_loop(row[0])
-            loops.append(loop)
-        return loops
+        return await self._loops.get_loops_for_coordinator(coordinator_id)
 
     def _apply_guardrails(
         self,

--- a/services/api/src/api/gmail/workers.py
+++ b/services/api/src/api/gmail/workers.py
@@ -41,7 +41,7 @@ async def startup(ctx: dict) -> None:
     logging.basicConfig(level=logging.INFO, format="%(levelname)s:%(name)s: %(message)s")
     init_sentry(service="worker")
     database_url = os.environ.get("DATABASE_URL", "postgresql://dev:dev@localhost:5432/lrp_dev")
-    pool = AsyncConnectionPool(conninfo=database_url, min_size=10, max_size=25)
+    pool = AsyncConnectionPool(conninfo=database_url, min_size=5, max_size=20, timeout=30.0)
     await pool.open()
 
     encryption_key = os.environ.get("GMAIL_TOKEN_ENCRYPTION_KEY", "")
@@ -419,5 +419,5 @@ class WorkerSettings:
     on_job_start = on_job_start
     on_job_end = on_job_end
     redis_settings = RedisSettings.from_dsn(REDIS_URL)
-    max_jobs = 20
+    max_jobs = 10
     job_timeout = 180

--- a/services/api/src/api/main.py
+++ b/services/api/src/api/main.py
@@ -35,7 +35,7 @@ init_sentry(service="api")
 @asynccontextmanager
 async def lifespan(app: FastAPI):
     database_url = os.environ.get("DATABASE_URL", "postgresql://dev:dev@localhost:5432/lrp_dev")
-    pool = AsyncConnectionPool(conninfo=database_url)
+    pool = AsyncConnectionPool(conninfo=database_url, timeout=30.0)
     await pool.open()
     app.state.db = pool
 

--- a/services/api/src/api/scheduling/service.py
+++ b/services/api/src/api/scheduling/service.py
@@ -284,36 +284,36 @@ class LoopService:
     async def get_loop(self, loop_id: str) -> Loop:
         """Get a fully populated loop with all nested relations."""
         async with self._pool.connection() as conn:
-            loop_row = await queries.get_loop(conn, id=loop_id)
-            if loop_row is None:
-                raise ValueError(f"Loop not found: {loop_id}")
+            return await self._populate_loop(conn, loop_id)
 
-            loop = _row_to_loop(loop_row)
+    async def _populate_loop(self, conn: AsyncConnection, loop_id: str) -> Loop:
+        """Populate a loop using an existing connection (no pool acquisition)."""
+        loop_row = await queries.get_loop(conn, id=loop_id)
+        if loop_row is None:
+            raise ValueError(f"Loop not found: {loop_id}")
 
-            # Populate actors (recruiter/client_contact may be null on loops
-            # auto-created with incomplete info; collected JIT at send time).
-            loop.coordinator = await self._get_coordinator(conn, loop.coordinator_id)
-            if loop.client_contact_id:
-                loop.client_contact = await self._get_client_contact(conn, loop.client_contact_id)
-            if loop.recruiter_id:
-                loop.recruiter = await self._get_contact(conn, loop.recruiter_id)
-            if loop.client_manager_id:
-                loop.client_manager = await self._get_contact(conn, loop.client_manager_id)
-            loop.candidate = await self._get_candidate(conn, loop.candidate_id)
+        loop = _row_to_loop(loop_row)
 
-            # Populate stages with time slots
-            stage_rows = await _collect(queries.get_stages_for_loop(conn, loop_id=loop_id))
-            stages = [_row_to_stage(r) for r in stage_rows]
-            for stage in stages:
-                ts_rows = await _collect(queries.get_time_slots_for_stage(conn, stage_id=stage.id))
-                stage.time_slots = [_row_to_time_slot(r) for r in ts_rows]
-            loop.stages = stages
+        loop.coordinator = await self._get_coordinator(conn, loop.coordinator_id)
+        if loop.client_contact_id:
+            loop.client_contact = await self._get_client_contact(conn, loop.client_contact_id)
+        if loop.recruiter_id:
+            loop.recruiter = await self._get_contact(conn, loop.recruiter_id)
+        if loop.client_manager_id:
+            loop.client_manager = await self._get_contact(conn, loop.client_manager_id)
+        loop.candidate = await self._get_candidate(conn, loop.candidate_id)
 
-            # Populate email threads
-            thread_rows = await _collect(queries.get_threads_for_loop(conn, loop_id=loop_id))
-            loop.email_threads = [_row_to_email_thread(r) for r in thread_rows]
+        stage_rows = await _collect(queries.get_stages_for_loop(conn, loop_id=loop_id))
+        stages = [_row_to_stage(r) for r in stage_rows]
+        for stage in stages:
+            ts_rows = await _collect(queries.get_time_slots_for_stage(conn, stage_id=stage.id))
+            stage.time_slots = [_row_to_time_slot(r) for r in ts_rows]
+        loop.stages = stages
 
-            return loop
+        thread_rows = await _collect(queries.get_threads_for_loop(conn, loop_id=loop_id))
+        loop.email_threads = [_row_to_email_thread(r) for r in thread_rows]
+
+        return loop
 
     async def get_status_board(self, coordinator_email: str) -> StatusBoard:
         """Build the status board for a coordinator."""
@@ -325,10 +325,10 @@ class LoopService:
             loop_rows = await _collect(
                 queries.get_all_loops_for_coordinator(conn, coordinator_id=coord.id)
             )
+            loops = [await self._populate_loop(conn, row[0]) for row in loop_rows]
 
         board = StatusBoard()
-        for loop_row in loop_rows:
-            loop = await self.get_loop(loop_row[0])
+        for loop in loops:
             summary = _loop_to_summary(loop)
 
             status = loop.computed_status
@@ -501,7 +501,7 @@ class LoopService:
             row = await queries.find_loop_by_gmail_thread_id(conn, gmail_thread_id=gmail_thread_id)
             if row is None:
                 return None
-            return await self.get_loop(row[0])
+            return await self._populate_loop(conn, row[0])
 
     async def find_loops_by_thread(self, gmail_thread_id: str) -> list[Loop]:
         """All loops linked to a Gmail thread (multi-loop threads supported)."""
@@ -509,7 +509,15 @@ class LoopService:
             rows = await _collect(
                 queries.find_loops_by_gmail_thread_id(conn, gmail_thread_id=gmail_thread_id)
             )
-        return [await self.get_loop(row[0]) for row in rows]
+            return [await self._populate_loop(conn, row[0]) for row in rows]
+
+    async def get_loops_for_coordinator(self, coordinator_id: str) -> list[Loop]:
+        """All loops for a coordinator, fully populated with a single connection."""
+        async with self._pool.connection() as conn:
+            rows = await _collect(
+                queries.get_loops_for_coordinator(conn, coordinator_id=coordinator_id)
+            )
+            return [await self._populate_loop(conn, row[0]) for row in rows]
 
     # ------------------------------------------------------------------
     # JIT actor patching (used when missing contact info is supplied at


### PR DESCRIPTION
## Summary

The arq worker was hitting `TimeoutError` cascades on `reclassify_after_loop_creation` and other classifier jobs. Root cause: the connection pool was being starved by N+1 connection-acquisition patterns during email classification.

## What was happening

- `find_loops_by_thread` released its connection, then called `get_loop()` for each linked loop — and each `get_loop()` re-acquired a new connection to run ~7 nested queries (coordinator, contacts, candidate, stages, time slots, threads).
- `_get_active_loops` in the classifier hook reached directly into `LoopService._pool` and did the same N+1 acquisition.
- With `max_jobs=20` arq workers running concurrently against a 25-connection pool, an incoming push slammed the pool. Connection acquisitions blocked, jobs hit the 180s `job_timeout`, and the worker fell over.

## Fix

- **Decouple loop population from connection acquisition.** Extract `_populate_loop(conn, loop_id)` so callers that already hold a connection reuse it instead of acquiring a new one. Public `get_loop()` still acquires from the pool for external callers.
- **Single connection per batch.** `find_loop_by_thread`, `find_loops_by_thread`, `get_status_board`, and the new `get_loops_for_coordinator` now use one connection for the whole operation.
- **Replace `_get_active_loops`** with a call to the new public method (also removes the `_pool` reach-through code smell).
- **Bound pool waits** with `timeout=30.0` on both worker and API pools — starvation now surfaces as a fast `PoolTimeout` instead of blocking jobs until the 180s arq timeout.
- **Right-size concurrency.** Worker pool tightened to `min=5, max=20` and `max_jobs` reduced from 20 → 10, so peak concurrent jobs can't exceed pool capacity.

## Test plan

- [x] `pytest tests/test_classifier_hook.py` — 24 passed
- [x] `pytest tests/test_draft_service.py tests/test_classifier_resolvers.py tests/test_addon.py tests/test_overview_service.py` — 53 passed
- [x] Full suite (excluding pre-existing failures in `test_ai_endpoint.py`, `test_ai_langfuse.py`, `test_live_updates.py`, `test_scheduling_integration.py`) — 312 passed
- [ ] Watch worker logs after deploy for absence of `reclassify_after_loop_creation` `TimeoutError`s

## Reviewer notes

- `max_jobs=10` is intentionally conservative. With the N+1 fix, each job now uses 1–2 connections at a time, so this could likely be raised back toward 15 once we have telemetry on the new ceiling.
- No schema changes, no migration, no env var changes — drop-in fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)