### PR TITLE
feat(addon): wire up ASK_COORDINATOR suggestion response flow

### DIFF
--- a/services/api/queries/suggestions.sql
+++ b/services/api/queries/suggestions.sql
@@ -58,6 +58,12 @@ UPDATE agent_suggestions
 SET status = :status, resolved_at = now(), resolved_by = :resolved_by
 WHERE id = :id AND status = 'pending';
 
+-- name: unresolve_suggestion!
+-- Revert an accepted suggestion back to pending (e.g., async processing failed).
+UPDATE agent_suggestions
+SET status = 'pending', resolved_at = NULL, resolved_by = NULL, summary = :summary
+WHERE id = :id AND status = 'accepted';
+
 -- name: supersede_pending_suggestions_for_loop!
 -- Mark all pending suggestions for a loop as superseded (outgoing email invalidated them).
 UPDATE agent_suggestions

--- a/services/api/src/api/addon/routes.py
+++ b/services/api/src/api/addon/routes.py
@@ -1508,6 +1508,69 @@ async def _handle_update_candidate_name(body: AddonRequest, svc: LoopService, em
     return await _build_refreshed_overview(request, email)
 
 
+async def _handle_respond_to_question(body: AddonRequest, svc: LoopService, email: str, **kwargs):
+    """Handle coordinator response to an ASK_COORDINATOR suggestion."""
+    from api.classifier.service import SuggestionService
+
+    request = kwargs.get("request")
+    suggestion_id = _get_param(body, "suggestion_id")
+    if not suggestion_id or not request:
+        return await _build_refreshed_overview(request, email)
+
+    suggestion_svc = SuggestionService(db_pool=svc._pool)
+    suggestion = await suggestion_svc.get_suggestion(suggestion_id)
+    if not suggestion:
+        return await _build_refreshed_overview(request, email)
+
+    user_input = _get_form_value(body, f"coordinator_response_{suggestion_id}")
+    if not user_input or not user_input.strip():
+        return await _build_refreshed_overview(request, email)
+    user_input = user_input.strip()
+
+    original_question = (suggestion.action_data or {}).get("question", "")
+    coordinator_response = (
+        f"Agent question (you asked): {original_question}\n"
+        f"Coordinator's response (they clarified): {user_input}"
+    )
+
+    await suggestion_svc.resolve(suggestion_id, SuggestionStatus.ACCEPTED, email)
+
+    redis = get_redis(request)
+    if redis:
+        try:
+            await redis.enqueue_job(
+                "process_coordinator_response",
+                suggestion_id,
+                coordinator_response,
+                email,
+                suggestion.gmail_thread_id,
+            )
+            logger.info(
+                "enqueued coordinator response processing for suggestion %s",
+                suggestion_id,
+            )
+        except Exception:
+            logger.exception(
+                "failed to enqueue coordinator response for suggestion %s — unresolving",
+                suggestion_id,
+            )
+            await suggestion_svc.unresolve(
+                suggestion_id,
+                f"Failed to queue response for processing. Original: {original_question}",
+            )
+    else:
+        logger.warning(
+            "redis unavailable — cannot process coordinator response for suggestion %s",
+            suggestion_id,
+        )
+        await suggestion_svc.unresolve(
+            suggestion_id,
+            f"Background processing unavailable. Original: {original_question}",
+        )
+
+    return await _build_refreshed_overview(request, email)
+
+
 _ACTION_HANDLERS = {
     # Loop creation (manual path)
     "show_create_form": _handle_show_create_form,
@@ -1520,6 +1583,7 @@ _ACTION_HANDLERS = {
     # Suggestion actions (ADVANCE_STAGE / LINK_THREAD / ASK_COORDINATOR / dismiss)
     "accept_suggestion": _handle_accept_suggestion,
     "reject_suggestion": _handle_reject_suggestion,
+    "respond_to_question": _handle_respond_to_question,
     "show_suggestions_tab": _handle_show_suggestions_tab,
     # JIT candidate rename (when classifier auto-created with placeholder)
     "update_candidate_name": _handle_update_candidate_name,

--- a/services/api/src/api/classifier/next_action_agent.py
+++ b/services/api/src/api/classifier/next_action_agent.py
@@ -134,11 +134,15 @@ class NextActionAgent:
         linked_loops: list[Loop],
         *,
         arq_pool: ArqRedis | None = None,
+        coordinator_response: str | None = None,
     ) -> None:
         msg = event.message
 
         context_input, existing_pending = await self._build_context(
-            event, linked_loops, event.thread_messages
+            event,
+            linked_loops,
+            event.thread_messages,
+            coordinator_response=coordinator_response,
         )
 
         try:
@@ -292,6 +296,8 @@ class NextActionAgent:
         event: EmailEvent,
         linked_loops: list[Loop],
         thread_messages: list[Message] | None = None,
+        *,
+        coordinator_response: str | None = None,
     ) -> tuple[NextActionInput, list[Suggestion]]:
         msg = event.message
 
@@ -345,6 +351,7 @@ class NextActionAgent:
             events=format_events(events),
             error="N/A",
             pending_suggestions=format_pending_suggestions(all_pending),
+            coordinator_response=coordinator_response or "No active questions.",
         ), all_pending
 
     def _resolve_target_loop(

--- a/services/api/src/api/classifier/schemas.py
+++ b/services/api/src/api/classifier/schemas.py
@@ -44,3 +44,4 @@ class NextActionInput(BaseModel):
     events: str
     error: str
     pending_suggestions: str = "No current pending suggestions."
+    coordinator_response: str = "No active questions."

--- a/services/api/src/api/classifier/service.py
+++ b/services/api/src/api/classifier/service.py
@@ -95,6 +95,11 @@ class SuggestionService:
                 conn, id=suggestion_id, status=status, resolved_by=resolved_by
             )
 
