### PR TITLE
fix(addon): cap suggestions per card to stay under Google's 28KB limit

### DIFF
--- a/services/api/src/api/addon/routes.py
+++ b/services/api/src/api/addon/routes.py
@@ -7,7 +7,6 @@ Token verification is applied at the router level via Depends().
 from __future__ import annotations
 
 import asyncio
-import json
 import logging
 import os
 import re
@@ -404,14 +403,10 @@ async def addon_homepage(body: AddonRequest, request: Request) -> dict:
 
     auth_card = await _check_gmail_auth(request, email)
     if auth_card:
-        result = _as_push(auth_card).model_dump(by_alias=True, exclude_none=True)
-        logger.info("Homepage response (auth): %s", json.dumps(result))
-        return result
+        return _as_push(auth_card).model_dump(by_alias=True, exclude_none=True)
 
     card = await _build_refreshed_overview(request, email)
-    result = _as_push(card).model_dump(by_alias=True, exclude_none=True)
-    logger.info("Homepage response: %s", json.dumps(result))
-    return result
+    return _as_push(card).model_dump(by_alias=True, exclude_none=True)
 
 
 @addon_router.post("/on-message")
@@ -424,9 +419,7 @@ async def addon_on_message(body: AddonRequest, request: Request) -> dict:
     auth_card = await _check_gmail_auth(request, email)
     if auth_card:
         logger.info("on-message: returning auth-required card for %s", email)
-        result = _as_push(auth_card).model_dump(by_alias=True, exclude_none=True)
-        logger.info("on-message response (auth): %s", json.dumps(result))
-        return result
+        return _as_push(auth_card).model_dump(by_alias=True, exclude_none=True)
 
     thread_id = None
     message_id = None
@@ -444,9 +437,7 @@ async def addon_on_message(body: AddonRequest, request: Request) -> dict:
     if not thread_id:
         # No thread context — show full overview
         card = await _build_refreshed_overview(request, email)
-        result = _as_push(card).model_dump(by_alias=True, exclude_none=True)
-        logger.info("on-message response (no thread): %s", json.dumps(result))
-        return result
+        return _as_push(card).model_dump(by_alias=True, exclude_none=True)
 
     # Show suggestions filtered to this thread
     overview_svc = _get_overview_service(request)
@@ -479,9 +470,7 @@ async def addon_on_message(body: AddonRequest, request: Request) -> dict:
         else:
             card = build_contextual_unlinked(thread_id, message_id=message_id)
 
-    result = _as_push(card).model_dump(by_alias=True, exclude_none=True)
-    logger.info("on-message response: %s", json.dumps(result))
-    return result
+    return _as_push(card).model_dump(by_alias=True, exclude_none=True)
 
 
 @addon_router.post("/action")

--- a/services/api/src/api/overview/cards.py
+++ b/services/api/src/api/overview/cards.py
@@ -623,6 +623,10 @@ def _build_candidate_rename(group: LoopSuggestionGroup) -> list[Widget]:
 # ---------------------------------------------------------------------------
 
 
+_MAX_SUGGESTIONS_PER_GROUP = 5
+_MAX_TOTAL_SUGGESTIONS = 15
+
+
 def build_overview(
     groups: list[LoopSuggestionGroup],
     base_url: str | None = None,
@@ -631,6 +635,9 @@ def build_overview(
 
     Each loop group becomes a Section. Standalone suggestions (no loop)
     are rendered in a headerless section at the top.
+
+    Google enforces a 28KB response size limit on card JSON, so we cap
+    the number of rendered suggestions per group and globally.
     """
     sections: list[Section] = []
     header_section = _overview_header_buttons(base_url)
@@ -648,6 +655,8 @@ def build_overview(
         )
         return _update_card(Card(sections=sections))
 
+    total_rendered = 0
+
     for group in groups:
         # Build all widgets for suggestions in this group
         group_widgets: list[Widget] = []
@@ -659,10 +668,25 @@ def build_overview(
             group_widgets.extend(rename_widgets)
             group_widgets.append(_divider())
 
+        group_rendered = 0
+        group_total = len(group.suggestions)
+
         for i, view in enumerate(group.suggestions):
+            if group_rendered >= _MAX_SUGGESTIONS_PER_GROUP:
+                break
+            if total_rendered >= _MAX_TOTAL_SUGGESTIONS:
+                break
             if i > 0:
                 group_widgets.append(_divider())
             group_widgets.extend(_build_suggestion_widgets(view))
+            group_rendered += 1
+            total_rendered += 1
+
+        hidden = group_total - group_rendered
+        if hidden > 0:
+            msg = f"{hidden} more — dismiss above to see more."
+            group_widgets.append(_divider())
+            group_widgets.append(_text(f'<font color="#888888"><i>{msg}</i></font>'))
 
         # Section header: loop title or "Unassigned" for loop-less
         header = None
@@ -673,8 +697,15 @@ def build_overview(
             parts = [p for p in [group.candidate_name, group.client_company] if p]
             header = ", ".join(parts) if parts else f"Loop {group.loop_id[:8]}"
 
-        # Add "Open in Gmail" link if the loop has threads (first thread)
-        # This is added as a small button in the section
         sections.append(Section(header=header, widgets=group_widgets))
+
+        if total_rendered >= _MAX_TOTAL_SUGGESTIONS:
+            remaining_groups = len(groups) - (groups.index(group) + 1)
+            if remaining_groups > 0:
+                msg = f"{remaining_groups} more loop(s) not shown — dismiss above to see more."
+                sections.append(
+                    Section(widgets=[_text(f'<font color="#888888"><i>{msg}</i></font>')])
+                )
+            break
 
     return _update_card(Card(sections=sections))


### PR DESCRIPTION
## Summary

- Caps rendered suggestions at 5 per group and 15 total per card in `build_overview()`
- Shows "N more — dismiss above to see more" when suggestions are truncated
- Removes the temporary debug JSON logging merged in #65

## Why

The staging sidebar was showing Google's generic "Something went wrong" error despite the API returning 200. Root cause: 50+ `ASK_COORDINATOR` fallback suggestions were being rendered into a single card section, producing a JSON response well over Google's 28KB card size limit. Google silently rejects oversized cards.

## Test plan

- [x] `test_overview_cards.py` passes (9/9)
- [ ] Deploy to staging and verify sidebar renders
- [ ] Verify truncation message appears when >5 suggestions exist in a group

🤖 Generated with [Claude Code](https://claude.com/claude-code)