### PR TITLE
fix(worker): stop leaking aiohttp sessions from litellm cancellations

### DIFF
--- a/services/api/src/api/ai/llm_service.py
+++ b/services/api/src/api/ai/llm_service.py
@@ -3,18 +3,20 @@
 Uses litellm.acompletion() with a simple primary → secondary → tertiary
 failover chain configured via environment variables.
 
-Latency budget:
-- Primary attempt: 25s timeout, 1 retry (~60s max with hard-timeout buffer)
-- Secondary attempt: 20s timeout, 0 retries (~25s with hard-timeout buffer)
-- Tertiary attempt: 20s timeout, 0 retries (~25s with hard-timeout buffer)
-- Total budget: ~110s max wall-clock time
+Latency budget (enforced by litellm itself, not wrapped externally):
+- Primary attempt: 25s timeout, 1 retry
+- Secondary attempt: 20s timeout, 0 retries
+- Tertiary attempt: 20s timeout, 0 retries
 
-Each attempt is wrapped in asyncio.wait_for with a +5s buffer over the
-LiteLLM timeout, to guard against the LiteLLM aiohttp transport not
-honoring stream-read timeouts.
+We deliberately do NOT wrap the call in asyncio.wait_for. External
+cancellation interrupts litellm's aiohttp transport mid-call without
+giving it a chance to close its ClientSession, leaking the session and
+its open connections (visible as ``Unclosed client session`` /
+``Unclosed connector connections`` in Sentry). Over hours those leaked
+file descriptors saturate the worker. We trust litellm's internal
+timeout to fail cleanly; arq's ``job_timeout`` is the ultimate ceiling.
 """
 
-import asyncio
 import logging
 import os
 import time
@@ -221,16 +223,11 @@ class LLMService:
                 span.set_data("ai.attempt", i)
                 span.set_data("ai.is_failover", i > 0)
                 try:
-                    # Belt-and-suspenders timeout: LiteLLM's `timeout` param is
-                    # not always honored by its aiohttp transport on stream
-                    # reads, so we enforce a hard ceiling at the asyncio layer.
-                    # The +5s buffer lets LiteLLM's own timeout fire first with
-                    # a clean error in the normal case; this only kicks in if
-                    # the underlying socket is actually stuck.
-                    response = await asyncio.wait_for(
-                        litellm.acompletion(**kwargs),
-                        timeout=timeout + 5.0,
-                    )
+                    # Trust litellm's own timeout. Wrapping this in
+                    # asyncio.wait_for cancels the inner task on timeout, which
+                    # leaks litellm's aiohttp ClientSession because cleanup
+                    # doesn't get to run. arq's job_timeout is the outer ceiling.
+                    response = await litellm.acompletion(**kwargs)
                 except Exception as exc:
                     elapsed_ms = (time.monotonic() - start) * 1000
                     span.set_data("ai.latency_ms", elapsed_ms)

--- a/services/api/src/api/gmail/workers.py
+++ b/services/api/src/api/gmail/workers.py
@@ -420,4 +420,8 @@ class WorkerSettings:
     on_job_end = on_job_end
     redis_settings = RedisSettings.from_dsn(REDIS_URL)
     max_jobs = 20
-    job_timeout = 180
+    # Outer ceiling. We rely on litellm's own per-call timeouts (25s/20s) for
+    # LLM ops; this only fires for genuinely stuck jobs. Higher than 180s so
+    # the cancellation path — which leaks aiohttp sessions from litellm — is
+    # hit less often.
+    job_timeout = 600


### PR DESCRIPTION
## Summary

Stopgap for the worker hang/timeout cycle. After several hours of uptime, jobs start hitting arq's 180s `job_timeout` and the queue backs up by hours. Restarting the worker temporarily fixes it.

## Root cause (per Sentry)

Sentry breadcrumbs from a wedged worker show:

```
Unclosed client session client_session: <aiohttp.client.ClientSession ...>
Unclosed connector connections: ['deque([(<aiohttp.client_proto.ResponseHandler ...>, ...), ... 17 entries ...])']
```

aiohttp itself is naming the leak. A `ClientSession` was garbage-collected with **17 live HTTP connections still attached**. Multiplied by every leaked session over the worker's lifetime → hundreds of zombie TCP connections / FDs. Once FDs are saturated, new sockets can't open cleanly and existing socket I/O (including Postgres) gets starved. Jobs hang, arq cancels at 180s — which only causes more cancellations and more leaks. Death spiral.

The leak is from this code:

```python
response = await asyncio.wait_for(
    litellm.acompletion(**kwargs),
    timeout=timeout + 5.0,
)
```

When `wait_for` fires, the inner `acompletion` task is cancelled. Cancellation interrupts litellm's aiohttp transport mid-call without giving it a chance to close its `ClientSession`. With our failover chain, a single classify call can spawn up to 4 sessions; any timed out leak.

## Change

1. **Drop the outer `asyncio.wait_for`.** Trust litellm's own per-attempt timeout (25s primary / 20s fallbacks) — when litellm times itself out, it closes its session cleanly. The wait_for was added because litellm's timeout sometimes doesn't honor stream reads, but the cure is worse than the disease.
2. **Raise arq `job_timeout` from 180s → 600s.** This is the *outer* cancellation path — the only place we still cancel litellm forcibly. Higher value means it fires far less often.

## Why this is a stopgap, not a fix

If litellm itself hangs (the original reason for the wait_for), a job will now run for up to 600s instead of failing fast. The proper fix is a managed shared `aiohttp.ClientSession` passed into litellm (so cancellation doesn't matter — the session is owned by us and lives for the worker's lifetime), or using `AsyncAnthropic` directly with manual failover. Both are larger changes; this stopgap should buy meaningful breathing room.

## Test plan

- [x] `pytest tests/test_ai_llm_service.py` — 20 passed
- [ ] Deploy and watch Sentry for `Unclosed client session` warnings — they should go away
- [ ] Watch arq job duration — most should still finish in <10s; 600s ceiling should rarely fire

## Reviewer notes

- No DB / pool changes — explicitly *not* the previous PR's hypothesis (#58, closed).
- The 600s job_timeout pairs with litellm's existing internal budget (~110s for full failover chain). It's a backstop, not the primary timeout.

🤖 Generated with [Claude Code](https://claude.com/claude-code)