### PR TITLE
fix(classifier): default reasoning field to prevent LLM parse failures

### DIFF
--- a/services/api/src/api/classifier/models.py
+++ b/services/api/src/api/classifier/models.py
@@ -122,7 +122,7 @@ class SuggestionItem(BaseModel):
     action: SuggestedAction
     confidence: float = Field(ge=0.0, le=1.0)
     summary: str
-    reasoning: str
+    reasoning: str = ""
     target_loop_id: str | None = None
     action_data: dict[str, Any] = {}
 
@@ -131,7 +131,7 @@ class ClassificationResult(BaseModel):
     """LLM output schema — one or more suggestions per email."""
 
     suggestions: list[SuggestionItem]
-    reasoning: str
+    reasoning: str = ""
 
 
 # -- Database model --


### PR DESCRIPTION
## Summary

- Defaults `reasoning` to `""` on both `SuggestionItem` and `ClassificationResult` Pydantic models so that LLM responses missing this field still parse successfully

## Problem

Gemini 2.5 Flash via OpenRouter consistently omits the `reasoning` field from `SuggestionItem` objects in the `classify_new_thread` endpoint. In a recent production push notification batch (4 messages for `adam@longridgepartners.com`):

- **4/4** first parse attempts failed due to missing `reasoning`
- **3/4** recovered on the "fix your JSON" retry
- **1/4** failed even after retry, raising `LLMParseError` and creating a fallback `ask_coordinator` suggestion instead of the actual classification

The `reasoning` field is informational — it's stored in the suggestion record but no downstream logic branches on its value. Making it required caused unnecessary retries (doubling LLM calls) and occasional hard failures.

## Test plan

- [x] All 58 classifier tests pass
- [x] Verified model accepts input both with and without `reasoning`
- [x] Backward compatible — existing code that provides `reasoning` is unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)