+    async def unresolve(self, suggestion_id: str, new_summary: str) -> None:
+        """Revert an accepted suggestion to pending (used when async processing fails)."""
+        async with self._pool.connection() as conn, conn.transaction():
+            await queries.unresolve_suggestion(conn, id=suggestion_id, summary=new_summary)
+
     async def supersede_pending_for_loop(self, loop_id: str, resolved_by: str) -> None:
         """Mark all pending suggestions for a loop as superseded."""
         async with self._pool.connection() as conn, conn.transaction():

--- a/services/api/src/api/gmail/workers.py
+++ b/services/api/src/api/gmail/workers.py
@@ -92,6 +92,9 @@ async def startup(ctx: dict) -> None:
         loop_service=loop_service,
         sender_blacklist=load_blacklist(),
     )
+    ctx["next_action_agent"] = agent
+    ctx["suggestion_service"] = suggestion_service
+    ctx["loop_service"] = loop_service
     logger.info("worker startup complete — EmailRouter active")
 
 
@@ -430,10 +433,94 @@ async def run_next_action_agent(
         )
 
 
+async def process_coordinator_response(
+    ctx: dict,
+    suggestion_id: str,
+    coordinator_response: str,
+    coordinator_email: str,
+    gmail_thread_id: str,
+) -> None:
+    """Re-run the NextActionAgent after a coordinator answers an ASK_COORDINATOR question.
+
+    The addon resolves the suggestion as ACCEPTED before enqueueing this job.
+    On failure, we un-resolve the suggestion so it reappears in the UI.
+    """
+    gmail: GmailClient = ctx["gmail"]
+    agent = ctx["next_action_agent"]
+    suggestion_svc = ctx["suggestion_service"]
+    loop_service = ctx["loop_service"]
+
+    try:
+        thread = await gmail.get_thread(coordinator_email, gmail_thread_id)
+        if not thread.messages:
+            logger.warning("empty thread %s — cannot process coordinator response", gmail_thread_id)
+            await suggestion_svc.unresolve(
+                suggestion_id, "Thread has no messages — please review manually."
+            )
+            return
+
+        message = thread.messages[-1]
+
+        direction = classify_direction(message, coordinator_email)
+        prior_messages = [
+            m for m in thread.messages if m.id != message.id and m.date < message.date
+        ]
+        message_type, new_participants = classify_message_type(message, prior_messages)
+
+        event = EmailEvent(
+            message=message,
+            coordinator_email=coordinator_email,
+            direction=direction,
+            message_type=message_type,
+            new_participants=new_participants,
+            thread_messages=thread.messages,
+        )
+
+        linked_loops = await loop_service.find_loops_by_thread(gmail_thread_id)
+        if not linked_loops:
+            logger.warning(
+                "no linked loops for thread %s — cannot process coordinator response",
+                gmail_thread_id,
+            )
+            await suggestion_svc.unresolve(
+                suggestion_id, "Thread is no longer linked to a loop — please review manually."
+            )
+            return
+
+        await agent.act(
+            event,
+            linked_loops,
+            coordinator_response=coordinator_response,
+            arq_pool=ctx.get("redis"),
+        )
+        logger.info(
+            "coordinator response processed for suggestion %s (thread %s)",
+            suggestion_id,
+            gmail_thread_id,
+        )
+    except GmailTokenStaleError:
+        logger.warning(
+            "stale token for %s — coordinator response skipped (suggestion %s)",
+            coordinator_email,
+            suggestion_id,
+        )
+        await suggestion_svc.unresolve(
+            suggestion_id,
+            "Gmail access expired — please ask your admin to re-authorize, then try again.",
+        )
+    except Exception as exc:
+        logger.exception(
+            "coordinator response processing failed for suggestion %s (thread %s)",
+            suggestion_id,
+            gmail_thread_id,
+        )
+        await suggestion_svc.unresolve(suggestion_id, f"Processing failed: {exc}")
+
+
 class WorkerSettings:
     """arq worker configuration."""
 
