### PR TITLE
feat(agent): deduplicate suggestions via pending_suggestions context

### DIFF
--- a/services/api/src/api/classifier/formatters.py
+++ b/services/api/src/api/classifier/formatters.py
@@ -13,6 +13,7 @@ from __future__ import annotations
 from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
+    from api.classifier.models import Suggestion
     from api.gmail.models import Message
     from api.scheduling.models import Loop, LoopEvent
 
@@ -179,3 +180,35 @@ def format_stage_states() -> str:
     for state in StageState:
         lines.append(f"  - {state.value}: {NEXT_ACTIONS[state]}")
     return "\n".join(lines)
+
+
+def format_pending_suggestions(suggestions: list[Suggestion]) -> str:
+    """Format pending suggestions so the LLM can see what's already queued."""
+    if not suggestions:
+        return "No current pending suggestions."
+
+    lines = ["Pending suggestions awaiting coordinator review:"]
+    for sug in suggestions:
+        line = f"  - [{sug.loop_id}] {sug.action}"
+        if sug.summary:
+            line += f": {sug.summary}"
+        if sug.action_data:
+            highlights = _action_data_highlights(sug.action, sug.action_data)
+            if highlights:
+                line += f" ({highlights})"
+        lines.append(line)
+
+    return "\n".join(lines)
+
+
+def _action_data_highlights(action: str, action_data: dict) -> str:
+    if action == "advance_stage":
+        return f"target_stage={action_data.get('target_stage', '?')}"
+    elif action == "draft_email":
+        recipient = action_data.get("recipient_type", "?")
+        return f"to={recipient}"
+    elif action == "ask_coordinator":
+        q = action_data.get("question", "")
+        preview = q[:80] + ("..." if len(q) > 80 else "")
+        return f'question="{preview}"'
+    return ""

--- a/services/api/src/api/classifier/formatters.py
+++ b/services/api/src/api/classifier/formatters.py
@@ -206,7 +206,9 @@ def _action_data_highlights(action: str, action_data: dict) -> str:
         return f"target_stage={action_data.get('target_stage', '?')}"
     elif action == "draft_email":
         recipient = action_data.get("recipient_type", "?")
-        return f"to={recipient}"
+        body = action_data.get("body", "")
+        body_preview = body[:80] + ("..." if len(body) > 80 else "")
+        return f'to={recipient}, body="{body_preview}"'
     elif action == "ask_coordinator":
         q = action_data.get("question", "")
         preview = q[:80] + ("..." if len(q) > 80 else "")

--- a/services/api/src/api/classifier/next_action_agent.py
+++ b/services/api/src/api/classifier/next_action_agent.py
@@ -11,6 +11,7 @@ CREATE_LOOP and LINK_THREAD are blacklisted to prevent recursion.
 
 from __future__ import annotations
 
+import json
 import logging
 from datetime import UTC, datetime
 from typing import TYPE_CHECKING
