### PR TITLE
fix(addon): scope Gmail API fallback to compound IDs and use domain-wide delegation

### DIFF
--- a/services/api/src/api/addon/routes.py
+++ b/services/api/src/api/addon/routes.py
@@ -295,7 +295,7 @@ def parse_name_email(text: str) -> tuple[str, str] | None:
     return m.group(1), m.group(2)
 
 
-def _normalize_gmail_id(raw_id: str | None) -> str | None:
+def _normalize_gmail_id(raw_id: str | None) -> tuple[str | None, bool]:
     """Convert Google contextual-trigger IDs to Gmail API hex format.
 
     Google's contextual triggers send IDs like 'thread-f:1862729221917227576'
@@ -304,36 +304,33 @@ def _normalize_gmail_id(raw_id: str | None) -> str | None:
 
     Some Workspace editions send compound IDs like
     'thread-f:DEC|msg-f:DEC' — we split on '|' and use the first segment.
+
+    Returns ``(normalized_id, was_rewritten)`` so callers can decide whether
+    to attempt a Gmail API fallback when the rewritten ID misses the DB.
     """
     if not raw_id:
-        return None
+        return None, False
     segment = raw_id.split("|")[0]
-    if segment != raw_id:
+    was_compound = segment != raw_id
+    if was_compound:
         logger.warning("Compound Gmail ID received: %s — using first segment", raw_id)
     m = _GMAIL_CONTEXTUAL_ID_RE.match(segment)
     if m:
-        return hex(int(m.group(1)))[2:]  # strip '0x' prefix
-    return raw_id
+        return hex(int(m.group(1)))[2:], was_compound  # strip '0x' prefix
+    return raw_id, False
 
 
-async def _resolve_thread_id_via_api(access_token: str, message_id: str) -> str | None:
-    """Fetch the canonical threadId from the Gmail API using the add-on's access token.
+async def _resolve_thread_id_via_gmail(
+    gmail_client, user_email: str, message_id: str
+) -> str | None:
+    """Fetch the canonical threadId via domain-wide delegation.
 