-    functions = [process_gmail_push, run_next_action_agent]  # noqa: RUF012
+    functions = [process_gmail_push, run_next_action_agent, process_coordinator_response]  # noqa: RUF012
     cron_jobs = [  # noqa: RUF012
         cron(poll_gmail_history, second=0),  # every 60s
         cron(renew_gmail_watches, hour={0, 6, 12, 18}, minute=0, second=0),

--- a/services/api/src/api/overview/cards.py
+++ b/services/api/src/api/overview/cards.py
@@ -365,13 +365,16 @@ def _build_ask_suggestion(view: SuggestionView) -> list[Widget]:
         )
     )
 
-    # Respond button (disabled - backend not implemented yet)
+    input_name = f"coordinator_response_{sug.id}"
     widgets.append(
         _buttons(
             Button(
-                text="Respond (coming soon)",
-                on_click=_action("accept_suggestion", suggestion_id=sug.id),
-                disabled=True,
+                text="Respond",
+                on_click=_action(
+                    "respond_to_question",
+                    required_widgets=[input_name],
+                    suggestion_id=sug.id,
+                ),
             ),
             _dismiss_button(sug.id),
         )

--- a/services/api/tests/test_overview_cards.py
+++ b/services/api/tests/test_overview_cards.py
@@ -195,7 +195,8 @@ class TestAskCoordinatorSuggestionBuilder:
         widgets = _build_ask_suggestion(view)
         text = str([w.model_dump(by_alias=True, exclude_none=True) for w in widgets])
         assert "morning or afternoon" in text
-        assert "coming soon" in text.lower()
+        assert "respond_to_question" in text
+        assert "coordinator_response_sug_1" in text
 
 
 class TestSuggestionDispatcher:


### PR DESCRIPTION
## Summary

- Enables the "Respond" button on ASK_COORDINATOR suggestions in the Gmail sidebar so coordinators can answer agent questions inline
- When the coordinator submits a response, the suggestion resolves immediately (optimistic UI), and a background worker re-runs the `next-action-agent` with the formatted Q&A injected via the new `coordinator_response` prompt variable
- On worker failure, the suggestion automatically un-resolves back to pending with an error explanation so the coordinator can retry or dismiss

## Changes

**SQL + Service layer:**
- `unresolve_suggestion` query reverts an ACCEPTED suggestion back to PENDING (guarded by `WHERE status = 'accepted'`)
- `SuggestionService.unresolve()` method

**Schema + Agent:**
- `coordinator_response` field added to `NextActionInput` (default: `"No active questions."`)
- Threaded through `NextActionAgent.act()` → `_build_context()` → LLM prompt

**Worker:**
- New `process_coordinator_response` function calls the agent directly (bypasses router since thread is already linked)
- Handles Gmail token errors and general failures by un-resolving with context
- `startup()` now stores `next_action_agent`, `suggestion_service`, and `loop_service` in worker ctx

**Addon handler:**
- New `respond_to_question` action reads form input, formats Q&A string, resolves optimistically, enqueues worker job
- Falls back to unresolve if Redis enqueue fails

**UI card:**
- Respond button enabled with `required_widgets` validation (Google enforces non-empty input client-side)

## Prerequisite

LangFuse `next-action-agent` prompt v23+ must include the `{{coordinator_response}}` template variable (already added).

## Test plan

- [ ] Open sidebar on a thread with an ASK_COORDINATOR suggestion
- [ ] Verify "Respond" button is enabled and requires non-empty text input
- [ ] Type a response and click Respond — suggestion should disappear immediately
- [ ] Check worker logs for `process_coordinator_response` job execution
- [ ] Verify new suggestions appear from the re-run
- [ ] Test failure path: stop worker, respond to a question, verify suggestion reappears with error after worker restarts

🤖 Generated with [Claude Code](https://claude.com/claude-code)