### PR TITLE
fix(worker): consume async generator in get_all_watched_emails

### DIFF
--- a/services/api/src/api/gmail/auth.py
+++ b/services/api/src/api/gmail/auth.py
@@ -171,5 +171,4 @@ class TokenStore:
     async def get_all_watched_emails(self) -> list[str]:
         """List all coordinator emails with valid (non-stale) stored tokens."""
         async with self._pool.connection() as conn:
-            rows = await token_queries.get_all_watched_emails(conn)
-            return [row[0] for row in rows]
+            return [row[0] async for row in token_queries.get_all_watched_emails(conn)]


### PR DESCRIPTION
## Summary

- Fixes `TypeError: object async_generator can't be used in 'await' expression` that crashes the `poll_gmail_history` and `renew_gmail_watches` cron jobs on startup.
- Root cause: the aiosql `apsycopg` adapter returns an async generator for suffix-less SELECT queries, but `TokenStore.get_all_watched_emails` was `await`ing the result instead of iterating it.
- Uses an async list comprehension (`[row[0] async for row in ...]`), matching the existing pattern in `workers.py:298` for `get_processed_message_ids`.

## Test plan

- [x] Syntax check passes
- [x] 84/85 tests pass (1 pre-existing mock failure unrelated to this change)
- [x] Verified no other suffix-less queries are incorrectly awaited

🤖 Generated with [Claude Code](https://claude.com/claude-code)