### PR TITLE
debug: log full card JSON response in add-on endpoints

### DIFF
--- a/services/api/src/api/addon/routes.py
+++ b/services/api/src/api/addon/routes.py
@@ -7,6 +7,7 @@ Token verification is applied at the router level via Depends().
 from __future__ import annotations
 
 import asyncio
+import json
 import logging
 import os
 import re
@@ -403,10 +404,14 @@ async def addon_homepage(body: AddonRequest, request: Request) -> dict:
 
     auth_card = await _check_gmail_auth(request, email)
     if auth_card:
-        return _as_push(auth_card).model_dump(by_alias=True, exclude_none=True)
+        result = _as_push(auth_card).model_dump(by_alias=True, exclude_none=True)
+        logger.info("Homepage response (auth): %s", json.dumps(result))
+        return result
 
     card = await _build_refreshed_overview(request, email)
-    return _as_push(card).model_dump(by_alias=True, exclude_none=True)
+    result = _as_push(card).model_dump(by_alias=True, exclude_none=True)
+    logger.info("Homepage response: %s", json.dumps(result))
+    return result
 
 
 @addon_router.post("/on-message")
@@ -419,7 +424,9 @@ async def addon_on_message(body: AddonRequest, request: Request) -> dict:
     auth_card = await _check_gmail_auth(request, email)
     if auth_card:
         logger.info("on-message: returning auth-required card for %s", email)
-        return _as_push(auth_card).model_dump(by_alias=True, exclude_none=True)
+        result = _as_push(auth_card).model_dump(by_alias=True, exclude_none=True)
+        logger.info("on-message response (auth): %s", json.dumps(result))
+        return result
 
     thread_id = None
     message_id = None
@@ -437,7 +444,9 @@ async def addon_on_message(body: AddonRequest, request: Request) -> dict:
     if not thread_id:
         # No thread context — show full overview
         card = await _build_refreshed_overview(request, email)
-        return _as_push(card).model_dump(by_alias=True, exclude_none=True)
+        result = _as_push(card).model_dump(by_alias=True, exclude_none=True)
+        logger.info("on-message response (no thread): %s", json.dumps(result))
+        return result
 
     # Show suggestions filtered to this thread
     overview_svc = _get_overview_service(request)
@@ -470,7 +479,9 @@ async def addon_on_message(body: AddonRequest, request: Request) -> dict:
         else:
             card = build_contextual_unlinked(thread_id, message_id=message_id)
 
-    return _as_push(card).model_dump(by_alias=True, exclude_none=True)
+    result = _as_push(card).model_dump(by_alias=True, exclude_none=True)
+    logger.info("on-message response: %s", json.dumps(result))
+    return result
 
 
 @addon_router.post("/action")


### PR DESCRIPTION
## Summary

- Adds `json.dumps` logging of the full card response in all return paths of `addon_homepage` and `addon_on_message`
- Labels each log line with the code path that produced it (auth, no-thread, thread-scoped)

## Why

The staging sidebar shows Google's generic "Something went wrong when executing the add-on" error, but Railway logs confirm the API returned HTTP 200. This means Google received our response but rejected the card JSON at render time. We need to see the exact payload to identify what's invalid (empty sections, empty function URLs, null values, etc.).

## Reviewer notes

This is temporary debug logging — will be removed once the card validation issue is identified and fixed. The JSON output may be large in logs but is necessary to diagnose the rendering failure.

## Test plan

- [ ] Deploy to staging
- [ ] Open Gmail → click add-on icon (fires `/addon/homepage`)
- [ ] Open an email thread (fires `/addon/on-message`)
- [ ] Check Railway logs for `Homepage response:` or `on-message response:` entries
- [ ] Paste logged JSON into [Card Builder](https://addons.gsuite.google.com/uikit/builder) to validate

🤖 Generated with [Claude Code](https://claude.com/claude-code)