@@ -22,6 +23,7 @@ from api.classifier.formatters import (
     format_email,
     format_events,
     format_linked_loops,
+    format_pending_suggestions,
     format_thread_history,
 )
 from api.classifier.models import (
@@ -44,6 +46,7 @@ if TYPE_CHECKING:
     from langfuse import Langfuse
 
     from api.ai.llm_service import LLMService
+    from api.classifier.models import Suggestion
     from api.classifier.service import SuggestionService
     from api.drafts.service import DraftService
     from api.gmail.hooks import EmailEvent
@@ -80,6 +83,11 @@ def _resolve_coordinator_name(event: EmailEvent, coord: Coordinator | None) -> s
             return name
 
     return addr_email.split("@", 1)[0]
+
+
+def _suggestion_fingerprint(loop_id: str | None, action: str, action_data: dict) -> str:
+    """Canonical fingerprint for deduplication: loop_id + action + normalized action_data."""
+    return f"{loop_id or ''}|{action}|{json.dumps(action_data, sort_keys=True, default=str)}"
 
 
 def _format_per_loop_actors(
@@ -129,7 +137,9 @@ class NextActionAgent:
     ) -> None:
         msg = event.message
 
-        context_input = await self._build_context(event, linked_loops, event.thread_messages)
+        context_input, existing_pending = await self._build_context(
+            event, linked_loops, event.thread_messages
+        )
 
         try:
             result: ClassificationResult = await determine_next_action(
@@ -215,14 +225,29 @@ class NextActionAgent:
                 if not error:
                     valid_items.append((item, target_loop))
 
+        seen_fingerprints: set[str] = {
+            _suggestion_fingerprint(s.loop_id, s.action, s.action_data) for s in existing_pending
+        }
+
         for item, target_loop in valid_items:
+            loop_id = target_loop.id if target_loop else None
+            fp = _suggestion_fingerprint(loop_id, item.action, item.action_data)
+            if fp in seen_fingerprints:
+                logger.info(
+                    "dedup: skipping duplicate suggestion (action=%s, loop_id=%s)",
+                    item.action,
+                    loop_id,
+                )
+                continue
+            seen_fingerprints.add(fp)
+
             suggestion = await self._suggestions.create_suggestion(
                 coordinator_email=event.coordinator_email,
                 gmail_message_id=msg.id,
                 gmail_thread_id=msg.thread_id,
                 item=item,
                 reasoning=result.reasoning,
-                loop_id=target_loop.id if target_loop else None,
+                loop_id=loop_id,
             )
 
             logger.info(
@@ -267,7 +292,7 @@ class NextActionAgent:
         event: EmailEvent,
         linked_loops: list[Loop],
         thread_messages: list[Message] | None = None,
-    ) -> NextActionInput:
+    ) -> tuple[NextActionInput, list[Suggestion]]:
         msg = event.message
 
         if thread_messages:
@@ -301,6 +326,10 @@ class NextActionAgent:
                     client_company = lp.client_contact.company
                 break
 
+        all_pending: list[Suggestion] = []
+        for lp in linked_loops:
+            all_pending.extend(await self._suggestions.get_pending_for_loop(lp.id))
+
         return NextActionInput(
             coordinator_name=coordinator_name,
             coordinator_email=event.coordinator_email,
@@ -315,7 +344,8 @@ class NextActionAgent:
             loop_state=format_linked_loops(linked_loops),
             events=format_events(events),
             error="N/A",
-        )
+            pending_suggestions=format_pending_suggestions(all_pending),
+        ), all_pending
 
     def _resolve_target_loop(
         self,

--- a/services/api/src/api/classifier/schemas.py
+++ b/services/api/src/api/classifier/schemas.py
@@ -43,3 +43,4 @@ class NextActionInput(BaseModel):
     loop_state: str
     events: str
     error: str
+    pending_suggestions: str = "No current pending suggestions."

--- a/services/api/tests/test_classifier_formatters.py
+++ b/services/api/tests/test_classifier_formatters.py
@@ -7,8 +7,15 @@ from api.classifier.formatters import (
     format_email,
     format_events,
     format_loop_state,
+    format_pending_suggestions,
     format_stage_states,
     format_thread_history,
+)
+from api.classifier.models import (
+    EmailClassification,
+    SuggestedAction,
+    Suggestion,
+    SuggestionStatus,
 )
 from api.gmail.models import EmailAddress, Message
 from api.scheduling.models import (
@@ -173,3 +180,62 @@ class TestFormatStaticContent:
         result = format_stage_states()
         for state in StageState:
             assert state.value in result
+
+
+def _suggestion(
+    loop_id="lop_1",
+    action=SuggestedAction.ADVANCE_STAGE,
+    action_data=None,
+    summary="Move to next stage",
+) -> Suggestion:
+    if action_data is None:
+        action_data = {"target_stage": "awaiting_client"}
+    return Suggestion(
+        id="sug_1",
+        coordinator_email="coord@lrp.com",
+        gmail_message_id="msg1",
+        gmail_thread_id="thread1",
+        loop_id=loop_id,
+        classification=EmailClassification.AVAILABILITY_RESPONSE,
+        action=action,
+        confidence=0.9,
+        summary=summary,
+        action_data=action_data,
+        status=SuggestionStatus.PENDING,
+    )
+
+
+class TestFormatPendingSuggestions:
+    def test_empty_returns_default(self):
+        result = format_pending_suggestions([])
+        assert result == "No current pending suggestions."
+
+    def test_multiple_suggestions_formatted(self):
+        suggestions = [
+            _suggestion(
+                loop_id="lop_1",
+                action=SuggestedAction.ADVANCE_STAGE,
+                action_data={"target_stage": "awaiting_client"},
+                summary="Move to awaiting client",
+            ),
+            _suggestion(
+                loop_id="lop_2",
+                action=SuggestedAction.DRAFT_EMAIL,
+                action_data={"body": "Hi there", "recipient_type": "recruiter"},
+                summary="Send availability request",
+            ),
+            _suggestion(
+                loop_id="lop_1",
+                action=SuggestedAction.ASK_COORDINATOR,
+                action_data={"question": "Which time works?"},
+                summary="Need clarification",
+            ),
+        ]
+        result = format_pending_suggestions(suggestions)
+        assert "Pending suggestions" in result
+        assert "[lop_1] advance_stage: Move to awaiting client" in result
+        assert "target_stage=awaiting_client" in result
+        assert "[lop_2] draft_email: Send availability request" in result
+        assert "to=recruiter" in result
+        assert "[lop_1] ask_coordinator: Need clarification" in result
+        assert 'question="Which time works?"' in result

--- a/services/api/tests/test_classifier_formatters.py
+++ b/services/api/tests/test_classifier_formatters.py
@@ -237,5 +237,6 @@ class TestFormatPendingSuggestions:
         assert "target_stage=awaiting_client" in result
         assert "[lop_2] draft_email: Send availability request" in result
         assert "to=recruiter" in result
+        assert 'body="Hi there"' in result
         assert "[lop_1] ask_coordinator: Need clarification" in result
         assert 'question="Which time works?"' in result

--- a/services/api/tests/test_classifier_hook.py
+++ b/services/api/tests/test_classifier_hook.py
@@ -10,7 +10,9 @@ from api.classifier.models import (
     ClassificationResult,
     EmailClassification,
     SuggestedAction,
+    Suggestion,
     SuggestionItem,
+    SuggestionStatus,
 )
 from api.classifier.next_action_agent import NextActionAgent
 from api.classifier.router import EmailRouter, _is_internal_only
@@ -166,6 +168,7 @@ def _make_agent():
     langfuse = MagicMock()
     suggestion_service = MagicMock()
     suggestion_service.create_suggestion = AsyncMock(return_value=MagicMock(id="sug_test"))
+    suggestion_service.get_pending_for_loop = AsyncMock(return_value=[])
 
     loop_service = MagicMock()
     loop_service.get_coordinator_by_email = AsyncMock(return_value=None)
@@ -542,3 +545,104 @@ class TestInternalOnlyFilter:
         classifier.classify.assert_not_called()
         agent.act.assert_not_called()
         loop_service.find_loops_by_thread.assert_not_called()
+
+
+# --- Deduplication ---
+
+
+def _pending_suggestion(
+    loop_id="lop_1",
+    action=SuggestedAction.ADVANCE_STAGE,
+    action_data=None,
+) -> Suggestion:
+    if action_data is None:
+        action_data = {"target_stage": "awaiting_client"}
+    return Suggestion(
+        id="sug_existing",
+        coordinator_email="coord@lrp.com",
+        gmail_message_id="msg0",
+        gmail_thread_id="thread1",
+        loop_id=loop_id,
+        classification=EmailClassification.AVAILABILITY_RESPONSE,
+        action=action,
+        confidence=0.9,
+        summary="Existing suggestion",
+        action_data=action_data,
+        status=SuggestionStatus.PENDING,
+    )
+
+
+class TestDeduplication:
+    @pytest.mark.asyncio
+    async def test_duplicate_of_existing_pending_is_skipped(self):
+        agent, suggestion_service = _make_agent()
+        existing = _pending_suggestion(
+            action=SuggestedAction.ADVANCE_STAGE,
+            action_data={"target_stage": "awaiting_client"},
+        )
+        suggestion_service.get_pending_for_loop.return_value = [existing]
+
+        result = _classification_result(
+            items=[
+                _suggestion_item(
+                    action=SuggestedAction.ADVANCE_STAGE,
+                    target_stage=StageState.AWAITING_CLIENT,
+                )
+            ]
+        )
+
+        with patch(
+            "api.classifier.next_action_agent.determine_next_action",
+            new_callable=AsyncMock,
+            return_value=result,
+        ):
+            await agent.act(_event(), [_loop()])
+
+        suggestion_service.create_suggestion.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_same_batch_duplicate_only_creates_first(self):
+        agent, suggestion_service = _make_agent()
+
+        item = _suggestion_item(
+            action=SuggestedAction.DRAFT_EMAIL,
+            action_data={"body": "Hi there", "recipient_type": "recruiter"},
+        )
+        result = _classification_result(items=[item, item])
+
+        with patch(
+            "api.classifier.next_action_agent.determine_next_action",
+            new_callable=AsyncMock,
+            return_value=result,
+        ):
+            await agent.act(_event(), [_loop()])
+
+        assert suggestion_service.create_suggestion.call_count == 1
+
+    @pytest.mark.asyncio
+    async def test_different_action_data_not_deduplicated(self):
+        agent, suggestion_service = _make_agent()
+        existing = _pending_suggestion(
+            action=SuggestedAction.ADVANCE_STAGE,
+            action_data={"target_stage": "awaiting_client"},
+        )
+        suggestion_service.get_pending_for_loop.return_value = [existing]
+
+        result = _classification_result(
+            items=[
+                _suggestion_item(
+                    action=SuggestedAction.ADVANCE_STAGE,
+                    target_stage=StageState.SCHEDULED,
+                    action_data={"target_stage": "scheduled"},
+                )
+            ]
+        )
+
+        with patch(
+            "api.classifier.next_action_agent.determine_next_action",
+            new_callable=AsyncMock,
+            return_value=result,
+        ):
+            await agent.act(_event(), [_loop()])
+
+        suggestion_service.create_suggestion.assert_called_once()


### PR DESCRIPTION
## Summary

- Adds a `pending_suggestions` template variable to the next-action-agent prompt, populated with all currently pending suggestions for loops on the thread. This gives the LLM visibility into what's already queued so it can avoid proposing duplicates.
- Adds a hard dedup check: if a new suggestion matches an existing pending suggestion on (loop_id, action, action_data), it's discarded. Also catches same-batch duplicates within a single LLM response.
- New `format_pending_suggestions()` formatter renders pending suggestions in a human-readable format for the prompt.

## LangFuse action needed

After merging, add `{{pending_suggestions}}` to the "next-action-agent" prompt template with guidance to avoid duplicating existing suggestions.

## Test plan

- [x] `test_duplicate_of_existing_pending_is_skipped` — verifies exact match against DB is discarded
- [x] `test_same_batch_duplicate_only_creates_first` — verifies LLM returning 2 identical items only persists one
- [x] `test_different_action_data_not_deduplicated` — verifies different action_data is NOT falsely deduplicated
- [x] `test_empty_returns_default` / `test_multiple_suggestions_formatted` — formatter coverage
- [x] All 50 existing + new tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)