### PR TITLE
fix(addon): handle compound Gmail contextual-trigger thread IDs

### DIFF
--- a/services/api/src/api/addon/routes.py
+++ b/services/api/src/api/addon/routes.py
@@ -301,13 +301,42 @@ def _normalize_gmail_id(raw_id: str | None) -> str | None:
     Google's contextual triggers send IDs like 'thread-f:1862729221917227576'
     (decimal with prefix), but the Gmail API and our database use the hex
     form '19d9be5bb11dba38'. They're the same number in different bases.
+
+    Some Workspace editions send compound IDs like
+    'thread-f:DEC|msg-f:DEC' — we split on '|' and use the first segment.
     """
     if not raw_id:
         return None
-    m = _GMAIL_CONTEXTUAL_ID_RE.match(raw_id)
+    segment = raw_id.split("|")[0]
+    if segment != raw_id:
+        logger.warning("Compound Gmail ID received: %s — using first segment", raw_id)
+    m = _GMAIL_CONTEXTUAL_ID_RE.match(segment)
     if m:
         return hex(int(m.group(1)))[2:]  # strip '0x' prefix
     return raw_id
+
+
+async def _resolve_thread_id_via_api(access_token: str, message_id: str) -> str | None:
+    """Fetch the canonical threadId from the Gmail API using the add-on's access token.
+
+    Used as a last-resort fallback when ``_normalize_gmail_id`` produces an ID
+    that doesn't match anything in our database.
+    """
+    import httpx
+
+    url = f"https://www.googleapis.com/gmail/v1/users/me/messages/{message_id}"
+    try:
+        async with httpx.AsyncClient(timeout=5.0) as client:
+            resp = await client.get(
+                url,
+                headers={"Authorization": f"Bearer {access_token}"},
+                params={"fields": "threadId"},
+            )
+            resp.raise_for_status()
+            return resp.json().get("threadId")
+    except Exception:
+        logger.exception("Gmail API fallback failed for message %s", message_id)
+        return None
 
 
 async def _check_gmail_auth(request: Request, user_email: str) -> CardResponse | None:
@@ -462,10 +491,24 @@ async def addon_on_message(body: AddonRequest, request: Request) -> dict:
             thread_id,
             loop.id if loop else None,
         )
+        # Gmail API fallback: if normalization produced an ID that matches
+        # nothing, ask the Gmail API for the canonical threadId using the
+        # add-on's short-lived access token.
+        if not loop and body.gmail and body.gmail.access_token and message_id:
+            api_thread_id = await _resolve_thread_id_via_api(body.gmail.access_token, message_id)
+            if api_thread_id and api_thread_id != thread_id:
+                logger.info(
+                    "on-message: API fallback resolved thread_id=%s (was %s)",
+                    api_thread_id,
+                    thread_id,
+                )
+                groups = await overview_svc.get_thread_overview_data(api_thread_id, email)
+                if groups:
+                    card = build_overview(groups, base_url=base_url)
+                    return _as_push(card).model_dump(by_alias=True, exclude_none=True)
+                loop = await svc.find_loop_by_thread(api_thread_id)
+
         if loop:
-            # Thread is linked but no pending suggestions yet — keep the
-            # user anchored to this thread instead of widening to the
-            # global overview (which would surface unrelated loops' items).
             card = build_loop_pending_card(thread_id, message_id=message_id)
         else:
             card = build_contextual_unlinked(thread_id, message_id=message_id)

--- a/services/api/tests/test_addon.py
+++ b/services/api/tests/test_addon.py
@@ -240,6 +240,49 @@ class TestRefresh:
         assert "window.close()" in resp.text
 
 
+class TestNormalizeGmailId:
+    """Unit tests for _normalize_gmail_id — the contextual-trigger ID normalizer."""
+
+    def test_none_returns_none(self):
+        from api.addon.routes import _normalize_gmail_id
+
+        assert _normalize_gmail_id(None) is None
+
+    def test_empty_string_returns_none(self):
+        from api.addon.routes import _normalize_gmail_id
+
+        assert _normalize_gmail_id("") is None
+
+    def test_thread_f_decimal_converted_to_hex(self):
+        from api.addon.routes import _normalize_gmail_id
+
+        result = _normalize_gmail_id("thread-f:1864465495488333224")
+        assert result == hex(1864465495488333224)[2:]
+
+    def test_msg_f_decimal_converted_to_hex(self):
+        from api.addon.routes import _normalize_gmail_id
+
+        result = _normalize_gmail_id("msg-f:1864465495488333224")
+        assert result == hex(1864465495488333224)[2:]
+
+    def test_compound_pipe_separated_uses_first_segment(self):
+        from api.addon.routes import _normalize_gmail_id
+
+        raw = "thread-f:1864465495488333224|msg-f:1864465495488333224"
+        result = _normalize_gmail_id(raw)
+        assert result == hex(1864465495488333224)[2:]
+
+    def test_already_hex_returned_as_is(self):
+        from api.addon.routes import _normalize_gmail_id
+
+        assert _normalize_gmail_id("19dfda858c78f74e") == "19dfda858c78f74e"
+
+    def test_unknown_format_returned_as_is(self):
+        from api.addon.routes import _normalize_gmail_id
+
+        assert _normalize_gmail_id("some-other-format") == "some-other-format"
+
+
 class TestStaticFiles:
     async def test_logo_served(self, client: AsyncClient):
         resp = await client.get("/static/logo.png")


### PR DESCRIPTION
## Summary

- Google's contextual triggers now send `threadId` as a pipe-separated compound (e.g. `thread-f:DEC|msg-f:DEC`) for some Workspace editions, breaking the regex normalizer and causing the "no loop" card to show on every thread view
- Fixes `_normalize_gmail_id` to split on `|` before matching, with a warning log for monitoring
- Adds a Gmail API fallback (`_resolve_thread_id_via_api`) that uses the add-on's access token to fetch the canonical thread ID when normalization still produces a miss
- Adds 7 unit tests for the normalizer covering all known formats

## Test plan

- [x] Unit tests pass (17/17 in `test_addon.py`)
- [ ] Deploy and have Adam open a thread — log should show compound ID warning, sidebar should display pending suggestion
- [ ] Verify other coordinators' sidebar still works (the `|` split is a no-op when there's no pipe)

🤖 Generated with [Claude Code](https://claude.com/claude-code)