### PR TITLE
feat(worker): mark tokens stale on RefreshError to avoid retry storms

### DIFF
--- a/services/api/migrations/0012_token_stale_flag.py
+++ b/services/api/migrations/0012_token_stale_flag.py
@@ -1,0 +1,14 @@
+"""Add is_stale flag to gmail_tokens for marking revoked/expired tokens."""
+
+from yoyo import step
+
+step(
+    """
+    ALTER TABLE gmail_tokens
+        ADD COLUMN is_stale BOOLEAN NOT NULL DEFAULT false;
+    """,
+    """
+    ALTER TABLE gmail_tokens
+        DROP COLUMN is_stale;
+    """,
+)

--- a/services/api/queries/gmail_tokens.sql
+++ b/services/api/queries/gmail_tokens.sql
@@ -1,15 +1,16 @@
 -- name: store_token(user_email, refresh_token_encrypted, scopes)!
--- Upsert an encrypted refresh token for a user.
+-- Upsert an encrypted refresh token for a user, clearing stale flag on re-auth.
 INSERT INTO gmail_tokens (user_email, refresh_token_encrypted, scopes, updated_at)
 VALUES (:user_email, :refresh_token_encrypted, :scopes, now())
 ON CONFLICT (user_email) DO UPDATE SET
     refresh_token_encrypted = EXCLUDED.refresh_token_encrypted,
     scopes = EXCLUDED.scopes,
+    is_stale = false,
     updated_at = now();
 
 -- name: load_token(user_email)^
--- Load the encrypted refresh token for a user. Returns None if not found.
-SELECT user_email, refresh_token_encrypted, scopes, created_at, updated_at
+-- Load the encrypted refresh token, scopes, and stale flag for a user.
+SELECT refresh_token_encrypted, scopes, is_stale
 FROM gmail_tokens
 WHERE user_email = :user_email;
 
@@ -23,3 +24,17 @@ WHERE user_email = :user_email;
 SELECT EXISTS(
     SELECT 1 FROM gmail_tokens WHERE user_email = :user_email
 ) AS has_token;
+
+-- name: mark_stale(user_email)!
+-- Flag a token as stale after a RefreshError.
+UPDATE gmail_tokens
+SET is_stale = true, updated_at = now()
+WHERE user_email = :user_email;
+
+-- name: is_token_stale(user_email)$
+-- Check if a user's token is marked stale.
+SELECT is_stale FROM gmail_tokens WHERE user_email = :user_email;
+
+-- name: get_all_watched_emails
+-- List coordinator emails with valid (non-stale) stored tokens.
+SELECT user_email FROM gmail_tokens WHERE NOT is_stale;

--- a/services/api/src/api/gmail/_transport.py
+++ b/services/api/src/api/gmail/_transport.py
@@ -10,7 +10,10 @@ import asyncio
 from typing import TYPE_CHECKING, Any
 
 import sentry_sdk
+from google.auth.exceptions import RefreshError
 from googleapiclient.discovery import build
+
+from api.gmail.exceptions import GmailTokenStaleError
 
 if TYPE_CHECKING:
     from google.oauth2.credentials import Credentials
