### PR TITLE
fix: relax client name matching in link_thread guardrail

### DIFF
--- a/services/api/src/api/classifier/loop_classifier.py
+++ b/services/api/src/api/classifier/loop_classifier.py
@@ -396,10 +396,13 @@ class LoopClassifier:
             if target.client_contact and target.client_contact.company
             else None
         )
+        extracted_client = extraction.client_company.lower().strip() if extraction else ""
+        target_client = target_company.lower().strip() if target_company else ""
         if (
             extraction
             and target_company
-            and extraction.client_company.lower().strip() != target_company.lower().strip()
+            and extracted_client not in target_client
+            and target_client not in extracted_client
         ):
             return (
                 f"LINK_THREAD action_data says client is '{extraction.client_company}' "


### PR DESCRIPTION
## Summary

- Relaxes the client company name check in the `_validate_link_thread` guardrail from exact equality to **bidirectional substring containment**
- Fixes false rejections when the email uses a short name (e.g. "Marshall Wace") but the loop stores the full legal entity ("Marshall Wace North America L.P.")
- Candidate name matching remains strict (exact equality)

## Context

Production trace showed the classifier correctly identifying Protik Nandy's existing loop but the guardrail rejecting the `LINK_THREAD` because `"Marshall Wace" != "Marshall Wace North America L.P."`. The LLM then retried and produced a worse result.

## Test plan

- [x] Existing 34 classifier tests pass
- [ ] Verify in staging: "Marshall Wace" ↔ "Marshall Wace North America L.P." links correctly
- [ ] Verify genuinely different clients (e.g. "Marshall Wace" vs "Point72") still get rejected

🤖 Generated with [Claude Code](https://claude.com/claude-code)