-    Used as a last-resort fallback when ``_normalize_gmail_id`` produces an ID
-    that doesn't match anything in our database.
+    Only invoked when ``_normalize_gmail_id`` rewrote a compound ID that
+    didn't match anything in the database — not on every unlinked thread.
     """
-    import httpx
-
-    url = f"https://www.googleapis.com/gmail/v1/users/me/messages/{message_id}"
     try:
-        async with httpx.AsyncClient(timeout=5.0) as client:
-            resp = await client.get(
-                url,
-                headers={"Authorization": f"Bearer {access_token}"},
-                params={"fields": "threadId"},
-            )
-            resp.raise_for_status()
-            return resp.json().get("threadId")
+        message = await gmail_client.get_message(user_email, message_id)
+        return message.thread_id
     except Exception:
         logger.exception("Gmail API fallback failed for message %s", message_id)
         return None
@@ -452,9 +449,10 @@ async def addon_on_message(body: AddonRequest, request: Request) -> dict:
 
     thread_id = None
     message_id = None
+    id_was_rewritten = False
     if body.gmail:
-        thread_id = _normalize_gmail_id(body.gmail.thread_id)
-        message_id = _normalize_gmail_id(body.gmail.message_id)
+        thread_id, id_was_rewritten = _normalize_gmail_id(body.gmail.thread_id)
+        message_id, _ = _normalize_gmail_id(body.gmail.message_id)
 
     logger.info(
         "on-message: thread_id=%s, message_id=%s, email=%s",
@@ -491,11 +489,9 @@ async def addon_on_message(body: AddonRequest, request: Request) -> dict:
             thread_id,
             loop.id if loop else None,
         )
-        # Gmail API fallback: if normalization produced an ID that matches
-        # nothing, ask the Gmail API for the canonical threadId using the
-        # add-on's short-lived access token.
-        if not loop and body.gmail and body.gmail.access_token and message_id:
-            api_thread_id = await _resolve_thread_id_via_api(body.gmail.access_token, message_id)
+        gmail = get_gmail(request)
+        if not loop and id_was_rewritten and gmail and message_id:
+            api_thread_id = await _resolve_thread_id_via_gmail(gmail, email, message_id)
             if api_thread_id and api_thread_id != thread_id:
                 logger.info(
                     "on-message: API fallback resolved thread_id=%s (was %s)",

--- a/services/api/tests/test_addon.py
+++ b/services/api/tests/test_addon.py
@@ -246,41 +246,52 @@ class TestNormalizeGmailId:
     def test_none_returns_none(self):
         from api.addon.routes import _normalize_gmail_id
 
-        assert _normalize_gmail_id(None) is None
+        result, rewritten = _normalize_gmail_id(None)
+        assert result is None
+        assert rewritten is False
 
     def test_empty_string_returns_none(self):
         from api.addon.routes import _normalize_gmail_id
 
-        assert _normalize_gmail_id("") is None
+        result, rewritten = _normalize_gmail_id("")
+        assert result is None
+        assert rewritten is False
 
     def test_thread_f_decimal_converted_to_hex(self):
         from api.addon.routes import _normalize_gmail_id
 
-        result = _normalize_gmail_id("thread-f:1864465495488333224")
+        result, rewritten = _normalize_gmail_id("thread-f:1864465495488333224")
         assert result == hex(1864465495488333224)[2:]
+        assert rewritten is False
 
     def test_msg_f_decimal_converted_to_hex(self):
         from api.addon.routes import _normalize_gmail_id
 
-        result = _normalize_gmail_id("msg-f:1864465495488333224")
+        result, rewritten = _normalize_gmail_id("msg-f:1864465495488333224")
         assert result == hex(1864465495488333224)[2:]
+        assert rewritten is False
 
     def test_compound_pipe_separated_uses_first_segment(self):
         from api.addon.routes import _normalize_gmail_id
 
         raw = "thread-f:1864465495488333224|msg-f:1864465495488333224"
-        result = _normalize_gmail_id(raw)
+        result, rewritten = _normalize_gmail_id(raw)
         assert result == hex(1864465495488333224)[2:]
+        assert rewritten is True
 
     def test_already_hex_returned_as_is(self):
         from api.addon.routes import _normalize_gmail_id
 
-        assert _normalize_gmail_id("19dfda858c78f74e") == "19dfda858c78f74e"
+        result, rewritten = _normalize_gmail_id("19dfda858c78f74e")
+        assert result == "19dfda858c78f74e"
+        assert rewritten is False
 
     def test_unknown_format_returned_as_is(self):
         from api.addon.routes import _normalize_gmail_id
 
-        assert _normalize_gmail_id("some-other-format") == "some-other-format"
+        result, rewritten = _normalize_gmail_id("some-other-format")
+        assert result == "some-other-format"
+        assert rewritten is False
 
 
 class TestStaticFiles:


### PR DESCRIPTION
## Summary

Follow-up to #72. The initial Gmail API fallback had two problems observed in production:

- **Too broadly scoped** — it fired on every unlinked thread (the common case for threads without loops), producing noisy log entries on every sidebar open.
- **Wrong auth mechanism** — it used the add-on's short-lived `accessToken`, which lacks Gmail API scopes, resulting in 401 errors on every fallback attempt.

## Changes

- **`_normalize_gmail_id` now returns `(id, was_rewritten)`** — callers know whether the ID was a compound pipe-separated format that got split, so the fallback only fires when we actually rewrote the ID (not on every unlinked thread).
- **Replaced `_resolve_thread_id_via_api` (httpx + accessToken) with `_resolve_thread_id_via_gmail` (GmailClient)** — uses domain-wide delegation which already has the correct Gmail API scopes.
- **Tests updated** to assert the `was_rewritten` boolean for all `_normalize_gmail_id` cases.

## Test plan

- [x] All 17 `test_addon.py` tests pass
- [x] Lint clean (`ruff check` + `ruff format`)
- [ ] Deploy to staging and verify Adam's compound-ID threads resolve correctly
- [ ] Verify no more 401 errors in production logs for the fallback path
- [ ] Confirm other coordinators' sidebar continues to work (no regression)