@@ -39,4 +42,7 @@ async def execute(credentials: Credentials, fn, *, op_name: str = "gmail") -> An
     distinct messages.get vs messages.send vs history.list calls.
     """
     with sentry_sdk.start_span(op="http.client", name=f"gmail:{op_name}"):
-        return await asyncio.to_thread(_execute_sync, credentials, fn)
+        try:
+            return await asyncio.to_thread(_execute_sync, credentials, fn)
+        except RefreshError as exc:
+            raise GmailTokenStaleError(f"Gmail token refresh failed: {exc}") from exc

--- a/services/api/src/api/gmail/auth.py
+++ b/services/api/src/api/gmail/auth.py
@@ -14,6 +14,7 @@ from api.gmail.exceptions import (
     GmailTokenStaleError,
     GmailUserNotAuthorizedError,
 )
+from api.gmail.queries import token_queries
 
 if TYPE_CHECKING:
     from datetime import datetime
@@ -31,8 +32,6 @@ _DEFAULT_SCOPES = ",".join(
 )
 SCOPES = os.environ.get("REQUIRED_SCOPES", _DEFAULT_SCOPES).split(",")
 TOKEN_URI = "https://oauth2.googleapis.com/token"
-
-_LOAD_SQL = "SELECT refresh_token_encrypted, scopes, is_stale FROM gmail_tokens WHERE user_email = %(email)s"  # noqa: E501
 
 
 class TokenStore:
@@ -59,17 +58,11 @@ class TokenStore:
         """Encrypt and upsert a refresh token for a user."""
         encrypted = self._encrypt(refresh_token)
         async with self._pool.connection() as conn:
-            await conn.execute(
-                """
-                INSERT INTO gmail_tokens (user_email, refresh_token_encrypted, scopes, updated_at)
-                VALUES (%(user_email)s, %(token)s, %(scopes)s, now())
-                ON CONFLICT (user_email) DO UPDATE SET
-                    refresh_token_encrypted = EXCLUDED.refresh_token_encrypted,
-                    scopes = EXCLUDED.scopes,
-                    is_stale = false,
-                    updated_at = now()
-                """,
-                {"user_email": user_email, "token": encrypted, "scopes": scopes},
+            await token_queries.store_token(
+                conn,
+                user_email=user_email,
+                refresh_token_encrypted=encrypted,
+                scopes=scopes,
             )
 
     async def load_credentials(self, user_email: str) -> Credentials:
@@ -79,8 +72,7 @@ class TokenStore:
         GmailScopeError if re-authorization is needed.
         """
         async with self._pool.connection() as conn:
-            cur = await conn.execute(_LOAD_SQL, {"email": user_email})
-            row = await cur.fetchone()
+            row = await token_queries.load_token(conn, user_email=user_email)
 
         if row is None:
             raise GmailUserNotAuthorizedError(
@@ -114,41 +106,23 @@ class TokenStore:
     async def mark_stale(self, user_email: str) -> None:
         """Flag a token as stale after a RefreshError — stops further attempts."""
         async with self._pool.connection() as conn:
-            await conn.execute(
-                """
-                UPDATE gmail_tokens SET is_stale = true, updated_at = now()
-                WHERE user_email = %(email)s
-                """,
-                {"email": user_email},
-            )
+            await token_queries.mark_stale(conn, user_email=user_email)
 
     async def is_token_stale(self, user_email: str) -> bool:
         """Check if a user's token is marked stale."""
         async with self._pool.connection() as conn:
-            cur = await conn.execute(
-                "SELECT is_stale FROM gmail_tokens WHERE user_email = %(email)s",
-                {"email": user_email},
-            )
-            row = await cur.fetchone()
-            return bool(row[0]) if row else False
+            result = await token_queries.is_token_stale(conn, user_email=user_email)
+            return bool(result)
 
     async def delete_token(self, user_email: str) -> None:
         """Remove a user's stored token."""
         async with self._pool.connection() as conn:
-            await conn.execute(
-                "DELETE FROM gmail_tokens WHERE user_email = %(email)s",
-                {"email": user_email},
-            )
+            await token_queries.delete_token(conn, user_email=user_email)
 
     async def has_token(self, user_email: str) -> bool:
         """Check if a user has stored credentials."""
         async with self._pool.connection() as conn:
-            cur = await conn.execute(
-                "SELECT EXISTS(SELECT 1 FROM gmail_tokens WHERE user_email = %(email)s)",
-                {"email": user_email},
-            )
-            row = await cur.fetchone()
-            return row[0] if row else False
+            return await token_queries.has_token(conn, user_email=user_email)
 
     # --- Push pipeline state ---
 
@@ -197,6 +171,5 @@ class TokenStore:
     async def get_all_watched_emails(self) -> list[str]:
         """List all coordinator emails with valid (non-stale) stored tokens."""
         async with self._pool.connection() as conn:
-            cur = await conn.execute("SELECT user_email FROM gmail_tokens WHERE NOT is_stale")
-            rows = await cur.fetchall()
+            rows = await token_queries.get_all_watched_emails(conn)
             return [row[0] for row in rows]

--- a/services/api/src/api/gmail/auth.py
+++ b/services/api/src/api/gmail/auth.py
@@ -8,7 +8,12 @@ from typing import TYPE_CHECKING
 from cryptography.fernet import Fernet, InvalidToken
 from google.oauth2.credentials import Credentials
 
-from api.gmail.exceptions import GmailAuthError, GmailScopeError, GmailUserNotAuthorizedError
+from api.gmail.exceptions import (
+    GmailAuthError,
+    GmailScopeError,
+    GmailTokenStaleError,
+    GmailUserNotAuthorizedError,
+)
 
 if TYPE_CHECKING:
     from datetime import datetime
@@ -27,7 +32,7 @@ _DEFAULT_SCOPES = ",".join(
 SCOPES = os.environ.get("REQUIRED_SCOPES", _DEFAULT_SCOPES).split(",")
 TOKEN_URI = "https://oauth2.googleapis.com/token"
 
-_LOAD_SQL = "SELECT refresh_token_encrypted, scopes FROM gmail_tokens WHERE user_email = %(email)s"
+_LOAD_SQL = "SELECT refresh_token_encrypted, scopes, is_stale FROM gmail_tokens WHERE user_email = %(email)s"  # noqa: E501
 
 
 class TokenStore:
@@ -61,6 +66,7 @@ class TokenStore:
                 ON CONFLICT (user_email) DO UPDATE SET
                     refresh_token_encrypted = EXCLUDED.refresh_token_encrypted,
                     scopes = EXCLUDED.scopes,
+                    is_stale = false,
                     updated_at = now()
                 """,
                 {"user_email": user_email, "token": encrypted, "scopes": scopes},
@@ -81,6 +87,11 @@ class TokenStore:
                 f"No stored token for {user_email}. User must authorize via the add-on first."
             )
 
+        if row[2]:  # is_stale
+            raise GmailTokenStaleError(
+                f"Token for {user_email} is stale (revoked/expired). Re-authorization required."
+            )
+
         granted = set(row[1])
         required = set(SCOPES)
         missing = required - granted
@@ -99,6 +110,27 @@ class TokenStore:
             token_uri=TOKEN_URI,
             scopes=row[1],
         )
+
+    async def mark_stale(self, user_email: str) -> None:
+        """Flag a token as stale after a RefreshError — stops further attempts."""
+        async with self._pool.connection() as conn:
+            await conn.execute(
+                """
+                UPDATE gmail_tokens SET is_stale = true, updated_at = now()
+                WHERE user_email = %(email)s
+                """,
+                {"email": user_email},
+            )
+
+    async def is_token_stale(self, user_email: str) -> bool:
+        """Check if a user's token is marked stale."""
+        async with self._pool.connection() as conn:
+            cur = await conn.execute(
+                "SELECT is_stale FROM gmail_tokens WHERE user_email = %(email)s",
+                {"email": user_email},
+            )
+            row = await cur.fetchone()
+            return bool(row[0]) if row else False
 
     async def delete_token(self, user_email: str) -> None:
         """Remove a user's stored token."""
@@ -163,8 +195,8 @@ class TokenStore:
             )
 
     async def get_all_watched_emails(self) -> list[str]:
-        """List all coordinator emails with stored tokens."""
+        """List all coordinator emails with valid (non-stale) stored tokens."""
         async with self._pool.connection() as conn:
-            cur = await conn.execute("SELECT user_email FROM gmail_tokens")
+            cur = await conn.execute("SELECT user_email FROM gmail_tokens WHERE NOT is_stale")
             rows = await cur.fetchall()
             return [row[0] for row in rows]

--- a/services/api/src/api/gmail/client.py
+++ b/services/api/src/api/gmail/client.py
@@ -16,6 +16,7 @@ from api.gmail.exceptions import (
     GmailAuthError,
     GmailNotFoundError,
     GmailRateLimitError,
+    GmailTokenStaleError,
     GmailValidationError,
 )
 from api.gmail.models import Draft, Message, Thread, parse_message
@@ -87,6 +88,10 @@ class GmailClient:
         creds = await self._get_creds(user_email)
         try:
             return await _transport.execute(creds, fn, op_name=caller_name)
+        except GmailTokenStaleError:
+            await self._token_store.mark_stale(user_email)
+            logger.warning("marked token stale for %s (RefreshError)", user_email)
+            raise
         except HttpError as exc:
             raise _map_http_error(exc) from exc
 

--- a/services/api/src/api/gmail/exceptions.py
+++ b/services/api/src/api/gmail/exceptions.py
@@ -25,6 +25,13 @@ class GmailRateLimitError(GmailApiError):
     """Gmail API quota exceeded."""
 
 
+class GmailTokenStaleError(GmailAuthError):
+    """Refresh token is revoked/expired — token has been marked stale in the DB.
+
+    The user must re-authenticate via the OAuth flow to clear this state.
+    """
+
+
 class GmailScopeError(GmailAuthError):
     """Stored token is missing required OAuth scopes — user must re-authorize."""
 

--- a/services/api/src/api/gmail/queries.py
+++ b/services/api/src/api/gmail/queries.py
@@ -1,4 +1,4 @@
-"""Load Gmail push-pipeline SQL queries via aiosql."""
+"""Load Gmail SQL queries via aiosql."""
 
 from pathlib import Path
 
@@ -10,4 +10,8 @@ _SQL_DIR = Path(__file__).resolve().parent.parent.parent.parent / "queries"
 
 queries = TracedQueries(
     aiosql.from_path(_SQL_DIR / "gmail_push.sql", "apsycopg", mandatory_parameters=False)
+)
+
+token_queries = TracedQueries(
+    aiosql.from_path(_SQL_DIR / "gmail_tokens.sql", "apsycopg", mandatory_parameters=False)
 )

--- a/services/api/src/api/gmail/webhook.py
+++ b/services/api/src/api/gmail/webhook.py
@@ -106,6 +106,9 @@ async def gmail_webhook(request: Request) -> Response:
     if not await gmail.has_token(coordinator_email):
         logger.debug("webhook for unknown coordinator: %s", coordinator_email)
         return Response(status_code=200)
+    if await gmail._token_store.is_token_stale(coordinator_email):
+        logger.debug("webhook for stale-token coordinator: %s", coordinator_email)
+        return Response(status_code=200)
 
     # Enqueue background job
     redis = get_redis(request)

--- a/services/api/src/api/gmail/workers.py
+++ b/services/api/src/api/gmail/workers.py
@@ -18,7 +18,7 @@ from psycopg_pool import AsyncConnectionPool
 
 from api.gmail.auth import TokenStore
 from api.gmail.client import GmailClient
-from api.gmail.exceptions import GmailNotFoundError, GmailScopeError
+from api.gmail.exceptions import GmailNotFoundError, GmailScopeError, GmailTokenStaleError
 from api.gmail.hooks import (
     EmailEvent,
     classify_direction,
@@ -146,17 +146,22 @@ async def process_gmail_push(ctx: dict, coordinator_email: str, history_id: str)
             logger.debug("debounced push for %s", coordinator_email)
             return
 
-    # Use our stored cursor, not the push notification's history_id
-    stored_history_id = await token_store.get_history_id(coordinator_email)
-    if not stored_history_id:
-        # No baseline yet (OAuth callback didn't set one, or legacy user).
-        # Use the push notification's history_id so we don't skip any messages.
-        logger.info("no baseline for %s, using push history_id=%s", coordinator_email, history_id)
-        await token_store.update_history_id(coordinator_email, history_id)
-        await _process_history(ctx, coordinator_email, history_id)
-        return
+    try:
+        # Use our stored cursor, not the push notification's history_id
+        stored_history_id = await token_store.get_history_id(coordinator_email)
+        if not stored_history_id:
+            # No baseline yet (OAuth callback didn't set one, or legacy user).
+            # Use the push notification's history_id so we don't skip any messages.
+            logger.info(
+                "no baseline for %s, using push history_id=%s", coordinator_email, history_id
+            )
+            await token_store.update_history_id(coordinator_email, history_id)
+            await _process_history(ctx, coordinator_email, history_id)
+            return
 
-    await _process_history(ctx, coordinator_email, stored_history_id)
+        await _process_history(ctx, coordinator_email, stored_history_id)
+    except GmailTokenStaleError:
+        logger.warning("stale token for %s during push processing — skipping", coordinator_email)
 
 
 async def poll_gmail_history(ctx: dict) -> None:
@@ -176,6 +181,8 @@ async def poll_gmail_history(ctx: dict) -> None:
                 continue
 
             await _process_history(ctx, coordinator_email, stored_history_id)
+        except GmailTokenStaleError:
+            logger.warning("stale token for %s — skipping until re-auth", coordinator_email)
         except GmailScopeError:
             logger.warning("scope error for %s — skipping until re-auth", coordinator_email)
         except Exception:
@@ -202,6 +209,8 @@ async def renew_gmail_watches(ctx: dict) -> None:
                 expiry,
             )
             logger.info("renewed watch for %s, expires %s", coordinator_email, expiry)
+        except GmailTokenStaleError:
+            logger.warning("stale token for %s — skipping watch renewal", coordinator_email)
         except GmailScopeError:
             logger.warning("scope error for %s — skipping watch renewal", coordinator_email)
         except Exception:
@@ -340,6 +349,8 @@ async def _process_history(ctx: dict, coordinator_email: str, start_history_id: 
             )
             await router.on_email(event, arq_pool=ctx.get("redis"))
 
+        except GmailTokenStaleError:
+            raise
         except GmailNotFoundError:
             logger.info(
                 "message %s not fetchable for %s (likely spam/filter/delete)",
@@ -403,6 +414,12 @@ async def run_next_action_agent(
         logger.info(
             "next action agent processed message %s (thread %s)",
             message.id,
+            gmail_thread_id,
+        )
+    except GmailTokenStaleError:
+        logger.warning(
+            "stale token for %s — next action agent skipped (thread %s)",
+            coordinator_email,
             gmail_thread_id,
         )
     except Exception:

--- a/services/api/tests/test_gmail_webhook.py
+++ b/services/api/tests/test_gmail_webhook.py
@@ -45,6 +45,7 @@ def app():
     # Mock Gmail client — has_token must be AsyncMock since it's awaited
     mock_gmail = MagicMock()
     mock_gmail.has_token = AsyncMock(return_value=True)
+    mock_gmail._token_store.is_token_stale = AsyncMock(return_value=False)
     test_app.state.gmail = mock_gmail
 
     # Mock Redis


### PR DESCRIPTION
## Summary

- Adds an `is_stale` column to `gmail_tokens` — set when a Google `RefreshError` indicates the token is revoked/expired
- Worker skips stale tokens cheaply at credential-load time (no API call to Google) instead of failing repeatedly
- Re-authentication via the OAuth flow automatically clears the stale flag

## How it works

1. **First failure**: transport layer catches `google.auth.exceptions.RefreshError` → raises `GmailTokenStaleError` → client marks token stale in DB
2. **Subsequent attempts**: `load_credentials()` checks the flag and raises `GmailTokenStaleError` before decrypting — zero network cost
3. **Recovery**: `store_token()` (called by OAuth callback) resets `is_stale = false`

## Changes

- **Migration** `0012_token_stale_flag.py`: adds `is_stale BOOLEAN NOT NULL DEFAULT false`
- **`exceptions.py`**: new `GmailTokenStaleError` (subclass of `GmailAuthError`)
- **`auth.py`**: `mark_stale()`, `is_token_stale()`, staleness check in `load_credentials`, clear in `store_token`, filter in `get_all_watched_emails`
- **`_transport.py`**: catches `RefreshError` → `GmailTokenStaleError`
- **`client.py`**: catches `GmailTokenStaleError` in `_exec`, calls `mark_stale`, re-raises
- **`workers.py`**: explicit handling in all worker/cron functions (log + skip, no arq retry)
- **`webhook.py`**: gates job enqueue on staleness to avoid pointless work

## Test plan

- [x] Existing webhook tests updated and passing
- [ ] Deploy migration to staging
- [ ] Revoke a test coordinator's token → verify worker logs "stale" warning once, then skips silently
- [ ] Re-authorize via add-on → verify worker resumes processing

🤖 Generated with [Claude Code](https://claude.com/claude-code)