### PR TITLE
feat(agent): XML I/O, conversation-history retries, expire_suggestion

### DIFF
--- a/services/api/queries/suggestions.sql
+++ b/services/api/queries/suggestions.sql
@@ -76,6 +76,12 @@ UPDATE agent_suggestions
 SET status = 'expired', resolved_at = now()
 WHERE status = 'pending' AND created_at < :cutoff;
 
+-- name: expire_suggestion!
+-- Mark a single pending suggestion as expired. No-ops if not pending.
+UPDATE agent_suggestions
+SET status = 'expired', resolved_at = now(), resolved_by = :resolved_by
+WHERE id = :id AND status = 'pending';
+
 -- name: get_pending_suggestions_with_context
 -- Denormalized query for the overview card: suggestions + loop context + draft context.
 -- Returns everything the UI needs in a single round-trip (no N+1).

--- a/services/api/queries/suggestions.sql
+++ b/services/api/queries/suggestions.sql
@@ -92,6 +92,14 @@ FROM agent_suggestions
 WHERE gmail_thread_id = :gmail_thread_id
 LIMIT 1;
 
+-- name: update_action_data!
+-- Replace the action_data JSONB blob on a suggestion. Used by the addon to
+-- stash UI-driven state (currently UPDATE_ACTOR's pending_pick from the
+-- autocomplete onChange handler) before the coordinator commits via Save.
+UPDATE agent_suggestions
+SET action_data = :action_data
+WHERE id = :id;
+
 -- name: get_pending_suggestions_with_context
 -- Denormalized query for the overview card: suggestions + loop context + draft context.
 -- Returns everything the UI needs in a single round-trip (no N+1).

--- a/services/api/queries/suggestions.sql
+++ b/services/api/queries/suggestions.sql
@@ -82,6 +82,16 @@ UPDATE agent_suggestions
 SET status = 'expired', resolved_at = now(), resolved_by = :resolved_by
 WHERE id = :id AND status = 'pending';
 
+-- name: has_suggestion_for_thread^
+-- Cheap existence check: any suggestion row for this thread, any status.
+-- Used by the in-message sidebar to distinguish "agent has run on this
+-- thread (show 'all caught up')" from "agent hasn't run yet (show
+-- 'generating')". A single indexed lookup; we don't care which row matches.
+SELECT 1
+FROM agent_suggestions
+WHERE gmail_thread_id = :gmail_thread_id
+LIMIT 1;
+
 -- name: get_pending_suggestions_with_context
 -- Denormalized query for the overview card: suggestions + loop context + draft context.
 -- Returns everything the UI needs in a single round-trip (no N+1).

--- a/services/api/src/api/addon/routes.py
+++ b/services/api/src/api/addon/routes.py
@@ -919,10 +919,10 @@ async def _handle_recruiter_selected(body: AddonRequest, svc: LoopService, email
     Three callers, distinguished by which extra params come along:
 
     - **UPDATE_ACTOR path** (``update_actor_role`` present): the coordinator
-      picked from the autocomplete on an UPDATE_ACTOR card. Delegate to
-      ``_handle_update_actor`` — autocomplete-selection IS the commit for
-      this card. (For mid-type values that don't parse as "Name <email>",
-      ``_handle_update_actor`` no-ops and refreshes.)
+      picked from the autocomplete on an UPDATE_ACTOR card. STAGE the pick
+      on the suggestion's ``action_data.pending_pick`` and refresh — the
+      card re-renders with the inputs pre-filled, and the coordinator must
+      click Save to actually commit. Autocomplete selection never commits.
 
     - **JIT path** (``draft_id`` present): the coordinator picked a recruiter
       from the autocomplete on a DRAFT_EMAIL card. Stash on draft pending
@@ -941,10 +941,13 @@ async def _handle_recruiter_selected(body: AddonRequest, svc: LoopService, email
     def _field(name: str) -> str | None:
         return _get_form_value(body, name)
 
-    # UPDATE_ACTOR origin — checked FIRST so we don't fall through to the
-    # create-loop form rebuild (which silently wipes the overview).
+    # UPDATE_ACTOR origin — stage the pick rather than commit. Misclicks in
+    # the autocomplete dropdown were committing directly to the loop with no
+    # way to undo; this routes through the standard Save-button commit step.
     if suggestion_id and update_actor_role:
-        return await _handle_update_actor(body, svc, email, **kwargs)
+        return await _stash_update_actor_pick(
+            body, svc, email, request, suggestion_id, update_actor_role
+        )
 
     if draft_id and suggestion_id:
         # JIT path — stash the pick on draft.pending_jit_data instead of
@@ -1683,6 +1686,58 @@ async def _handle_respond_to_question(body: AddonRequest, svc: LoopService, emai
 
 
 _UPDATE_ACTOR_ROLES = frozenset({"recruiter", "client_manager", "client_contact"})
+
+
+async def _stash_update_actor_pick(
+    body: AddonRequest,
+    svc: LoopService,
+    email: str,
+    request,
+    suggestion_id: str,
+    update_actor_role: str,
+):
+    """Autocomplete onChange handler for UPDATE_ACTOR cards.
+
+    Stages the directory selection by writing it to the suggestion's
+    ``action_data.pending_pick``. The card builder reads pending_pick on
+    re-render and pre-fills the autocomplete inputs with the staged values,
+    so the coordinator sees what they picked but the change is NOT
+    committed until they click Save (which routes to _handle_update_actor).
+
+    Idempotent: re-picking from the autocomplete overwrites pending_pick.
+    Mid-typed input that doesn't parse as "Name <email>" is a no-op refresh
+    — same gating as the JIT path uses.
+    """
+    from api.classifier.service import SuggestionService
+
+    name_field = f"update_actor_name_{suggestion_id}"
+    email_field = f"update_actor_email_{suggestion_id}"
+    raw_name = _get_form_value(body, name_field) or ""
+    raw_email = _get_form_value(body, email_field) or ""
+    parsed = parse_name_email(raw_name) or parse_name_email(raw_email)
+    if parsed is None:
+        return await _build_refreshed_overview(request, email)
+    new_name, new_email = parsed
+    new_email = new_email.strip()
+    if not new_email:
+        return await _build_refreshed_overview(request, email)
+
+    suggestion_svc = SuggestionService(db_pool=svc._pool)
+    suggestion = await suggestion_svc.get_suggestion(suggestion_id)
+    if suggestion is None:
+        return await _build_refreshed_overview(request, email)
+
+    new_action_data = dict(suggestion.action_data or {})
+    new_action_data["role"] = update_actor_role  # idempotent — already set by the agent
+    new_action_data["pending_pick"] = {"name": new_name, "email": new_email}
+    await suggestion_svc.update_action_data(suggestion_id, new_action_data)
+    logger.info(
+        "staged update_actor pick for suggestion %s (role=%s, email=%s)",
+        suggestion_id,
+        update_actor_role,
+        new_email,
+    )
+    return await _build_refreshed_overview(request, email)
 
 
 async def _handle_update_actor(body: AddonRequest, svc: LoopService, email: str, **kwargs):

--- a/services/api/src/api/addon/routes.py
+++ b/services/api/src/api/addon/routes.py
@@ -1615,6 +1615,108 @@ async def _handle_respond_to_question(body: AddonRequest, svc: LoopService, emai
     return await _build_refreshed_overview(request, email)
 
 
+_UPDATE_ACTOR_ROLES = frozenset({"recruiter", "client_manager", "client_contact"})
+
+
+async def _handle_update_actor(body: AddonRequest, svc: LoopService, email: str, **kwargs):
+    """Handle UPDATE_ACTOR suggestion submission — point the loop at a new actor.
+
+    Mirrors ASK_COORDINATOR's shape (resolve → ACCEPTED → enqueue agent
+    re-run) but the "answer" is structured: the coordinator picked a
+    Workspace user (recruiter/CM) or typed a client contact name+email.
+
+    After updating the loop's FK, we enqueue ``run_next_action_agent`` so
+    the agent's next pass sees the new actor in the loop XML and can
+    naturally suggest a follow-up draft (e.g., emailing the newly-added
+    recruiter for availability).
+    """
+    from api.classifier.service import SuggestionService
+
+    request = kwargs.get("request")
+    suggestion_id = _get_param(body, "suggestion_id")
+    role = _get_param(body, "update_actor_role")
+    if not suggestion_id or not request or role not in _UPDATE_ACTOR_ROLES:
+        return await _build_refreshed_overview(request, email)
+
+    suggestion_svc = SuggestionService(db_pool=svc._pool)
+    suggestion = await suggestion_svc.get_suggestion(suggestion_id)
+    if not suggestion or not suggestion.loop_id:
+        return await _build_refreshed_overview(request, email)
+
+    def _f(name: str) -> str:
+        return (_get_form_value(body, f"{name}_{suggestion_id}") or "").strip()
+
+    raw_name = _f("update_actor_name")
+    raw_email = _f("update_actor_email")
+    # Either field may carry the directory-autocomplete "Name <email>" combo
+    # — split defensively the same way the create-loop form does.
+    parsed = parse_name_email(raw_name) or parse_name_email(raw_email)
+    if parsed is not None:
+        actor_name, actor_email = parsed
+    else:
+        actor_name, actor_email = raw_name, raw_email
+    actor_email = actor_email.strip()
+    if not actor_email:
+        return await _build_refreshed_overview(request, email)
+
+    try:
+        if role == "client_contact":
+            company = _f("update_actor_company")
+            contact = await svc.find_or_create_client_contact(
+                name=actor_name or actor_email,
+                email=actor_email,
+                company=company or None,
+            )
+            await svc.set_client_contact(suggestion.loop_id, contact.id, email)
+        else:
+            contact = await svc.find_or_create_contact(
+                name=actor_name or actor_email,
+                email=actor_email,
+                role=role,
+            )
+            if role == "recruiter":
+                await svc.set_recruiter(suggestion.loop_id, contact.id, email)
+            else:
+                await svc.set_client_manager(suggestion.loop_id, contact.id, email)
+    except Exception:
+        logger.exception(
+            "failed to update actor (role=%s, loop=%s, suggestion=%s)",
+            role,
+            suggestion.loop_id,
+            suggestion_id,
+        )
+        return await _build_refreshed_overview(request, email)
+
+    await suggestion_svc.resolve(suggestion_id, SuggestionStatus.ACCEPTED, email)
+
+    # The new actor is now on the loop. Re-run the agent so it can suggest
+    # follow-ups (e.g., a draft email to the just-added recruiter) with the
+    # updated loop state in scope.
+    if suggestion.gmail_thread_id:
+        redis = get_redis(request)
+        if redis is not None:
+            try:
+                await redis.enqueue_job(
+                    "run_next_action_agent",
+                    email,
+                    None,  # gmail_message_id — let worker pick the latest from the thread
+                    suggestion.gmail_thread_id,
+                )
+                logger.info(
+                    "enqueued next-action re-run after update_actor (role=%s, loop=%s)",
+                    role,
+                    suggestion.loop_id,
+                )
+            except Exception:
+                # Best-effort — the loop update succeeded; swallow the enqueue error.
+                logger.exception(
+                    "failed to enqueue next-action re-run after update_actor " "(suggestion %s)",
+                    suggestion_id,
+                )
+
+    return await _build_refreshed_overview(request, email)
+
+
 _ACTION_HANDLERS = {
     # Loop creation (manual path)
     "show_create_form": _handle_show_create_form,
@@ -1631,6 +1733,8 @@ _ACTION_HANDLERS = {
     "show_suggestions_tab": _handle_show_suggestions_tab,
     # JIT candidate rename (when classifier auto-created with placeholder)
     "update_candidate_name": _handle_update_candidate_name,
+    # UPDATE_ACTOR — coordinator sets/replaces a loop's recruiter/CM/client_contact
+    "update_actor": _handle_update_actor,
     # JIT pending-pick management (recruiter / client / CM staged on draft)
     "clear_jit": _handle_clear_jit,
 }

--- a/services/api/src/api/addon/routes.py
+++ b/services/api/src/api/addon/routes.py
@@ -53,6 +53,7 @@ from api.scheduling.cards import (
     build_contextual_unlinked,
     build_create_loop_form,
     build_error_card,
+    build_loop_caught_up_card,
     build_loop_pending_card,
 )
 from api.scheduling.models import StageState
@@ -486,6 +487,10 @@ async def addon_on_message(body: AddonRequest, request: Request) -> dict:
         # No suggestions for this thread — check if it's linked to a loop
         svc = get_scheduling(request)
         loop = await svc.find_loop_by_thread(thread_id)
+        # Track the thread_id that produced a loop match — the Gmail-API
+        # fallback below may rewrite it, and the suggestion-existence check
+        # must run against the same id the loop was found under.
+        resolved_thread_id = thread_id
         logger.info(
             "on-message: thread_id=%s, linked_loop=%s",
             thread_id,
@@ -505,9 +510,23 @@ async def addon_on_message(body: AddonRequest, request: Request) -> dict:
                     card = build_overview(groups, base_url=base_url)
                     return _as_push(card).model_dump(by_alias=True, exclude_none=True)
                 loop = await svc.find_loop_by_thread(api_thread_id)
+                if loop:
+                    resolved_thread_id = api_thread_id
 
         if loop:
-            card = build_loop_pending_card(thread_id, message_id=message_id)
+            # Pick between "Generating…" and "All caught up" by checking
+            # whether the agent has produced any suggestion rows for this
+            # thread at all (any status). If yes, the agent has run and
+            # there's just nothing pending right now — don't pretend work
+            # is in flight.
+            from api.classifier.service import SuggestionService
+
+            suggestion_svc = SuggestionService(db_pool=svc._pool)
+            has_history = await suggestion_svc.has_any_suggestions_for_thread(resolved_thread_id)
+            if has_history:
+                card = build_loop_caught_up_card(resolved_thread_id, message_id=message_id)
+            else:
+                card = build_loop_pending_card(resolved_thread_id, message_id=message_id)
         else:
             card = build_contextual_unlinked(thread_id, message_id=message_id)
 

--- a/services/api/src/api/addon/routes.py
+++ b/services/api/src/api/addon/routes.py
@@ -867,26 +867,35 @@ async def _handle_show_create_form(body: AddonRequest, svc: LoopService, email: 
 async def _handle_recruiter_selected(body: AddonRequest, svc: LoopService, email: str, **kwargs):
     """onChangeAction handler for recruiter directory autocomplete.
 
-    Two callers, distinguished by whether ``draft_id`` is in the action
-    parameters:
+    Three callers, distinguished by which extra params come along:
+
+    - **UPDATE_ACTOR path** (``update_actor_role`` present): the coordinator
+      picked from the autocomplete on an UPDATE_ACTOR card. Delegate to
+      ``_handle_update_actor`` — autocomplete-selection IS the commit for
+      this card. (For mid-type values that don't parse as "Name <email>",
+      ``_handle_update_actor`` no-ops and refreshes.)
 
     - **JIT path** (``draft_id`` present): the coordinator picked a recruiter
-      from the autocomplete on a DRAFT_EMAIL card. Commit the contact to the
-      loop immediately and refresh the overview so the JIT inputs disappear
-      and Send enables. Without this, the onChange would re-render the
-      standalone create-loop form by mistake — the bug screenshot showed.
+      from the autocomplete on a DRAFT_EMAIL card. Stash on draft pending
+      data so the JIT inputs collapse to a "selected" badge but nothing
+      commits until Send.
 
-    - **Create-loop form path** (no ``draft_id``): the coordinator picked a
-      recruiter inside the standalone create-loop form. Split
-      ``"Name <email>"`` into the two fields and re-render the form,
-      preserving every other field's typed value via ``prefill_*``.
+    - **Create-loop form path** (neither): the coordinator picked inside the
+      standalone create-loop form. Split ``"Name <email>"`` into the two
+      fields and re-render the form with prefills.
     """
     request = kwargs.get("request")
     suggestion_id = _get_param(body, "suggestion_id")
     draft_id = _get_param(body, "draft_id")
+    update_actor_role = _get_param(body, "update_actor_role")
 
     def _field(name: str) -> str | None:
         return _get_form_value(body, name)
+
+    # UPDATE_ACTOR origin — checked FIRST so we don't fall through to the
+    # create-loop form rebuild (which silently wipes the overview).
+    if suggestion_id and update_actor_role:
+        return await _handle_update_actor(body, svc, email, **kwargs)
 
     if draft_id and suggestion_id:
         # JIT path — stash the pick on draft.pending_jit_data instead of

--- a/services/api/src/api/addon/routes.py
+++ b/services/api/src/api/addon/routes.py
@@ -1455,8 +1455,17 @@ async def _handle_accept_suggestion(body: AddonRequest, svc: LoopService, email:
     return await _build_refreshed_overview(request, email)
 
 
+# Reject re-runs the agent for these action types — DRAFT_EMAIL and
+# ASK_COORDINATOR are the cases where a different next attempt is plausible.
+# ADVANCE_STAGE / NO_ACTION / EXPIRE_SUGGESTION rejections stay dead-ends.
+_RERUN_ON_REJECT_ACTIONS = frozenset({SuggestedAction.DRAFT_EMAIL, SuggestedAction.ASK_COORDINATOR})
+
+
 async def _handle_reject_suggestion(body: AddonRequest, svc: LoopService, email: str, **kwargs):
-    """Dismiss a suggestion — resolve as REJECTED, discard draft if applicable."""
+    """Dismiss a suggestion — resolve as REJECTED, discard draft if applicable,
+    and (for DRAFT_EMAIL / ASK_COORDINATOR) enqueue a re-run so the agent can
+    propose a materially different alternative.
+    """
     from api.classifier.service import SuggestionService
 
     request = kwargs.get("request")
@@ -1476,6 +1485,31 @@ async def _handle_reject_suggestion(body: AddonRequest, svc: LoopService, email:
                 await draft_svc.mark_discarded(draft.id)
 
     await suggestion_svc.resolve(suggestion_id, SuggestionStatus.REJECTED, email)
+
+    if (
+        suggestion is not None
+        and suggestion.action in _RERUN_ON_REJECT_ACTIONS
+        and suggestion.gmail_thread_id
+    ):
+        redis = get_redis(request)
+        if redis is not None:
+            try:
+                await redis.enqueue_job(
+                    "process_rejection_response",
+                    suggestion_id,
+                    email,
+                    suggestion.gmail_thread_id,
+                )
+                logger.info(
+                    "enqueued rejection re-run for suggestion %s (action=%s)",
+                    suggestion_id,
+                    suggestion.action,
+                )
+            except Exception:
+                # Best-effort — the rejection itself succeeded, swallow the enqueue error.
+                logger.exception(
+                    "failed to enqueue rejection re-run for suggestion %s", suggestion_id
+                )
 
     return await _build_refreshed_overview(request, email)
 

--- a/services/api/src/api/addon/routes.py
+++ b/services/api/src/api/addon/routes.py
@@ -46,6 +46,7 @@ from api.gmail.exceptions import (
     GmailValidationError,
 )
 from api.gmail.forward import build_forwarded_body, prefix_forward_subject
+from api.gmail.models import Message  # noqa: TC001 — used in _pick_thread_anchor signature
 from api.overview.cards import build_overview
 from api.overview.service import OverviewService
 from api.scheduling.cards import (
@@ -294,6 +295,35 @@ def parse_name_email(text: str) -> tuple[str, str] | None:
     if m is None:
         return None
     return m.group(1), m.group(2)
+
+
+def _pick_thread_anchor(
+    messages: list[Message], to_emails: list[str], *, is_forward: bool
+) -> Message | None:
+    """Pick the Message whose Message-ID we'll point In-Reply-To at on send.
+
+    Default: latest message overall.
+
+    For non-forward sends, when one of the recipients has previously sent on
+    this thread, prefer their latest message instead — that way the
+    recipient's Gmail can match the In-Reply-To against a Message-ID in their
+    own Sent folder and thread our reply cleanly. The most consequential case
+    is replying to a client after the conversation went internal (e.g.,
+    recruiter avails landed in our mailbox between the client's last send
+    and our reply): anchoring on the client's last message keeps their
+    thread intact.
+
+    Forwards always anchor on the latest overall — we're inserting a new
+    party who, by definition, didn't send a prior message on this thread.
+    """
+    if not messages:
+        return None
+    if not is_forward and to_emails:
+        recipient_set = {e.lower() for e in to_emails}
+        matches = [m for m in messages if m.from_.email.lower() in recipient_set]
+        if matches:
+            return max(matches, key=lambda m: m.date)
+    return max(messages, key=lambda m: m.date)
 
 
 def _normalize_gmail_id(raw_id: str | None) -> tuple[str | None, bool]:
@@ -1366,8 +1396,17 @@ async def _handle_send_draft(body: AddonRequest, svc: LoopService, email: str, *
     in_reply_to = None
     references = None
     if thread and thread.messages:
-        last_msg = thread.messages[-1]
-        in_reply_to = last_msg.message_id_header
+        # Anchor In-Reply-To on a message the recipient is most likely to
+        # have in their own mailbox. For non-forward sends, prefer the
+        # recipient's own last message on the thread when present — this is
+        # what makes a client see our reply on their original thread instead
+        # of as a brand-new conversation.
+        anchor_msg = _pick_thread_anchor(
+            thread.messages,
+            draft.to_emails,
+            is_forward=draft.is_forward,
+        )
+        in_reply_to = anchor_msg.message_id_header if anchor_msg else None
         ref_ids = [m.message_id_header for m in thread.messages if m.message_id_header]
         if ref_ids:
             references = " ".join(ref_ids)

--- a/services/api/src/api/addon/routes.py
+++ b/services/api/src/api/addon/routes.py
@@ -1455,17 +1455,17 @@ async def _handle_accept_suggestion(body: AddonRequest, svc: LoopService, email:
     return await _build_refreshed_overview(request, email)
 
 
-# Reject re-runs the agent for these action types — DRAFT_EMAIL and
-# ASK_COORDINATOR are the cases where a different next attempt is plausible.
-# ADVANCE_STAGE / NO_ACTION / EXPIRE_SUGGESTION rejections stay dead-ends.
-_RERUN_ON_REJECT_ACTIONS = frozenset({SuggestedAction.DRAFT_EMAIL, SuggestedAction.ASK_COORDINATOR})
-
-
 async def _handle_reject_suggestion(body: AddonRequest, svc: LoopService, email: str, **kwargs):
     """Dismiss a suggestion — resolve as REJECTED, discard draft if applicable,
-    and (for DRAFT_EMAIL / ASK_COORDINATOR) enqueue a re-run so the agent can
+    and (for any manually-resolved action) enqueue a re-run so the agent can
     propose a materially different alternative.
+
+    Eligibility is expressed as "not auto-resolved" rather than an explicit
+    allow-list: auto-resolved actions (ADVANCE_STAGE, EXPIRE_SUGGESTION) never
+    surface to the coordinator anyway, so this is mostly a defensive check,
+    but it stays correct if a new manually-resolvable action type is added.
     """
+    from api.classifier.resolvers import AGENT_AUTO_RESOLVE_ACTIONS
     from api.classifier.service import SuggestionService
 
     request = kwargs.get("request")
@@ -1488,7 +1488,7 @@ async def _handle_reject_suggestion(body: AddonRequest, svc: LoopService, email:
 
     if (
         suggestion is not None
-        and suggestion.action in _RERUN_ON_REJECT_ACTIONS
+        and suggestion.action not in AGENT_AUTO_RESOLVE_ACTIONS
         and suggestion.gmail_thread_id
     ):
         redis = get_redis(request)

--- a/services/api/src/api/ai/langfuse_client.py
+++ b/services/api/src/api/ai/langfuse_client.py
@@ -92,8 +92,17 @@ def fetch_prompt(
             to iterate on prompts without affecting prod.
     """
     resolved_label = label or DEFAULT_PROMPT_LABEL
+
+    # Non-production labels skip the SDK's 60s prompt cache so a freshly
+    # published version is picked up on the very next call — critical for
+    # iterating on prompts in dev/staging. Production keeps the default
+    # cache so the SDK can serve from cache during a LangFuse outage.
+    get_prompt_kwargs: dict = {"label": resolved_label, "type": prompt_type}
+    if resolved_label != "production":
+        get_prompt_kwargs["cache_ttl_seconds"] = 0
+
     try:
-        prompt = client.get_prompt(name, label=resolved_label, type=prompt_type)
+        prompt = client.get_prompt(name, **get_prompt_kwargs)
     except Exception as exc:
         error_msg = str(exc).lower()
         if "not found" in error_msg:

--- a/services/api/src/api/classifier/formatters.py
+++ b/services/api/src/api/classifier/formatters.py
@@ -11,6 +11,7 @@ a configurable character limit (~4 chars/token as a rough proxy).
 from __future__ import annotations
 
 from typing import TYPE_CHECKING
+from xml.sax.saxutils import escape as _xml_escape
 
 if TYPE_CHECKING:
     from api.classifier.models import Suggestion
@@ -223,6 +224,161 @@ def format_pending_suggestions(suggestions: list[Suggestion]) -> str:
         lines.append(line)
 
     return "\n".join(lines)
+
+
+# ---------------------------------------------------------------------------
+# XML formatters — feed the next-action-agent prompt's structured inputs
+# ---------------------------------------------------------------------------
+
+
+def _escape(value: str | None) -> str:
+    """XML-escape a possibly-null string."""
+    return _xml_escape(value or "")
+
+
+def _format_address(name: str | None, email: str) -> str:
+    """Render an address as 'Name email' (matching the prompt's expected shape)."""
+    if name:
+        return f"{name} {email}"
+    return email
+
+
+_DIRECTION_LABELS = {
+    "incoming": "inbound",
+    "outgoing": "outbound",
+}
+
+
+def format_email_xml(message: Message, direction: str) -> str:
+    """Render a single message as an <email> XML block.
+
+    Direction is normalised to ``inbound`` / ``outbound`` to match the prompt's
+    vocabulary (the internal enum uses ``incoming`` / ``outgoing``).
+    """
+    direction_label = _DIRECTION_LABELS.get(direction, direction)
+    from_str = _format_address(message.from_.name, message.from_.email)
+    to_str = ", ".join(_format_address(a.name, a.email) for a in message.to)
+    cc_str = ", ".join(_format_address(a.name, a.email) for a in message.cc)
+
+    lines = [
+        f"<email direction='{_escape(direction_label)}'>",
+        f"  <timestamp>{_escape(message.date.isoformat())}</timestamp>",
+        f"  <from>{_escape(from_str)}</from>",
+        f"  <to>{_escape(to_str)}</to>",
+    ]
+    if cc_str:
+        lines.append(f"  <cc>{_escape(cc_str)}</cc>")
+    lines.append(f"  <subject>{_escape(message.subject)}</subject>")
+    lines.append(f"  <body>{_escape(message.body_text.strip())}</body>")
+    lines.append("</email>")
+    return "\n".join(lines)
+
+
+def format_thread_history_xml(
+    messages: list[Message],
+    current_message_id: str,
+    coordinator_email: str,
+    char_budget: int = DEFAULT_THREAD_CHAR_BUDGET,
+) -> str:
+    """Render thread history as concatenated <email> blocks, oldest first.
+
+    Excludes the trigger message (provided separately as ``{{email}}``).
+    Direction is per-message: outbound when sent by the coordinator's mailbox,
+    inbound otherwise. Truncates from the oldest end to stay within the
+    char budget; emits an XML comment marker when truncation occurs.
+    """
+    prior = [m for m in messages if m.id != current_message_id]
+    prior.sort(key=lambda m: m.date)  # oldest first
+
+    if not prior:
+        return "<!-- No prior messages in this thread -->"
+
+    # Render newest first so we can keep the most recent N within budget,
+    # then reverse to emit oldest-first.
+    rendered_newest_first: list[str] = []
+    total_chars = 0
+    truncated_count = 0
+
+    for msg in reversed(prior):
+        direction = "outbound" if msg.from_.email == coordinator_email else "inbound"
+        block = format_email_xml(msg, direction)
+        if total_chars + len(block) > char_budget and rendered_newest_first:
+            truncated_count = len(prior) - len(rendered_newest_first)
+            break
+        rendered_newest_first.append(block)
+        total_chars += len(block) + 1  # newline between blocks
+
+    parts: list[str] = []
+    if truncated_count > 0:
+        parts.append(f"<!-- {truncated_count} earlier message(s) truncated -->")
+    parts.extend(reversed(rendered_newest_first))
+    return "\n".join(parts)
+
+
+def _format_actor(prefix_tag: str, value: str | None) -> str:
+    """Render a single actor tag, defaulting to 'Unknown' when null."""
+    return f"<{prefix_tag}>{_escape(value or 'Unknown')}</{prefix_tag}>"
+
+
+def _format_client_contact(loop: Loop) -> str:
+    cc = loop.client_contact
+    if cc is None:
+        return "<client-contact>Unknown</client-contact>"
+    name = cc.name or cc.email
+    company = cc.company or ""
+    label = f"{name}, {company}".rstrip(", ").strip()
+    return f"<client-contact>{_escape(label or 'Unknown')}</client-contact>"
+
+
+def _format_pending_suggestions_xml(pending: list[Suggestion]) -> str:
+    if not pending:
+        return "<pending-suggestions>No current suggestions</pending-suggestions>"
+    children: list[str] = []
+    for sug in pending:
+        summary = sug.summary or ""
+        children.append(
+            f"    <suggestion id='{_escape(sug.id)}' action='{_escape(sug.action)}'>"
+            f"{_escape(summary)}</suggestion>"
+        )
+    inner = "\n".join(children)
+    return f"<pending-suggestions>\n{inner}\n  </pending-suggestions>"
+
+
+def format_loop_xml(loop: Loop, pending_for_loop: list[Suggestion]) -> str:
+    """Render a single loop as a <loop> XML block."""
+    coordinator_name = loop.coordinator.name if loop.coordinator else None
+    recruiter_name = loop.recruiter.name if loop.recruiter else None
+    candidate_name = loop.candidate.name if loop.candidate else None
+    cm_name = loop.client_manager.name if loop.client_manager else None
+
+    pending_block = _format_pending_suggestions_xml(pending_for_loop)
+    # Indent the pending block by two spaces so it aligns with siblings.
+    pending_block_indented = "\n".join("  " + line for line in pending_block.split("\n"))
+
+    lines = [
+        f"<loop id='{_escape(loop.id)}'>",
+        f"  <stage>{_escape(loop.state.value)}</stage>",
+        "  <actors>",
+        f"    {_format_actor('coordinator', coordinator_name)}",
+        f"    {_format_client_contact(loop)}",
+        f"    {_format_actor('client-manager', cm_name)}",
+        f"    {_format_actor('recruiter', recruiter_name)}",
+        f"    {_format_actor('candidate', candidate_name)}",
+        "  </actors>",
+        pending_block_indented,
+        "</loop>",
+    ]
+    return "\n".join(lines)
+
+
+def format_loops_xml(
+    loops: list[Loop],
+    pending_by_loop: dict[str, list[Suggestion]],
+) -> str:
+    """Render all loops linked to the thread as concatenated <loop> blocks."""
+    if not loops:
+        return "<!-- No loops linked to this thread -->"
+    return "\n".join(format_loop_xml(lp, pending_by_loop.get(lp.id, [])) for lp in loops)
 
 
 def _action_data_highlights(action: str, action_data: dict) -> str:

--- a/services/api/src/api/classifier/formatters.py
+++ b/services/api/src/api/classifier/formatters.py
@@ -355,6 +355,11 @@ def _format_pending_suggestion_body(sug: Suggestion) -> str:
             f"      <summary>{_escape(summary)}</summary>\n"
             f"      <question>{_escape(question)}</question>"
         )
+    if sug.action == "update_actor":
+        role = (data.get("role") or "").strip()
+        return (
+            f"      <summary>{_escape(summary)}</summary>\n" f"      <role>{_escape(role)}</role>"
+        )
     # Fallback for any future pending action types — keep the body terse.
     return f"      <summary>{_escape(summary)}</summary>"
 

--- a/services/api/src/api/classifier/formatters.py
+++ b/services/api/src/api/classifier/formatters.py
@@ -330,15 +330,45 @@ def _format_client_contact(loop: Loop) -> str:
     return f"<client-contact>{_escape(label or 'Unknown')}</client-contact>"
 
 
+def _format_pending_suggestion_body(sug: Suggestion) -> str:
+    """Render a pending suggestion's action_data so the agent can recognize
+    duplicates and target the right one for expire_suggestion.
+
+    Only draft_email and ask_coordinator end up pending in practice — the other
+    action types auto-resolve via the resolver registry. We format those two
+    explicitly and fall back to the summary for anything else.
+    """
+    summary = sug.summary or ""
+    data = sug.action_data or {}
+
+    if sug.action == "draft_email":
+        recipient = data.get("recipient_type", "")
+        body = (data.get("body") or "").strip()
+        return (
+            f"      <summary>{_escape(summary)}</summary>\n"
+            f"      <recipient-type>{_escape(recipient)}</recipient-type>\n"
+            f"      <body>{_escape(body)}</body>"
+        )
+    if sug.action == "ask_coordinator":
+        question = (data.get("question") or "").strip()
+        return (
+            f"      <summary>{_escape(summary)}</summary>\n"
+            f"      <question>{_escape(question)}</question>"
+        )
+    # Fallback for any future pending action types — keep the body terse.
+    return f"      <summary>{_escape(summary)}</summary>"
+
+
 def _format_pending_suggestions_xml(pending: list[Suggestion]) -> str:
     if not pending:
         return "<pending-suggestions>No current suggestions</pending-suggestions>"
     children: list[str] = []
     for sug in pending:
-        summary = sug.summary or ""
+        body = _format_pending_suggestion_body(sug)
         children.append(
-            f"    <suggestion id='{_escape(sug.id)}' action='{_escape(sug.action)}'>"
-            f"{_escape(summary)}</suggestion>"
+            f"    <suggestion id='{_escape(sug.id)}' action='{_escape(sug.action)}'>\n"
+            f"{body}\n"
+            f"    </suggestion>"
         )
     inner = "\n".join(children)
     return f"<pending-suggestions>\n{inner}\n  </pending-suggestions>"

--- a/services/api/src/api/classifier/generation.py
+++ b/services/api/src/api/classifier/generation.py
@@ -1,0 +1,79 @@
+"""Per-thread generation tokens for cancelling superseded agent runs.
+
+Three workers can fire NextActionAgent.act() on the same Gmail thread
+concurrently (run_next_action_agent, process_coordinator_response,
+process_rejection_response). Without coordination they race, don't see each
+other's writes, and produce duplicate suggestions.
+
+This module adds cooperative cancellation: each worker handler calls
+``claim_generation(redis, thread_id)`` on entry, passes the returned token
+and thread_id into ``NextActionAgent.act()``, and the agent checks
+``is_current_generation()`` at two points (before the LLM call and before
+persisting suggestions). If a newer worker overwrites the token in between,
+the older run logs and aborts without writing.
+
+The pattern mirrors the existing ``push_lock`` debounce in
+``api.gmail.workers``: Redis SET with a TTL as the coordination primitive,
+last-writer-wins, fail-open when Redis is unavailable.
+
+Cooperative cancellation only — we don't kill in-flight LLM calls or
+interrupt the event loop. Worst case is one wasted LLM round-trip.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import TYPE_CHECKING
+from uuid import uuid4
+
+if TYPE_CHECKING:
+    from arq.connections import ArqRedis
+
+logger = logging.getLogger(__name__)
+
+_GENERATION_TTL_SECONDS = 300  # 5 minutes — generous bound on a single agent run.
+_KEY_FMT = "agent_gen:{thread_id}"
+
+
+async def claim_generation(redis: ArqRedis | None, thread_id: str) -> str | None:
+    """Stamp this thread with a fresh generation token. Returns the token.
+
+    Returns None when ``redis`` is None — caller treats that as
+    "no cancellation available," and ``is_current_generation`` will fail
+    open. This keeps unit tests + degraded-Redis paths from blocking
+    legitimate agent work.
+
+    Last-writer-wins on SET. Two workers racing each other will both claim
+    successfully but with different tokens; the earlier one aborts at its
+    next checkpoint when it sees the newer token.
+    """
+    if redis is None:
+        return None
+    token = uuid4().hex
+    await redis.set(_KEY_FMT.format(thread_id=thread_id), token, ex=_GENERATION_TTL_SECONDS)
+    return token
+
+
+async def is_current_generation(
+    redis: ArqRedis | None, thread_id: str | None, token: str | None
+) -> bool:
+    """True iff the stored token matches ours.
+
+    Returns True (continue) when any of redis/thread_id/token is None — this
+    is the fail-open path. Used to gate the agent's LLM call and persist loop
+    behind an "are we still the current generation?" check.
+
+    Returns False when the stored token doesn't match OR is missing (TTL
+    expired or someone explicitly cleared it). Treating "missing" as
+    superseded is intentional: an LLM call that takes longer than the TTL
+    is an outlier and is safer to drop than to write potentially-stale
+    suggestions over a newer generation's work.
+    """
+    if redis is None or thread_id is None or token is None:
+        return True
+    stored = await redis.get(_KEY_FMT.format(thread_id=thread_id))
+    if stored is None:
+        return False
+    if isinstance(stored, bytes):
+        stored = stored.decode("utf-8")
+    return stored == token

--- a/services/api/src/api/classifier/models.py
+++ b/services/api/src/api/classifier/models.py
@@ -39,6 +39,7 @@ class SuggestedAction(StrEnum):
     DRAFT_EMAIL = "draft_email"
     ASK_COORDINATOR = "ask_coordinator"
     EXPIRE_SUGGESTION = "expire_suggestion"
+    UPDATE_ACTOR = "update_actor"
     NO_ACTION = "no_action"
 
 
@@ -83,6 +84,18 @@ class ExpireSuggestionData(BaseModel):
     suggestion_id: str
 
 
+class UpdateActorData(BaseModel):
+    """Action data for UPDATE_ACTOR — the agent asks the coordinator to set/replace
+    a loop's recruiter, client_manager, or client_contact.
+
+    Non-auto-resolvable: surfaces in the UI as a card with an autocomplete
+    (for internal roles) or plain inputs (for client_contact), so the
+    coordinator picks the new actor by hand. Variant of ASK_COORDINATOR.
+    """
+
+    role: Literal["recruiter", "client_manager", "client_contact"]
+
+
 class LinkThreadData(BaseModel):
     """Action data for LINK_THREAD — candidate/client identity for guardrail validation."""
 
@@ -120,6 +133,7 @@ ACTION_DATA_MODELS: dict[SuggestedAction, type[BaseModel]] = {
     SuggestedAction.LINK_THREAD: LinkThreadData,
     SuggestedAction.CREATE_LOOP: CreateLoopExtraction,
     SuggestedAction.EXPIRE_SUGGESTION: ExpireSuggestionData,
+    SuggestedAction.UPDATE_ACTOR: UpdateActorData,
 }
 
 

--- a/services/api/src/api/classifier/models.py
+++ b/services/api/src/api/classifier/models.py
@@ -38,6 +38,7 @@ class SuggestedAction(StrEnum):
     LINK_THREAD = "link_thread"
     DRAFT_EMAIL = "draft_email"
     ASK_COORDINATOR = "ask_coordinator"
+    EXPIRE_SUGGESTION = "expire_suggestion"
     NO_ACTION = "no_action"
 
 
@@ -76,6 +77,12 @@ class NoActionData(BaseModel):
     """Action data for NO_ACTION — empty by design."""
 
 
+class ExpireSuggestionData(BaseModel):
+    """Action data for EXPIRE_SUGGESTION — the pending suggestion to mark expired."""
+
+    suggestion_id: str
+
+
 class LinkThreadData(BaseModel):
     """Action data for LINK_THREAD — candidate/client identity for guardrail validation."""
 
@@ -112,6 +119,7 @@ ACTION_DATA_MODELS: dict[SuggestedAction, type[BaseModel]] = {
     SuggestedAction.NO_ACTION: NoActionData,
     SuggestedAction.LINK_THREAD: LinkThreadData,
     SuggestedAction.CREATE_LOOP: CreateLoopExtraction,
+    SuggestedAction.EXPIRE_SUGGESTION: ExpireSuggestionData,
 }
 
 

--- a/services/api/src/api/classifier/models.py
+++ b/services/api/src/api/classifier/models.py
@@ -91,9 +91,16 @@ class UpdateActorData(BaseModel):
     Non-auto-resolvable: surfaces in the UI as a card with an autocomplete
     (for internal roles) or plain inputs (for client_contact), so the
     coordinator picks the new actor by hand. Variant of ASK_COORDINATOR.
+
+    ``role`` is the only agent-emitted field. ``pending_pick`` is UI state
+    written by the addon's autocomplete onChange handler — it stages a
+    directory selection so the card can re-render with the inputs
+    pre-filled, requiring the coordinator to click Save before the change
+    commits. The agent never sets pending_pick.
     """
 
     role: Literal["recruiter", "client_manager", "client_contact"]
+    pending_pick: dict[str, str] | None = None
 
 
 class LinkThreadData(BaseModel):

--- a/services/api/src/api/classifier/next_action_agent.py
+++ b/services/api/src/api/classifier/next_action_agent.py
@@ -69,6 +69,7 @@ _AGENT_ALLOWED_ACTIONS = frozenset(
         SuggestedAction.DRAFT_EMAIL,
         SuggestedAction.ASK_COORDINATOR,
         SuggestedAction.EXPIRE_SUGGESTION,
+        SuggestedAction.UPDATE_ACTOR,
         SuggestedAction.NO_ACTION,
     }
 )
@@ -594,10 +595,10 @@ class NextActionAgent:
     ) -> tuple[SuggestionItem, str | None]:
         """Per-item guardrails. Returns (item, error_message)."""
         if item.action not in _AGENT_ALLOWED_ACTIONS:
+            allowed = ", ".join(sorted(a.value for a in _AGENT_ALLOWED_ACTIONS))
             return item, (
                 f"Action '{item.action}' is not allowed for the next action agent — "
-                "only advance_stage, draft_email, ask_coordinator, expire_suggestion, "
-                "and no_action are allowed"
+                f"allowed actions: {allowed}"
             )
 
         model_cls = ACTION_DATA_MODELS.get(item.action)

--- a/services/api/src/api/classifier/next_action_agent.py
+++ b/services/api/src/api/classifier/next_action_agent.py
@@ -4,27 +4,36 @@ Processes both inbound and outgoing emails. Decides on next steps:
 - Advance the loop's state (ADVANCE_STAGE — auto-resolved)
 - Draft an email (DRAFT_EMAIL — generates draft for coordinator review)
 - Ask the coordinator a question (ASK_COORDINATOR)
+- Expire a stale pending suggestion (EXPIRE_SUGGESTION — auto-resolved)
 - No action (NO_ACTION)
 
 CREATE_LOOP and LINK_THREAD are blacklisted to prevent recursion.
+
+I/O contract (new prompt):
+- Input is four XML-formatted template variables: ``date``, ``thread_history``,
+  ``email``, ``loops``.
+- Output is a JSON array wrapped in ``<suggestions>…</suggestions>`` tags.
+- Retries (errors, coordinator responses) ride the LLM conversation history
+  rather than being threaded back through input fields.
 """
 
 from __future__ import annotations
 
 import json
 import logging
+import re
 from datetime import UTC, datetime
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Any
 
+from langfuse.model import ChatPromptClient
 from pydantic import ValidationError
 
-from api.classifier.endpoints import determine_next_action
+from api.ai.langfuse_client import fetch_prompt
+from api.ai.llm_service import DEFAULT_MODEL
 from api.classifier.formatters import (
-    format_email,
-    format_events,
-    format_linked_loops,
-    format_pending_suggestions,
-    format_thread_history,
+    format_email_xml,
+    format_loops_xml,
+    format_thread_history_xml,
 )
 from api.classifier.models import (
     ACTION_DATA_MODELS,
@@ -40,18 +49,16 @@ from api.classifier.resolvers import (
 from api.classifier.schemas import NextActionInput
 
 if TYPE_CHECKING:
-    from collections.abc import Callable
-
     from arq.connections import ArqRedis
     from langfuse import Langfuse
 
-    from api.ai.llm_service import LLMService
+    from api.ai.llm_service import LLMResponse, LLMService
     from api.classifier.models import Suggestion
     from api.classifier.service import SuggestionService
     from api.drafts.service import DraftService
     from api.gmail.hooks import EmailEvent
     from api.gmail.models import Message
-    from api.scheduling.models import Coordinator, Loop
+    from api.scheduling.models import Loop
     from api.scheduling.service import LoopService
 
 logger = logging.getLogger(__name__)
@@ -61,28 +68,13 @@ _AGENT_ALLOWED_ACTIONS = frozenset(
         SuggestedAction.ADVANCE_STAGE,
         SuggestedAction.DRAFT_EMAIL,
         SuggestedAction.ASK_COORDINATOR,
+        SuggestedAction.EXPIRE_SUGGESTION,
         SuggestedAction.NO_ACTION,
     }
 )
 
-
-def _resolve_coordinator_name(event: EmailEvent, coord: Coordinator | None) -> str:
-    if coord and coord.name:
-        return coord.name
-
-    msg = event.message
-    addr_email = event.coordinator_email
-    candidates: list[str | None] = []
-    if msg.from_.email == addr_email:
-        candidates.append(msg.from_.name)
-    for addr in [*msg.to, *msg.cc]:
-        if addr.email == addr_email:
-            candidates.append(addr.name)
-    for name in candidates:
-        if name:
-            return name
-
-    return addr_email.split("@", 1)[0]
+_SUGGESTIONS_RE = re.compile(r"<suggestions>(.*?)</suggestions>", re.DOTALL)
+_JSON_ARRAY_RE = re.compile(r"\[[\s\S]*\]")
 
 
 def _suggestion_fingerprint(loop_id: str | None, action: str, action_data: dict) -> str:
@@ -90,23 +82,8 @@ def _suggestion_fingerprint(loop_id: str | None, action: str, action_data: dict)
     return f"{loop_id or ''}|{action}|{json.dumps(action_data, sort_keys=True, default=str)}"
 
 
-def _format_per_loop_actors(
-    loops: list[Loop],
-    extract: Callable[[Loop], str | None],
-) -> str:
-    """Format a per-loop actor field.
-
-    Single loop → plain name.  Multiple loops → "- lop_id: Name" per loop.
-    """
-    if not loops:
-        return "Unknown"
-    if len(loops) == 1:
-        return extract(loops[0]) or "Unknown"
-    lines: list[str] = []
-    for lp in loops:
-        name = extract(lp) or "Unknown"
-        lines.append(f"- {lp.id}: {name}")
-    return "\n".join(lines)
+class NextActionAgentError(Exception):
+    """Raised when the agent cannot produce a usable response."""
 
 
 class NextActionAgent:
@@ -135,6 +112,7 @@ class NextActionAgent:
         *,
         arq_pool: ArqRedis | None = None,
         coordinator_response: str | None = None,
+        originating_suggestion: Suggestion | None = None,
     ) -> None:
         msg = event.message
 
@@ -142,15 +120,34 @@ class NextActionAgent:
             event,
             linked_loops,
             event.thread_messages,
-            coordinator_response=coordinator_response,
         )
 
         try:
-            result: ClassificationResult = await determine_next_action(
-                llm=self._llm,
-                langfuse=self._langfuse,
-                data=context_input,
-            )
+            prompt = fetch_prompt(self._langfuse, "next-action-agent")
+            with self._langfuse.start_as_current_observation(
+                name="next-action-agent",
+                input=context_input.model_dump(),
+            ):
+                self._langfuse.update_current_span(
+                    metadata={
+                        "prompt_name": "next-action-agent",
+                        "prompt_version": prompt.version,
+                        "prompt_labels": prompt.labels,
+                    }
+                )
+                messages = self._build_initial_messages(
+                    prompt,
+                    context_input,
+                    coordinator_response=coordinator_response,
+                    originating_suggestion=originating_suggestion,
+                )
+                valid_items = await self._act_with_messages(
+                    prompt,
+                    messages,
+                    linked_loops,
+                    existing_pending,
+                    allow_retry=True,
+                )
         except Exception:
             logger.exception(
                 "next action agent failed for message %s on thread %s",
@@ -163,7 +160,7 @@ class NextActionAgent:
                 gmail_thread_id=msg.thread_id,
                 item=SuggestionItem(
                     classification="follow_up_needed",
-                    action="ask_coordinator",
+                    action=SuggestedAction.ASK_COORDINATOR,
                     confidence=0.0,
                     summary="Action determination failed — please review this email manually.",
                     reasoning="LLM call failed",
@@ -178,56 +175,6 @@ class NextActionAgent:
                 loop_id=linked_loops[0].id if linked_loops else None,
             )
             return
-
-        # Apply guardrails with error-driven retry
-        guardrail_errors: list[str] = []
-        valid_items: list[tuple[SuggestionItem, Loop | None]] = []
-
-        for item in result.suggestions:
-            target_loop, loop_error = self._resolve_target_loop(item, linked_loops)
-
-            if loop_error:
-                guardrail_errors.append(loop_error)
-                continue
-
-            # If we defaulted to the single linked loop, pin its id on the item
-            # so guardrails (and persistence) see a populated target_loop_id.
-            if target_loop and not item.target_loop_id:
-                item = item.model_copy(update={"target_loop_id": target_loop.id})
-
-            item, error = self._apply_guardrails(item)
-            if error:
-                guardrail_errors.append(error)
-            else:
-                valid_items.append((item, target_loop))
-
-        if guardrail_errors and not valid_items:
-            error_msg = "; ".join(guardrail_errors)
-            logger.info(
-                "all agent suggestions failed guardrails, retrying with error: %s",
-                error_msg,
-            )
-            retry_input = context_input.model_copy(update={"error": error_msg})
-            try:
-                result = await determine_next_action(
-                    llm=self._llm,
-                    langfuse=self._langfuse,
-                    data=retry_input,
-                )
-            except Exception:
-                logger.exception("next action agent retry failed for thread %s", msg.thread_id)
-                return
-
-            valid_items = []
-            for item in result.suggestions:
-                target_loop, loop_error = self._resolve_target_loop(item, linked_loops)
-                if loop_error:
-                    continue
-                if target_loop and not item.target_loop_id:
-                    item = item.model_copy(update={"target_loop_id": target_loop.id})
-                item, error = self._apply_guardrails(item)
-                if not error:
-                    valid_items.append((item, target_loop))
 
         seen_fingerprints: set[str] = {
             _suggestion_fingerprint(s.loop_id, s.action, s.action_data) for s in existing_pending
@@ -250,7 +197,7 @@ class NextActionAgent:
                 gmail_message_id=msg.id,
                 gmail_thread_id=msg.thread_id,
                 item=item,
-                reasoning=result.reasoning,
+                reasoning=item.reasoning,
                 loop_id=loop_id,
             )
 
@@ -291,80 +238,283 @@ class NextActionAgent:
                 except Exception:
                     logger.exception("draft creation failed for suggestion %s", suggestion.id)
 
+    # ------------------------------------------------------------------
+    # Conversation pipeline
+    # ------------------------------------------------------------------
+
+    async def _act_with_messages(
+        self,
+        prompt: Any,
+        messages: list[dict[str, str]],
+        linked_loops: list[Loop],
+        existing_pending: list[Suggestion],
+        *,
+        allow_retry: bool,
+    ) -> list[tuple[SuggestionItem, Loop | None]]:
+        """Run one LLM round-trip and validate the result.
+
+        On batch/per-item errors, optionally append the assistant reply plus a
+        user follow-up describing the errors and recurse once with
+        ``allow_retry=False``.
+        """
+        response = await self._call_llm(prompt, messages)
+        try:
+            result = self._parse_response(response.content)
+        except NextActionAgentError as exc:
+            if allow_retry:
+                logger.warning("next-action-agent parse failed (%s) — retrying with follow-up", exc)
+                follow_up = (
+                    "Your previous response could not be parsed. "
+                    f"Error: {exc}\n\n"
+                    "Please respond with a valid <suggestions>[...]</suggestions> "
+                    "JSON array."
+                )
+                next_messages = [
+                    *messages,
+                    {"role": "assistant", "content": response.content},
+                    {"role": "user", "content": follow_up},
+                ]
+                return await self._act_with_messages(
+                    prompt, next_messages, linked_loops, existing_pending, allow_retry=False
+                )
+            raise
+
+        valid_items, errors = self._validate_batch(
+            result.suggestions, linked_loops, existing_pending
+        )
+
+        if errors and allow_retry:
+            logger.info(
+                "next-action-agent batch errors (%d) — retrying with follow-up", len(errors)
+            )
+            follow_up = _build_error_followup(errors)
+            next_messages = [
+                *messages,
+                {"role": "assistant", "content": response.content},
+                {"role": "user", "content": follow_up},
+            ]
+            return await self._act_with_messages(
+                prompt, next_messages, linked_loops, existing_pending, allow_retry=False
+            )
+
+        if errors:
+            logger.warning(
+                "next-action-agent retry still produced %d error(s) — keeping %d valid item(s)",
+                len(errors),
+                len(valid_items),
+            )
+
+        return valid_items
+
+    async def _call_llm(self, prompt: Any, messages: list[dict[str, str]]) -> LLMResponse:
+        """Dispatch the conversation to the LLM service.
+
+        Model config is sourced from the prompt's LangFuse config so prompt-
+        version-pinned settings win.
+        """
+        config: dict = prompt.config or {}
+        model = config.get("model", DEFAULT_MODEL)
+        temperature = config.get("temperature", 0.0)
+        max_tokens = config.get("max_tokens", 4096)
+
+        return await self._llm.complete(
+            messages=messages,
+            model=model,
+            temperature=temperature,
+            max_tokens=max_tokens,
+        )
+
+    def _build_initial_messages(
+        self,
+        prompt: Any,
+        context_input: NextActionInput,
+        *,
+        coordinator_response: str | None,
+        originating_suggestion: Suggestion | None,
+    ) -> list[dict[str, str]]:
+        """Compile the prompt + (optionally) splice in the prior turn."""
+        input_dict = context_input.model_dump()
+
+        if isinstance(prompt, ChatPromptClient):
+            compiled = prompt.compile(**input_dict)
+            messages: list[dict[str, str]] = [dict(m) for m in compiled]
+        else:
+            compiled_str = prompt.compile(**input_dict)
+            messages = [
+                {"role": "system", "content": compiled_str},
+                {"role": "user", "content": json.dumps(input_dict)},
+            ]
+
+        if coordinator_response is not None and originating_suggestion is not None:
+            # Splice the prior turn into the conversation so the LLM sees the
+            # question it had asked and the coordinator's answer.
+            assistant_content = _reconstruct_prior_assistant(originating_suggestion)
+            messages.append({"role": "assistant", "content": assistant_content})
+            messages.append(
+                {
+                    "role": "user",
+                    "content": (
+                        "The coordinator responded with the following:\n" f"{coordinator_response}"
+                    ),
+                }
+            )
+
+        return messages
+
+    # ------------------------------------------------------------------
+    # Parsing
+    # ------------------------------------------------------------------
+
+    def _parse_response(self, content: str) -> ClassificationResult:
+        """Extract the <suggestions> JSON array from the LLM response."""
+        text = content.strip()
+        # Strip surrounding markdown fences, if any.
+        if text.startswith("```"):
+            lines = text.split("\n")
+            if len(lines) >= 2 and lines[-1].strip() == "```":
+                text = "\n".join(lines[1:-1]).strip()
+
+        match = _SUGGESTIONS_RE.search(text)
+        if match:
+            inner = match.group(1).strip()
+        else:
+            # Fallback: pull the first JSON array we can find.
+            array_match = _JSON_ARRAY_RE.search(text)
+            if not array_match:
+                raise NextActionAgentError(
+                    "response did not contain a <suggestions>…</suggestions> envelope or "
+                    "a JSON array"
+                )
+            inner = array_match.group(0)
+
+        try:
+            data = json.loads(inner)
+        except json.JSONDecodeError as exc:
+            raise NextActionAgentError(f"suggestions JSON failed to parse: {exc}") from exc
+
+        if not isinstance(data, list):
+            raise NextActionAgentError("suggestions payload must be a JSON array")
+
+        suggestions: list[SuggestionItem] = []
+        for raw in data:
+            try:
+                suggestions.append(SuggestionItem.model_validate(raw))
+            except ValidationError as exc:
+                raise NextActionAgentError(
+                    f"suggestion item failed schema validation: {exc}"
+                ) from exc
+
+        return ClassificationResult(suggestions=suggestions)
+
+    # ------------------------------------------------------------------
+    # Context building
+    # ------------------------------------------------------------------
+
     async def _build_context(
         self,
         event: EmailEvent,
         linked_loops: list[Loop],
         thread_messages: list[Message] | None = None,
-        *,
-        coordinator_response: str | None = None,
     ) -> tuple[NextActionInput, list[Suggestion]]:
         msg = event.message
 
         if thread_messages:
-            thread_history_text = format_thread_history(thread_messages, msg.id)
+            thread_history_xml = format_thread_history_xml(
+                thread_messages, msg.id, event.coordinator_email
+            )
         else:
-            thread_history_text = "No prior messages in this thread."
+            thread_history_xml = "<!-- No prior messages in this thread -->"
 
-        coord = await self._loops.get_coordinator_by_email(event.coordinator_email)
-        coordinator_name = _resolve_coordinator_name(event, coord)
         date_str = datetime.now(UTC).date().isoformat()
 
-        events = []
-        if linked_loops:
-            events = await self._loops.get_events(linked_loops[0].id)
-
-        candidate_name = _format_per_loop_actors(
-            linked_loops, lambda lp: lp.candidate.name if lp.candidate else None
-        )
-        recruiter_name = _format_per_loop_actors(
-            linked_loops, lambda lp: lp.recruiter.name if lp.recruiter else None
-        )
-
-        # Client/company are shared across loops on a thread — take the first non-null.
-        client_name = "Unknown"
-        client_company = "Unknown"
-        for lp in linked_loops:
-            if lp.client_contact:
-                if lp.client_contact.name:
-                    client_name = lp.client_contact.name
-                if lp.client_contact.company:
-                    client_company = lp.client_contact.company
-                break
-
         all_pending: list[Suggestion] = []
+        pending_by_loop: dict[str, list[Suggestion]] = {}
         for lp in linked_loops:
-            all_pending.extend(await self._suggestions.get_pending_for_loop(lp.id))
+            loop_pending = await self._suggestions.get_pending_for_loop(lp.id)
+            pending_by_loop[lp.id] = loop_pending
+            all_pending.extend(loop_pending)
 
-        return NextActionInput(
-            coordinator_name=coordinator_name,
-            coordinator_email=event.coordinator_email,
-            date=date_str,
-            candidate_name=candidate_name,
-            recruiter_name=recruiter_name,
-            client_name=client_name,
-            client_company=client_company,
-            direction=event.direction.value,
-            email=format_email(msg, event.direction.value, event.message_type.value),
-            thread_history=thread_history_text,
-            loop_state=format_linked_loops(linked_loops),
-            events=format_events(events),
-            error="N/A",
-            pending_suggestions=format_pending_suggestions(all_pending),
-            coordinator_response=coordinator_response or "No active questions.",
-        ), all_pending
+        return (
+            NextActionInput(
+                date=date_str,
+                thread_history=thread_history_xml,
+                email=format_email_xml(msg, event.direction.value),
+                loops=format_loops_xml(linked_loops, pending_by_loop),
+            ),
+            all_pending,
+        )
+
+    # ------------------------------------------------------------------
+    # Guardrails
+    # ------------------------------------------------------------------
+
+    def _validate_batch(
+        self,
+        suggestions: list[SuggestionItem],
+        linked_loops: list[Loop],
+        existing_pending: list[Suggestion],
+    ) -> tuple[list[tuple[SuggestionItem, Loop | None]], list[str]]:
+        """Per-item validation + batch-level guardrails.
+
+        Returns (valid_items, errors). Valid items may still be returned
+        alongside errors; the caller decides whether to retry.
+        """
+        errors: list[str] = []
+        valid: list[tuple[SuggestionItem, Loop | None]] = []
+
+        pending_ids = {s.id for s in existing_pending}
+
+        for item in suggestions:
+            target_loop, loop_error = self._resolve_target_loop(item, linked_loops)
+            if loop_error:
+                errors.append(loop_error)
+                continue
+            if target_loop and not item.target_loop_id:
+                item = item.model_copy(update={"target_loop_id": target_loop.id})
+
+            item, item_error = self._apply_guardrails(item, pending_ids)
+            if item_error:
+                errors.append(item_error)
+                continue
+
+            valid.append((item, target_loop))
+
+        # Batch-level: recruiter draft cap.
+        recruiter_drafts = sum(
+            1
+            for it, _ in valid
+            if it.action == SuggestedAction.DRAFT_EMAIL
+            and it.action_data.get("recipient_type") == "recruiter"
+        )
+        known_recruiters = len({lp.recruiter_id for lp in linked_loops if lp.recruiter_id})
+        if recruiter_drafts > known_recruiters:
+            errors.append(
+                f"Too many recruiter draft emails ({recruiter_drafts}) for "
+                f"{known_recruiters} known recruiter(s) on this thread — combine updates "
+                "so each recruiter receives a single email covering all of their candidates."
+            )
+
+        # Batch-level: only one client draft per generation.
+        client_drafts = sum(
+            1
+            for it, _ in valid
+            if it.action == SuggestedAction.DRAFT_EMAIL
+            and it.action_data.get("recipient_type") == "client"
+        )
+        if client_drafts > 1:
+            errors.append(
+                "Multiple client draft emails were proposed — combine them into a single "
+                "client-facing email for this generation."
+            )
+
+        return valid, errors
 
     def _resolve_target_loop(
         self,
         item: SuggestionItem,
         linked_loops: list[Loop],
     ) -> tuple[Loop | None, str | None]:
-        """Resolve the target loop for a suggestion. Returns (loop, error).
-
-        The agent only operates on linked threads, so target_loop_id is required
-        for every action. The guardrail layer enforces that — this just maps the
-        ID to a Loop instance.
-        """
+        """Resolve the target loop for a suggestion. Returns (loop, error)."""
         loop_ids = [lp.id for lp in linked_loops]
 
         if item.target_loop_id:
@@ -376,9 +526,6 @@ class NextActionAgent:
                 f"Available loop IDs: {', '.join(loop_ids)}"
             )
 
-        # No target_loop_id — fine only if exactly one loop is linked AND we
-        # default to that loop. The required-target_loop_id guardrail then
-        # tags the suggestion with the resolved id at persistence time.
         if len(linked_loops) == 1:
             return linked_loops[0], None
 
@@ -390,38 +537,73 @@ class NextActionAgent:
     def _apply_guardrails(
         self,
         item: SuggestionItem,
+        pending_ids: set[str],
     ) -> tuple[SuggestionItem, str | None]:
-        """Apply guardrails. Returns (item, error_message). error_message is None if valid."""
-        # 1. Action allow-list
+        """Per-item guardrails. Returns (item, error_message)."""
         if item.action not in _AGENT_ALLOWED_ACTIONS:
-            return (
-                item.model_copy(update={"action": SuggestedAction.NO_ACTION}),
+            return item, (
                 f"Action '{item.action}' is not allowed for the next action agent — "
-                f"only advance_stage, draft_email, ask_coordinator, and no_action are allowed",
+                "only advance_stage, draft_email, ask_coordinator, expire_suggestion, "
+                "and no_action are allowed"
             )
 
-        # 2. action_data shape match
         model_cls = ACTION_DATA_MODELS.get(item.action)
         if model_cls is None:
-            return (
-                item.model_copy(update={"action": SuggestedAction.NO_ACTION}),
-                f"action '{item.action}' has no action_data schema",
-            )
+            return item, f"action '{item.action}' has no action_data schema"
         try:
             model_cls.model_validate(item.action_data)
         except ValidationError as e:
-            return (
-                item.model_copy(update={"action": SuggestedAction.NO_ACTION}),
-                f"action_data for '{item.action}' is invalid: {e}",
+            return item, f"action_data for '{item.action}' is invalid: {e}"
+
+        if not item.target_loop_id:
+            return item, (
+                f"action '{item.action}' requires target_loop_id "
+                "(the agent always acts on a linked loop)"
             )
 
-        # 3. target_loop_id required for all agent actions (the agent only
-        #    operates on linked threads, so every suggestion is *about* a loop)
-        if not item.target_loop_id:
-            return (
-                item.model_copy(update={"action": SuggestedAction.NO_ACTION}),
-                f"action '{item.action}' requires target_loop_id "
-                f"(the agent always acts on a linked loop)",
-            )
+        if item.action == SuggestedAction.EXPIRE_SUGGESTION:
+            target_sug_id = item.action_data.get("suggestion_id")
+            if target_sug_id not in pending_ids:
+                return item, (
+                    f"expire_suggestion target '{target_sug_id}' is not a known pending "
+                    "suggestion on this thread."
+                )
 
         return item, None
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _build_error_followup(errors: list[str]) -> str:
+    bullets = "\n".join(f"- {e}" for e in errors)
+    return (
+        "Your previous suggestions resulted in the following errors:\n"
+        f"{bullets}\n\n"
+        "Please produce a corrected <suggestions>[...]</suggestions> array."
+    )
+
+
+def _reconstruct_prior_assistant(suggestion: Suggestion) -> str:
+    """Re-serialize a resolved suggestion as the prior assistant turn.
+
+    Good enough for the coordinator-response flow: the model sees that it had
+    asked the question. We don't try to reconstruct sibling suggestions from
+    the same generation — keeping things simple and stateless.
+    """
+    payload: dict[str, Any] = {
+        "classification": suggestion.classification.value
+        if hasattr(suggestion.classification, "value")
+        else suggestion.classification,
+        "action": suggestion.action.value
+        if hasattr(suggestion.action, "value")
+        else suggestion.action,
+        "confidence": suggestion.confidence,
+        "summary": suggestion.summary,
+        "reasoning": suggestion.reasoning or "",
+        "target_loop_id": suggestion.loop_id,
+        "action_data": suggestion.action_data or {},
+    }
+    return f"<suggestions>{json.dumps([payload])}</suggestions>"

--- a/services/api/src/api/classifier/next_action_agent.py
+++ b/services/api/src/api/classifier/next_action_agent.py
@@ -141,12 +141,27 @@ class NextActionAgent:
                     coordinator_response=coordinator_response,
                     originating_suggestion=originating_suggestion,
                 )
-                valid_items = await self._act_with_messages(
+                valid_items, raw_responses = await self._act_with_messages(
                     prompt,
                     messages,
                     linked_loops,
                     existing_pending,
                     allow_retry=True,
+                )
+                self._langfuse.update_current_span(
+                    output={
+                        "suggestions": [
+                            {
+                                "action": item.action,
+                                "target_loop_id": item.target_loop_id,
+                                "summary": item.summary,
+                                "action_data": item.action_data,
+                                "confidence": item.confidence,
+                            }
+                            for item, _ in valid_items
+                        ],
+                        "raw_responses": raw_responses,
+                    }
                 )
         except Exception:
             logger.exception(
@@ -250,14 +265,22 @@ class NextActionAgent:
         existing_pending: list[Suggestion],
         *,
         allow_retry: bool,
-    ) -> list[tuple[SuggestionItem, Loop | None]]:
+        prior_responses: list[str] | None = None,
+    ) -> tuple[list[tuple[SuggestionItem, Loop | None]], list[str]]:
         """Run one LLM round-trip and validate the result.
 
         On batch/per-item errors, optionally append the assistant reply plus a
         user follow-up describing the errors and recurse once with
         ``allow_retry=False``.
+
+        Returns ``(valid_items, raw_responses)`` where ``raw_responses`` is the
+        full list of assistant payloads across the initial call and any retry —
+        captured on the span output so LangFuse traces show what the model
+        produced even if guardrails dropped items.
         """
+        prior_responses = prior_responses or []
         response = await self._call_llm(prompt, messages)
+        responses = [*prior_responses, response.content]
         try:
             result = self._parse_response(response.content)
         except NextActionAgentError as exc:
@@ -275,7 +298,12 @@ class NextActionAgent:
                     {"role": "user", "content": follow_up},
                 ]
                 return await self._act_with_messages(
-                    prompt, next_messages, linked_loops, existing_pending, allow_retry=False
+                    prompt,
+                    next_messages,
+                    linked_loops,
+                    existing_pending,
+                    allow_retry=False,
+                    prior_responses=responses,
                 )
             raise
 
@@ -294,7 +322,12 @@ class NextActionAgent:
                 {"role": "user", "content": follow_up},
             ]
             return await self._act_with_messages(
-                prompt, next_messages, linked_loops, existing_pending, allow_retry=False
+                prompt,
+                next_messages,
+                linked_loops,
+                existing_pending,
+                allow_retry=False,
+                prior_responses=responses,
             )
 
         if errors:
@@ -304,7 +337,7 @@ class NextActionAgent:
                 len(valid_items),
             )
 
-        return valid_items
+        return valid_items, responses
 
     async def _call_llm(self, prompt: Any, messages: list[dict[str, str]]) -> LLMResponse:
         """Dispatch the conversation to the LLM service.

--- a/services/api/src/api/classifier/next_action_agent.py
+++ b/services/api/src/api/classifier/next_action_agent.py
@@ -113,6 +113,7 @@ class NextActionAgent:
         arq_pool: ArqRedis | None = None,
         coordinator_response: str | None = None,
         originating_suggestion: Suggestion | None = None,
+        rejected_suggestion: Suggestion | None = None,
     ) -> None:
         msg = event.message
 
@@ -140,6 +141,7 @@ class NextActionAgent:
                     context_input,
                     coordinator_response=coordinator_response,
                     originating_suggestion=originating_suggestion,
+                    rejected_suggestion=rejected_suggestion,
                 )
                 valid_items, raw_responses = await self._act_with_messages(
                     prompt,
@@ -194,6 +196,16 @@ class NextActionAgent:
         seen_fingerprints: set[str] = {
             _suggestion_fingerprint(s.loop_id, s.action, s.action_data) for s in existing_pending
         }
+        # The just-rejected suggestion isn't in pending (it's REJECTED), but we
+        # must not let the agent re-emit it verbatim after a rejection re-run.
+        if rejected_suggestion is not None:
+            seen_fingerprints.add(
+                _suggestion_fingerprint(
+                    rejected_suggestion.loop_id,
+                    rejected_suggestion.action,
+                    rejected_suggestion.action_data,
+                )
+            )
 
         for item, target_loop in valid_items:
             loop_id = target_loop.id if target_loop else None
@@ -364,6 +376,7 @@ class NextActionAgent:
         *,
         coordinator_response: str | None,
         originating_suggestion: Suggestion | None,
+        rejected_suggestion: Suggestion | None = None,
     ) -> list[dict[str, str]]:
         """Compile the prompt + (optionally) splice in the prior turn."""
         input_dict = context_input.model_dump()
@@ -391,6 +404,13 @@ class NextActionAgent:
                     ),
                 }
             )
+        elif rejected_suggestion is not None:
+            # The coordinator dismissed the prior suggestion. We have no "why"
+            # signal — just the fact of rejection. Tell the model to try a
+            # materially different alternative or prefer no_action.
+            assistant_content = _reconstruct_prior_assistant(rejected_suggestion)
+            messages.append({"role": "assistant", "content": assistant_content})
+            messages.append({"role": "user", "content": _REJECTION_FOLLOWUP_TEXT})
 
         return messages
 
@@ -608,6 +628,17 @@ class NextActionAgent:
 # ---------------------------------------------------------------------------
 # Helpers
 # ---------------------------------------------------------------------------
+
+
+_REJECTION_FOLLOWUP_TEXT = (
+    "The coordinator rejected the previous suggestion. "
+    "We do NOT know why they rejected it.\n\n"
+    "Propose a materially different alternative — for example: a different "
+    "recipient, a different action type, or substantively different content. "
+    "Do NOT repeat the rejected suggestion with cosmetic changes.\n\n"
+    "If no materially different alternative is appropriate, emit no_action. "
+    "It is better to do nothing than to propose another likely-bad option."
+)
 
 
 def _build_error_followup(errors: list[str]) -> str:

--- a/services/api/src/api/classifier/next_action_agent.py
+++ b/services/api/src/api/classifier/next_action_agent.py
@@ -142,13 +142,19 @@ class NextActionAgent:
             prompt = fetch_prompt(self._langfuse, "next-action-agent")
             with self._langfuse.start_as_current_observation(
                 name="next-action-agent",
-                input=context_input.model_dump(),
             ):
+                # Span's ``input`` is set inside _call_llm to the live messages
+                # list at the moment of each LLM round-trip — that captures
+                # retry follow-ups (error feedback, coordinator responses,
+                # rejection prompts) that wouldn't be visible if we just
+                # serialized the NextActionInput dataclass. The structured
+                # context lives in metadata for reference.
                 self._langfuse.update_current_span(
                     metadata={
                         "prompt_name": "next-action-agent",
                         "prompt_version": prompt.version,
                         "prompt_labels": prompt.labels,
+                        "context": context_input.model_dump(),
                     }
                 )
                 messages = self._build_initial_messages(
@@ -414,11 +420,21 @@ class NextActionAgent:
 
         Model config is sourced from the prompt's LangFuse config so prompt-
         version-pinned settings win.
+
+        Updates the current LangFuse span's ``input`` to the messages list
+        we're about to send. Retries append assistant + user-feedback turns
+        to ``messages`` and recurse through this function, so the final span
+        input reflects the complete conversation the model saw — including
+        error follow-ups, coordinator responses, and rejection feedback.
+        Without this update the trace shows our internal ``NextActionInput``
+        dataclass rather than the actual prompt + retry history.
         """
         config: dict = prompt.config or {}
         model = config.get("model", DEFAULT_MODEL)
         temperature = config.get("temperature", 0.0)
         max_tokens = config.get("max_tokens", 4096)
+
+        self._langfuse.update_current_span(input=messages)
 
         return await self._llm.complete(
             messages=messages,

--- a/services/api/src/api/classifier/next_action_agent.py
+++ b/services/api/src/api/classifier/next_action_agent.py
@@ -85,7 +85,18 @@ def _suggestion_fingerprint(loop_id: str | None, action: str, action_data: dict)
 
 
 class NextActionAgentError(Exception):
-    """Raised when the agent cannot produce a usable response."""
+    """Raised when the agent cannot produce a usable response.
+
+    Carries ``raw_responses`` so the caller can write the unparsed LLM
+    output to the LangFuse span even when validation fails. Without this,
+    a parse failure (e.g., the model emits an out-of-enum classification
+    value) yields an empty trace output and we lose visibility into what
+    the model actually produced.
+    """
+
+    def __init__(self, message: str, *, raw_responses: list[str] | None = None):
+        super().__init__(message)
+        self.raw_responses = list(raw_responses or [])
 
 
 class NextActionAgent:
@@ -159,13 +170,27 @@ class NextActionAgent:
                         generation_token,
                     )
                     return
-                valid_items, raw_responses = await self._act_with_messages(
-                    prompt,
-                    messages,
-                    linked_loops,
-                    existing_pending,
-                    allow_retry=True,
-                )
+                try:
+                    valid_items, raw_responses = await self._act_with_messages(
+                        prompt,
+                        messages,
+                        linked_loops,
+                        existing_pending,
+                        allow_retry=True,
+                    )
+                except NextActionAgentError as exc:
+                    # The model produced something — we just couldn't use it
+                    # (schema mismatch, malformed JSON, etc.). Put the raw
+                    # content on the LangFuse span before the exception
+                    # escapes this with-block (the span closes on exit).
+                    # The outer except creates the manual-review fallback.
+                    self._langfuse.update_current_span(
+                        output={
+                            "raw_responses": exc.raw_responses,
+                            "parse_error": str(exc),
+                        }
+                    )
+                    raise
                 self._langfuse.update_current_span(
                     output={
                         "suggestions": [
@@ -346,7 +371,11 @@ class NextActionAgent:
                     allow_retry=False,
                     prior_responses=responses,
                 )
-            raise
+            # Final failure on the retry attempt — attach the accumulated
+            # responses so the caller can put them on the LangFuse span
+            # before falling through to the manual-review fallback. The bare
+            # ``raise`` would discard the responses list (and the trace).
+            raise NextActionAgentError(str(exc), raw_responses=responses) from exc
 
         valid_items, errors = self._validate_batch(
             result.suggestions, linked_loops, existing_pending

--- a/services/api/src/api/classifier/next_action_agent.py
+++ b/services/api/src/api/classifier/next_action_agent.py
@@ -35,6 +35,7 @@ from api.classifier.formatters import (
     format_loops_xml,
     format_thread_history_xml,
 )
+from api.classifier.generation import is_current_generation
 from api.classifier.models import (
     ACTION_DATA_MODELS,
     ClassificationResult,
@@ -115,6 +116,8 @@ class NextActionAgent:
         coordinator_response: str | None = None,
         originating_suggestion: Suggestion | None = None,
         rejected_suggestion: Suggestion | None = None,
+        generation_token: str | None = None,
+        generation_thread_id: str | None = None,
     ) -> None:
         msg = event.message
 
@@ -144,6 +147,18 @@ class NextActionAgent:
                     originating_suggestion=originating_suggestion,
                     rejected_suggestion=rejected_suggestion,
                 )
+                # Checkpoint 1: another worker may have started a newer run on
+                # this thread while we were building context. Skip the LLM
+                # round-trip entirely if we've been superseded.
+                if not await is_current_generation(
+                    arq_pool, generation_thread_id, generation_token
+                ):
+                    logger.info(
+                        "next-action-agent superseded before LLM (thread=%s, token=%s)",
+                        generation_thread_id,
+                        generation_token,
+                    )
+                    return
                 valid_items, raw_responses = await self._act_with_messages(
                     prompt,
                     messages,
@@ -191,6 +206,19 @@ class NextActionAgent:
                 ),
                 reasoning="LLM call failed",
                 loop_id=linked_loops[0].id if linked_loops else None,
+            )
+            return
+
+        # Checkpoint 2: the LLM call may have taken seconds. Another worker
+        # could have started and finished in that window. Drop our (possibly
+        # stale) suggestions rather than writing them on top of newer work.
+        if not await is_current_generation(arq_pool, generation_thread_id, generation_token):
+            logger.info(
+                "next-action-agent superseded after LLM "
+                "(thread=%s, token=%s, valid_items=%d) — dropping",
+                generation_thread_id,
+                generation_token,
+                len(valid_items),
             )
             return
 

--- a/services/api/src/api/classifier/resolvers.py
+++ b/services/api/src/api/classifier/resolvers.py
@@ -335,6 +335,13 @@ def build_agent_registry() -> dict[SuggestedAction, Resolver]:
     }
 
 
+# Single source of truth: which agent-side actions auto-resolve (and thus
+# never surface to the coordinator for manual accept/reject). Derived from
+# build_agent_registry() at import time so adding a new resolver auto-updates
+# any code that needs the negative (e.g., "what's manually resolvable").
+AGENT_AUTO_RESOLVE_ACTIONS: frozenset[SuggestedAction] = frozenset(build_agent_registry().keys())
+
+
 def build_registry() -> dict[SuggestedAction, Resolver]:
     """Combined registry — kept for backward compatibility."""
     return {**build_classifier_registry(), **build_agent_registry()}

--- a/services/api/src/api/classifier/resolvers.py
+++ b/services/api/src/api/classifier/resolvers.py
@@ -284,6 +284,37 @@ class LinkThreadResolver:
 
 
 # ---------------------------------------------------------------------------
+# EXPIRE_SUGGESTION
+# ---------------------------------------------------------------------------
+
+
+class ExpireSuggestionResolver:
+    """Mark a stale pending suggestion as expired.
+
+    Reads the target suggestion id from ``action_data["suggestion_id"]`` and
+    flips it to ``EXPIRED``. The expire suggestion itself is then marked
+    ``AUTO_APPLIED`` by ``try_auto_resolve``. If the target is no longer
+    pending (already accepted, rejected, etc.), the underlying SQL is a no-op.
+    """
+
+    async def resolve(self, suggestion: Suggestion, ctx: ResolverContext) -> None:
+        target_id = (suggestion.action_data or {}).get("suggestion_id")
+        if not target_id:
+            logger.warning(
+                "EXPIRE_SUGGESTION %s missing action_data.suggestion_id — skipping",
+                suggestion.id,
+            )
+            return
+
+        await ctx.suggestions.expire_by_id(target_id, resolved_by="agent")
+        logger.info(
+            "auto-expired suggestion %s via %s",
+            target_id,
+            suggestion.id,
+        )
+
+
+# ---------------------------------------------------------------------------
 # Registry
 # ---------------------------------------------------------------------------
 
@@ -300,6 +331,7 @@ def build_agent_registry() -> dict[SuggestedAction, Resolver]:
     """Auto-resolvers for the NextActionAgent (linked threads)."""
     return {
         SuggestedAction.ADVANCE_STAGE: AdvanceStageResolver(),
+        SuggestedAction.EXPIRE_SUGGESTION: ExpireSuggestionResolver(),
     }
 
 

--- a/services/api/src/api/classifier/router.py
+++ b/services/api/src/api/classifier/router.py
@@ -27,9 +27,27 @@ logger = logging.getLogger(__name__)
 INTERNAL_DOMAIN = "longridgepartners.com"
 
 
-def _is_internal_only(msg: Message) -> bool:
-    all_addresses = [msg.from_.email, *(a.email for a in msg.to), *(a.email for a in msg.cc)]
-    return all(addr.lower().endswith(f"@{INTERNAL_DOMAIN}") for addr in all_addresses)
+def _message_addresses(msg: Message) -> list[str]:
+    return [msg.from_.email, *(a.email for a in msg.to), *(a.email for a in msg.cc)]
+
+
+def _is_internal_only(msg: Message, thread_messages: list[Message] | None = None) -> bool:
+    """True iff every participant across the thread is at the internal domain.
+
+    We check the *thread* — not just the trigger message — because of cases like:
+      1. Client requests an interview (external sender).
+      2. Coordinator forwards the request to the recruiter (internal-only).
+      3. Recruiter replies with avails (internal-only trigger message).
+    The recruiter's reply on its own looks internal-only, but the thread is
+    clearly scheduling-related because the client is upstream. Looking at all
+    thread participants keeps step 3 eligible for loop creation.
+    """
+    messages = thread_messages if thread_messages else [msg]
+    for m in messages:
+        for addr in _message_addresses(m):
+            if not addr.lower().endswith(f"@{INTERNAL_DOMAIN}"):
+                return False
+    return True
 
 
 class EmailRouter:
@@ -81,9 +99,13 @@ class EmailRouter:
 
         # 3. Unlinked thread. Now the internal-only filter applies — random
         # LRP-to-LRP chatter shouldn't try to spawn a new scheduling loop.
-        if _is_internal_only(msg):
+        # Check the *thread* participants, not just the trigger message, so
+        # internal-only replies on a thread originally started by an external
+        # party (e.g., coordinator forwarded a client request to a recruiter,
+        # recruiter is now replying) still reach the classifier.
+        if _is_internal_only(msg, event.thread_messages):
             logger.debug(
-                "skipping internal-only email on unlinked thread %s (all participants @%s)",
+                "skipping internal-only thread %s (all participants across " "the thread are @%s)",
                 msg.thread_id,
                 INTERNAL_DOMAIN,
             )

--- a/services/api/src/api/classifier/router.py
+++ b/services/api/src/api/classifier/router.py
@@ -71,6 +71,7 @@ class EmailRouter:
         event: EmailEvent,
         *,
         arq_pool: ArqRedis | None = None,
+        generation_token: str | None = None,
     ) -> None:
         msg = event.message
 
@@ -94,7 +95,13 @@ class EmailRouter:
             # Linked thread → Next Action Agent (inbound and outgoing).
             # Internal-only messages are kept here: recruiter→coordinator on a
             # live loop is signal, not noise.
-            await self._agent.act(event, linked_loops, arq_pool=arq_pool)
+            await self._agent.act(
+                event,
+                linked_loops,
+                arq_pool=arq_pool,
+                generation_token=generation_token,
+                generation_thread_id=msg.thread_id if generation_token else None,
+            )
             return
 
         # 3. Unlinked thread. Now the internal-only filter applies — random

--- a/services/api/src/api/classifier/router.py
+++ b/services/api/src/api/classifier/router.py
@@ -65,28 +65,36 @@ class EmailRouter:
             )
             return
 
-        # 2. Internal-only messages
+        # 2. Check thread linkage. We need this BEFORE the internal-only filter
+        # because internal LRP-to-LRP traffic (recruiter sending avails to the
+        # coordinator, internal updates, etc.) is the substance of the work on
+        # a linked thread — dropping it would blind the agent to the very
+        # messages that drive a loop forward.
+        linked_loops = await self._loops.find_loops_by_thread(msg.thread_id)
+
+        if linked_loops:
+            # Linked thread → Next Action Agent (inbound and outgoing).
+            # Internal-only messages are kept here: recruiter→coordinator on a
+            # live loop is signal, not noise.
+            await self._agent.act(event, linked_loops, arq_pool=arq_pool)
+            return
+
+        # 3. Unlinked thread. Now the internal-only filter applies — random
+        # LRP-to-LRP chatter shouldn't try to spawn a new scheduling loop.
         if _is_internal_only(msg):
             logger.debug(
-                "skipping internal-only email on thread %s (all participants @%s)",
+                "skipping internal-only email on unlinked thread %s (all participants @%s)",
                 msg.thread_id,
                 INTERNAL_DOMAIN,
             )
             return
 
-        # 3. Check thread linkage
-        linked_loops = await self._loops.find_loops_by_thread(msg.thread_id)
+        # Only inbound messages on unlinked threads can create a new loop.
+        if event.direction == MessageDirection.OUTGOING:
+            logger.debug(
+                "skipping outgoing email on unlinked thread %s",
+                msg.thread_id,
+            )
+            return
 
-        if linked_loops:
-            # Linked thread → Next Action Agent (inbound and outgoing)
-            await self._agent.act(event, linked_loops, arq_pool=arq_pool)
-        else:
-            # Unlinked thread — only process inbound
-            if event.direction == MessageDirection.OUTGOING:
-                logger.debug(
-                    "skipping outgoing email on unlinked thread %s",
-                    msg.thread_id,
-                )
-                return
-
-            await self._classifier.classify(event, arq_pool=arq_pool)
+        await self._classifier.classify(event, arq_pool=arq_pool)

--- a/services/api/src/api/classifier/schemas.py
+++ b/services/api/src/api/classifier/schemas.py
@@ -28,20 +28,12 @@ class NextActionInput(BaseModel):
     """Template variables for the next-action-agent prompt.
 
     Used for emails (inbound or outgoing) on threads already linked to a loop.
+    All four fields are XML-formatted strings — the prompt parses them as
+    structured input. Conversational retries (errors, coordinator answers)
+    are handled via the LLM message history, not as input fields.
     """
 
-    coordinator_name: str
-    coordinator_email: str
     date: str
-    candidate_name: str
-    recruiter_name: str
-    client_name: str
-    client_company: str
-    direction: str
-    email: str
     thread_history: str
-    loop_state: str
-    events: str
-    error: str
-    pending_suggestions: str = "No current pending suggestions."
-    coordinator_response: str = "No active questions."
+    email: str
+    loops: str

--- a/services/api/src/api/classifier/service.py
+++ b/services/api/src/api/classifier/service.py
@@ -75,6 +75,17 @@ class SuggestionService:
             )
             return [_row_to_suggestion(r) for r in rows]
 
+    async def has_any_suggestions_for_thread(self, gmail_thread_id: str) -> bool:
+        """True iff any suggestion row exists for this thread, any status.
+
+        Heuristic for "has the agent run on this thread at least once?" — if
+        yes, the in-message sidebar shows "All caught up" instead of
+        "Generating suggestions…" when there's nothing pending.
+        """
+        async with self._pool.connection() as conn:
+            row = await queries.has_suggestion_for_thread(conn, gmail_thread_id=gmail_thread_id)
+            return row is not None
+
     async def get_pending_for_coordinator(self, coordinator_email: str) -> list[Suggestion]:
         async with self._pool.connection() as conn:
             rows = await _collect(

--- a/services/api/src/api/classifier/service.py
+++ b/services/api/src/api/classifier/service.py
@@ -112,6 +112,11 @@ class SuggestionService:
         async with self._pool.connection() as conn, conn.transaction():
             await queries.expire_old_suggestions(conn, cutoff=cutoff)
 
+    async def expire_by_id(self, suggestion_id: str, resolved_by: str = "agent") -> None:
+        """Expire a single pending suggestion by id. No-op if not pending."""
+        async with self._pool.connection() as conn, conn.transaction():
+            await queries.expire_suggestion(conn, id=suggestion_id, resolved_by=resolved_by)
+
 
 def _row_to_suggestion(row: tuple) -> Suggestion:
     """Tuple shape (15 cols):

--- a/services/api/src/api/classifier/service.py
+++ b/services/api/src/api/classifier/service.py
@@ -128,6 +128,20 @@ class SuggestionService:
         async with self._pool.connection() as conn, conn.transaction():
             await queries.expire_suggestion(conn, id=suggestion_id, resolved_by=resolved_by)
 
+    async def update_action_data(self, suggestion_id: str, action_data: dict) -> None:
+        """Replace a suggestion's action_data JSONB blob.
+
+        Used by the addon to stash UI-driven state (UPDATE_ACTOR's
+        ``pending_pick`` from the autocomplete onChange handler) so the card
+        can re-render with the staged values pre-filled in the inputs. The
+        coordinator must explicitly click Save to commit — autocomplete
+        selection alone never commits.
+        """
+        async with self._pool.connection() as conn, conn.transaction():
+            await queries.update_action_data(
+                conn, id=suggestion_id, action_data=json.dumps(action_data)
+            )
+
 
 def _row_to_suggestion(row: tuple) -> Suggestion:
     """Tuple shape (15 cols):

--- a/services/api/src/api/drafts/service.py
+++ b/services/api/src/api/drafts/service.py
@@ -36,8 +36,26 @@ def _is_forward_draft(
     to_emails: list[str],
     thread_messages: list[Message] | None,
     trigger_message_id: str | None = None,
+    recipient_type: str | None = None,
 ) -> bool:
-    """A draft is a forward when the recipient wasn't on the triggering message."""
+    """A draft is a forward when we'd be putting prior conversation in front of
+    a party who wasn't on the trigger message.
+
+    Special case: ``recipient_type == "client"`` is NEVER treated as a forward
+    even when the client wasn't on the triggering message. The trigger may be
+    an internal recruiter reply that happens to be the latest message on the
+    thread; quoting that to the client would leak internal LRP conversation
+    (the exact bug this guard prevents). Client-bound drafts always go out as
+    clean replies built from the draft body alone — the agent is expected to
+    summarize whatever it needs from the recruiter reply in its own words.
+
+    Non-client recipient types (``recruiter``, ``client_manager``, ``internal``)
+    retain the trigger-based detection — those are LRP folks, and forwarding
+    upstream context is the correct behavior (e.g., forwarding a client
+    request to a recruiter who hasn't seen the thread).
+    """
+    if recipient_type == "client":
+        return False
     if not thread_messages or not to_emails:
         return False
 
@@ -180,7 +198,12 @@ class DraftService:
             )
             body = body[:MAX_BODY_LENGTH] + "\n\n[Draft truncated — please review]"
 
-        is_forward = _is_forward_draft(to_emails, thread_messages, suggestion.gmail_message_id)
+        is_forward = _is_forward_draft(
+            to_emails,
+            thread_messages,
+            suggestion.gmail_message_id,
+            recipient_type=recipient_type,
+        )
 
         draft_id = make_id("drf")
         async with self._pool.connection() as conn, conn.transaction():

--- a/services/api/src/api/drafts/service.py
+++ b/services/api/src/api/drafts/service.py
@@ -170,7 +170,7 @@ class DraftService:
         to_emails, cc_emails = resolve_recipients(
             loop, recipient_type, sender_email=suggestion.coordinator_email
         )
-        subject = self._resolve_subject(loop)
+        subject = self._resolve_subject(loop, thread_messages)
 
         if len(body) > MAX_BODY_LENGTH:
             logger.warning(
@@ -280,5 +280,27 @@ class DraftService:
     # ------------------------------------------------------------------
 
     @staticmethod
-    def _resolve_subject(loop: Loop) -> str:
+    def _resolve_subject(loop: Loop, thread_messages: list[Message] | None = None) -> str:
+        """Outbound subject for a reply on this thread.
+
+        Mirrors the latest thread message's subject so Gmail on the recipient's
+        side threads our reply into the existing conversation. Per Google's
+        Gmail API threading rules (developers.google.com/gmail/api/guides/threads),
+        the Subject header must match the existing thread for the reply to
+        attach to it — even with threadId set and In-Reply-To/References
+        wired correctly. We prepend "Re: " only when the latest subject
+        doesn't already start with it (case-insensitive), so we don't stack
+        "Re: Re: Re:".
+
+        Falls back to the loop title when there's no thread history —
+        essentially unreachable today (drafts are always created on a linked
+        thread that has at least one message), but keeps the function total.
+        """
+        if thread_messages:
+            latest = max(thread_messages, key=lambda m: m.date)
+            subject = (latest.subject or "").strip()
+            if subject:
+                if subject.lower().startswith("re:"):
+                    return subject
+                return f"Re: {subject}"
         return f"Re: {loop.title}"

--- a/services/api/src/api/gmail/workers.py
+++ b/services/api/src/api/gmail/workers.py
@@ -451,6 +451,11 @@ async def process_coordinator_response(
     loop_service = ctx["loop_service"]
 
     try:
+        # Fetch the originating ask_coordinator suggestion so the agent can
+        # splice it into the LLM conversation history as the prior assistant
+        # turn. We read by id after the addon has already marked it ACCEPTED.
+        originating = await suggestion_svc.get_suggestion(suggestion_id)
+
         thread = await gmail.get_thread(coordinator_email, gmail_thread_id)
         if not thread.messages:
             logger.warning("empty thread %s — cannot process coordinator response", gmail_thread_id)
@@ -491,6 +496,7 @@ async def process_coordinator_response(
             event,
             linked_loops,
             coordinator_response=coordinator_response,
+            originating_suggestion=originating,
             arq_pool=ctx.get("redis"),
         )
         logger.info(

--- a/services/api/src/api/gmail/workers.py
+++ b/services/api/src/api/gmail/workers.py
@@ -16,6 +16,7 @@ from arq import cron
 from arq.connections import RedisSettings
 from psycopg_pool import AsyncConnectionPool
 
+from api.classifier.generation import claim_generation
 from api.gmail.auth import TokenStore
 from api.gmail.client import GmailClient
 from api.gmail.exceptions import GmailNotFoundError, GmailScopeError, GmailTokenStaleError
@@ -385,6 +386,12 @@ async def run_next_action_agent(
     """
     gmail: GmailClient = ctx["gmail"]
     router = ctx["router"]
+    redis = ctx.get("redis")
+    # Claim the per-thread generation token at worker entry. If a later
+    # worker (coordinator-response or rejection-rerun) starts for the same
+    # thread while we're mid-flight, it'll overwrite the token and our
+    # next-action-agent checkpoint will abort cleanly.
+    gen_token = await claim_generation(redis, gmail_thread_id)
 
     try:
         if gmail_message_id:
@@ -413,7 +420,7 @@ async def run_next_action_agent(
             new_participants=new_participants,
             thread_messages=thread_messages,
         )
-        await router.on_email(event, arq_pool=ctx.get("redis"))
+        await router.on_email(event, arq_pool=redis, generation_token=gen_token)
         logger.info(
             "next action agent processed message %s (thread %s)",
             message.id,
@@ -449,6 +456,11 @@ async def process_coordinator_response(
     agent = ctx["next_action_agent"]
     suggestion_svc = ctx["suggestion_service"]
     loop_service = ctx["loop_service"]
+    redis = ctx.get("redis")
+    # Claim the per-thread generation token so a concurrent run_next_action_agent
+    # or process_rejection_response on this thread can supersede us (or be
+    # superseded by us).
+    gen_token = await claim_generation(redis, gmail_thread_id)
 
     try:
         # Fetch the originating ask_coordinator suggestion so the agent can
@@ -497,7 +509,9 @@ async def process_coordinator_response(
             linked_loops,
             coordinator_response=coordinator_response,
             originating_suggestion=originating,
-            arq_pool=ctx.get("redis"),
+            arq_pool=redis,
+            generation_token=gen_token,
+            generation_thread_id=gmail_thread_id,
         )
         logger.info(
             "coordinator response processed for suggestion %s (thread %s)",
@@ -542,6 +556,11 @@ async def process_rejection_response(
     agent = ctx["next_action_agent"]
     suggestion_svc = ctx["suggestion_service"]
     loop_service = ctx["loop_service"]
+    redis = ctx.get("redis")
+    # Claim the per-thread generation token. A concurrent accept-driven
+    # re-run on the same thread (process_coordinator_response or
+    # run_next_action_agent) will supersede us if it starts later.
+    gen_token = await claim_generation(redis, gmail_thread_id)
 
     try:
         rejected = await suggestion_svc.get_suggestion(rejected_suggestion_id)
@@ -594,7 +613,9 @@ async def process_rejection_response(
             event,
             [target_loop],
             rejected_suggestion=rejected,
-            arq_pool=ctx.get("redis"),
+            arq_pool=redis,
+            generation_token=gen_token,
+            generation_thread_id=gmail_thread_id,
         )
         logger.info(
             "rejection re-run completed for suggestion %s (thread %s)",

--- a/services/api/src/api/gmail/workers.py
+++ b/services/api/src/api/gmail/workers.py
@@ -523,10 +523,107 @@ async def process_coordinator_response(
         await suggestion_svc.unresolve(suggestion_id, f"Processing failed: {exc}")
 
 
+async def process_rejection_response(
+    ctx: dict,
+    rejected_suggestion_id: str,
+    coordinator_email: str,
+    gmail_thread_id: str,
+) -> None:
+    """Re-run the NextActionAgent after a coordinator rejects a suggestion.
+
+    No "why" was captured — the agent has to guess at a materially different
+    alternative or fall back to no_action. Scope (DRAFT_EMAIL / ASK_COORDINATOR
+    only) is enforced upstream by ``_handle_reject_suggestion``.
+
+    Unlike ``process_coordinator_response``, failures do NOT un-resolve the
+    rejection. Rejection is final from the coordinator's perspective.
+    """
+    gmail: GmailClient = ctx["gmail"]
+    agent = ctx["next_action_agent"]
+    suggestion_svc = ctx["suggestion_service"]
+    loop_service = ctx["loop_service"]
+
+    try:
+        rejected = await suggestion_svc.get_suggestion(rejected_suggestion_id)
+        if rejected is None:
+            logger.warning(
+                "rejected suggestion %s not found — skipping re-run", rejected_suggestion_id
+            )
+            return
+
+        thread = await gmail.get_thread(coordinator_email, gmail_thread_id)
+        if not thread.messages:
+            logger.warning(
+                "empty thread %s — cannot run rejection re-run for suggestion %s",
+                gmail_thread_id,
+                rejected_suggestion_id,
+            )
+            return
+
+        message = thread.messages[-1]
+
+        direction = classify_direction(message, coordinator_email)
+        prior_messages = [
+            m for m in thread.messages if m.id != message.id and m.date < message.date
+        ]
+        message_type, new_participants = classify_message_type(message, prior_messages)
+
+        event = EmailEvent(
+            message=message,
+            coordinator_email=coordinator_email,
+            direction=direction,
+            message_type=message_type,
+            new_participants=new_participants,
+            thread_messages=thread.messages,
+        )
+
+        linked_loops = await loop_service.find_loops_by_thread(gmail_thread_id)
+        target_loop = next(
+            (lp for lp in linked_loops if lp.id == rejected.loop_id),
+            None,
+        )
+        if target_loop is None:
+            logger.warning(
+                "no matching loop for rejected suggestion %s (loop_id=%s) — skipping re-run",
+                rejected_suggestion_id,
+                rejected.loop_id,
+            )
+            return
+
+        await agent.act(
+            event,
+            [target_loop],
+            rejected_suggestion=rejected,
+            arq_pool=ctx.get("redis"),
+        )
+        logger.info(
+            "rejection re-run completed for suggestion %s (thread %s)",
+            rejected_suggestion_id,
+            gmail_thread_id,
+        )
+    except GmailTokenStaleError:
+        logger.warning(
+            "stale token for %s — rejection re-run skipped (suggestion %s)",
+            coordinator_email,
+            rejected_suggestion_id,
+        )
+    except Exception:
+        logger.exception(
+            "rejection re-run failed for suggestion %s (thread %s)",
+            rejected_suggestion_id,
+            gmail_thread_id,
+        )
+
+
 class WorkerSettings:
     """arq worker configuration."""
 
-    functions = [process_gmail_push, run_next_action_agent, process_coordinator_response]  # noqa: RUF012
+    functions = [  # noqa: RUF012
+        process_gmail_push,
+        run_next_action_agent,
+        process_coordinator_response,
+        process_rejection_response,
+    ]
     cron_jobs = [  # noqa: RUF012
         cron(poll_gmail_history, second=0),  # every 60s
         cron(renew_gmail_watches, hour={0, 6, 12, 18}, minute=0, second=0),

--- a/services/api/src/api/overview/cards.py
+++ b/services/api/src/api/overview/cards.py
@@ -563,6 +563,116 @@ def _build_link_thread_suggestion(view: SuggestionView) -> list[Widget]:
 
 
 # ---------------------------------------------------------------------------
+# UPDATE_ACTOR — variant of ASK_COORDINATOR
+# ---------------------------------------------------------------------------
+
+
+_ROLE_LABELS: dict[str, str] = {
+    "recruiter": "Recruiter",
+    "client_manager": "Client Manager",
+    "client_contact": "Client Contact",
+}
+
+
+def _current_actor_for_role(view: SuggestionView, role: str) -> tuple[str | None, str | None]:
+    """Return (name, email) of the loop's current actor in the given role, or
+    (None, None) if the role is empty."""
+    if role == "recruiter":
+        return view.recruiter_name, view.recruiter_email
+    if role == "client_manager":
+        return view.client_manager_name, view.client_manager_email
+    if role == "client_contact":
+        return view.client_contact_name, view.client_contact_email
+    return None, None
+
+
+def _build_update_actor_suggestion(view: SuggestionView) -> list[Widget]:
+    """UPDATE_ACTOR — agent asks the coordinator to set/replace a role on the
+    loop. Variant of ASK_COORDINATOR with a structured form instead of free
+    text.
+
+    - If the role is currently filled, show ``Currently: Name <email>`` so the
+      coordinator can make a conscious override decision.
+    - If empty, omit the "Currently" line entirely.
+    - Internal roles (recruiter, client_manager) get Workspace-directory
+      autocomplete; client_contact gets plain inputs (external, no directory).
+    """
+    sug = view.suggestion
+    sid = sug.id
+    data = sug.action_data or {}
+    role = (data.get("role") or "").strip()
+    role_label = _ROLE_LABELS.get(role, role or "actor")
+
+    widgets: list[Widget] = [_text(f"<b>🔄 Update {role_label}</b>")]
+
+    summary = sug.summary or ""
+    if summary:
+        widgets.append(_text(_escape_html_for_widget(summary)))
+
+    # Show the current actor when the role is filled, so the coordinator can
+    # decide whether to override. When empty, render nothing here.
+    current_name, current_email = _current_actor_for_role(view, role)
+    if current_email:
+        display = f"{current_name} &lt;{current_email}&gt;" if current_name else current_email
+        widgets.append(_text(f"<i>Currently: {display}</i>"))
+
+    if role in ("recruiter", "client_manager"):
+        name_field = f"update_actor_name_{sid}"
+        email_field = f"update_actor_email_{sid}"
+        widgets.extend(
+            build_recruiter_inputs(
+                action_url=get_action_url(),
+                directory_search_url=directory_search_url(),
+                name_field=name_field,
+                email_field=email_field,
+                on_change_extra_params={
+                    "suggestion_id": sid,
+                    "update_actor_role": role,
+                },
+            )
+        )
+        required = [email_field]
+    elif role == "client_contact":
+        name_field = f"update_actor_name_{sid}"
+        email_field = f"update_actor_email_{sid}"
+        company_field = f"update_actor_company_{sid}"
+        widgets.extend(
+            build_client_inputs(
+                name_field=name_field,
+                email_field=email_field,
+                company_field=company_field,
+            )
+        )
+        required = [email_field]
+    else:
+        # Unknown role — render error message and fall back to dismiss-only.
+        widgets.append(_text(f"<i>Unrecognised role <code>{role}</code> — please dismiss.</i>"))
+        widgets.append(_buttons(_dismiss_button(sid)))
+        return widgets
+
+    widgets.append(
+        _buttons(
+            Button(
+                text="Save",
+                on_click=_action(
+                    "update_actor",
+                    required_widgets=required,
+                    suggestion_id=sid,
+                    update_actor_role=role,
+                ),
+            ),
+            _dismiss_button(sid),
+        )
+    )
+    return widgets
+
+
+def _escape_html_for_widget(text: str) -> str:
+    """Card text supports a small HTML subset — escape angle brackets in summary."""
+    return text.replace("&", "&amp;").replace("<", "&lt;").replace(">", "&gt;")
+
+
+# ---------------------------------------------------------------------------
 # Dispatcher
 # ---------------------------------------------------------------------------
 
@@ -576,6 +686,7 @@ _SUGGESTION_BUILDERS = {
     SuggestedAction.ADVANCE_STAGE: _build_advance_suggestion,
     SuggestedAction.LINK_THREAD: _build_link_thread_suggestion,
     SuggestedAction.ASK_COORDINATOR: _build_ask_suggestion,
+    SuggestedAction.UPDATE_ACTOR: _build_update_actor_suggestion,
 }
 
 

--- a/services/api/src/api/overview/cards.py
+++ b/services/api/src/api/overview/cards.py
@@ -222,7 +222,9 @@ def _build_draft_suggestion(view: SuggestionView) -> list[Widget]:
         ),
         disabled=send_disabled,
     )
-    widgets.append(_buttons(_dismiss_button(sug.id), send_button))
+    # Convention across all suggestion cards: accept path on the left,
+    # reject/dismiss on the right. Send (or Forward) is the accept here.
+    widgets.append(_buttons(send_button, _dismiss_button(sug.id)))
     return widgets
 
 

--- a/services/api/src/api/overview/cards.py
+++ b/services/api/src/api/overview/cards.py
@@ -616,6 +616,15 @@ def _build_update_actor_suggestion(view: SuggestionView) -> list[Widget]:
         display = f"{current_name} &lt;{current_email}&gt;" if current_name else current_email
         widgets.append(_text(f"<i>Currently: {display}</i>"))
 
+    # When the coordinator has staged a pick via the autocomplete (the
+    # onChange handler stashes to action_data.pending_pick), render the
+    # inputs pre-filled. The user must still click Save to commit — this
+    # is the difference between "I clicked a row in the dropdown" and
+    # "I confirmed that's the recruiter I want."
+    pending = data.get("pending_pick") if isinstance(data.get("pending_pick"), dict) else None
+    prefill_name = pending.get("name") if pending else None
+    prefill_email = pending.get("email") if pending else None
+
     if role in ("recruiter", "client_manager"):
         name_field = f"update_actor_name_{sid}"
         email_field = f"update_actor_email_{sid}"
@@ -625,6 +634,8 @@ def _build_update_actor_suggestion(view: SuggestionView) -> list[Widget]:
                 directory_search_url=directory_search_url(),
                 name_field=name_field,
                 email_field=email_field,
+                prefill_name=prefill_name,
+                prefill_email=prefill_email,
                 on_change_extra_params={
                     "suggestion_id": sid,
                     "update_actor_role": role,

--- a/services/api/src/api/scheduling/cards.py
+++ b/services/api/src/api/scheduling/cards.py
@@ -257,6 +257,53 @@ def build_loop_pending_card(gmail_thread_id: str, message_id: str | None = None)
     )
 
 
+def build_loop_caught_up_card(gmail_thread_id: str, message_id: str | None = None) -> CardResponse:
+    """Thread-anchored empty state when the loop exists and the agent has
+    already produced suggestions on this thread, but none are pending right
+    now (everything was accepted/rejected/expired, or the agent emitted
+    no_action).
+
+    Mirrors ``build_loop_pending_card``'s shape but with copy that doesn't
+    imply work in flight — the original "Generating suggestions…" wording is
+    misleading once the agent has already run and there's simply nothing to do.
+
+    Keep the Refresh button: a new inbound on the thread can still produce
+    fresh suggestions, and coordinators often have the sidebar open while
+    waiting for the other side to reply.
+    """
+    base_url = _action_url.rsplit("/addon/", 1)[0] if _action_url else ""
+    refresh_button = Button(
+        text="↻ Refresh",
+        on_click=OnClick(
+            open_link=OpenLink(
+                url=f"{base_url}/addon/refresh",
+                open_as="OVERLAY",
+                on_close="RELOAD",
+            )
+        ),
+    )
+    return _update_card(
+        Card(
+            header=CardHeader(
+                title="All caught up",
+                subtitle="No actions needed for this thread.",
+            ),
+            sections=[
+                Section(
+                    widgets=[
+                        _text(
+                            "The agent has reviewed this thread and there are "
+                            "no pending suggestions right now. If anything "
+                            "changes, new suggestions will appear here."
+                        ),
+                        _buttons(refresh_button),
+                    ]
+                ),
+            ],
+        )
+    )
+
+
 def build_contextual_unlinked(gmail_thread_id: str, message_id: str | None = None) -> CardResponse:
     """Prompt to create or link when thread is not associated with a loop."""
     btn_params = {"gmail_thread_id": gmail_thread_id}

--- a/services/api/tests/test_addon_send_draft.py
+++ b/services/api/tests/test_addon_send_draft.py
@@ -173,3 +173,110 @@ async def test_reply_still_sends_when_thread_fetch_fails():
     assert call["in_reply_to"] is None
     assert call["references"] is None
     assert call["body"] == "Please share availability."
+
+
+class TestPickThreadAnchor:
+    """_pick_thread_anchor decides which Message-ID we point In-Reply-To at."""
+
+    def test_no_messages_returns_none(self):
+        from api.addon.routes import _pick_thread_anchor
+
+        assert _pick_thread_anchor([], ["x@y.com"], is_forward=False) is None
+
+    def test_forward_anchors_on_latest_overall(self):
+        """Forwards introduce a new party who hasn't sent anything yet —
+        anchor on the latest message regardless of recipient match."""
+        from api.addon.routes import _pick_thread_anchor
+
+        older = _make_message(
+            msg_id="m_old",
+            from_email="alice@client.com",
+            message_id_header="<old@mail.gmail.com>",
+        )
+        older.date = datetime(2026, 4, 1, tzinfo=UTC)
+        latest = _make_message(
+            msg_id="m_new",
+            from_email="recruiter@lrp.com",
+            message_id_header="<new@mail.gmail.com>",
+        )
+        latest.date = datetime(2026, 4, 20, tzinfo=UTC)
+        anchor = _pick_thread_anchor([older, latest], ["bob@new-party.com"], is_forward=True)
+        assert anchor.message_id_header == "<new@mail.gmail.com>"
+
+    def test_reply_to_client_with_prior_send_anchors_on_client(self):
+        """Client recipient who has sent on this thread → anchor on their
+        latest send so their Gmail can thread by Message-ID match."""
+        from api.addon.routes import _pick_thread_anchor
+
+        client_msg = _make_message(
+            msg_id="m_client",
+            from_email="alice@client.com",
+            message_id_header="<client@mail.gmail.com>",
+        )
+        client_msg.date = datetime(2026, 4, 10, tzinfo=UTC)
+        recruiter_reply = _make_message(
+            msg_id="m_rec",
+            from_email="recruiter@lrp.com",
+            message_id_header="<recruiter@mail.gmail.com>",
+        )
+        recruiter_reply.date = datetime(2026, 4, 15, tzinfo=UTC)
+        anchor = _pick_thread_anchor(
+            [client_msg, recruiter_reply], ["alice@client.com"], is_forward=False
+        )
+        assert anchor.message_id_header == "<client@mail.gmail.com>"
+
+    def test_reply_to_recipient_not_in_thread_falls_back_to_latest(self):
+        """When the recipient hasn't sent anything on this thread (the
+        coord-forwarded-into-recruiter-only-thread scenario), fall back to
+        the latest message overall. Subject mirroring carries threading
+        on the recipient's side; this preserves prior behavior."""
+        from api.addon.routes import _pick_thread_anchor
+
+        coord_fwd = _make_message(
+            msg_id="m_fwd",
+            from_email="coord@lrp.com",
+            message_id_header="<fwd@mail.gmail.com>",
+        )
+        coord_fwd.date = datetime(2026, 4, 10, tzinfo=UTC)
+        recruiter_reply = _make_message(
+            msg_id="m_rec",
+            from_email="recruiter@lrp.com",
+            message_id_header="<recruiter@mail.gmail.com>",
+        )
+        recruiter_reply.date = datetime(2026, 4, 15, tzinfo=UTC)
+        # Client has never sent on this thread.
+        anchor = _pick_thread_anchor(
+            [coord_fwd, recruiter_reply], ["alice@client.com"], is_forward=False
+        )
+        assert anchor.message_id_header == "<recruiter@mail.gmail.com>"
+
+    def test_reply_picks_latest_match_when_multiple_from_recipient(self):
+        """If the recipient has sent more than once, pick their LATEST."""
+        from api.addon.routes import _pick_thread_anchor
+
+        first = _make_message(
+            msg_id="m_first",
+            from_email="alice@client.com",
+            message_id_header="<first@mail.gmail.com>",
+        )
+        first.date = datetime(2026, 4, 1, tzinfo=UTC)
+        second = _make_message(
+            msg_id="m_second",
+            from_email="alice@client.com",
+            message_id_header="<second@mail.gmail.com>",
+        )
+        second.date = datetime(2026, 4, 20, tzinfo=UTC)
+        # Intentionally not in chronological order:
+        anchor = _pick_thread_anchor([second, first], ["alice@client.com"], is_forward=False)
+        assert anchor.message_id_header == "<second@mail.gmail.com>"
+
+    def test_reply_recipient_match_is_case_insensitive(self):
+        from api.addon.routes import _pick_thread_anchor
+
+        client_msg = _make_message(
+            msg_id="m_client",
+            from_email="Alice@Client.com",
+            message_id_header="<client@mail.gmail.com>",
+        )
+        anchor = _pick_thread_anchor([client_msg], ["ALICE@CLIENT.COM"], is_forward=False)
+        assert anchor.message_id_header == "<client@mail.gmail.com>"

--- a/services/api/tests/test_ai_langfuse.py
+++ b/services/api/tests/test_ai_langfuse.py
@@ -78,6 +78,32 @@ class TestFetchPrompt:
         with pytest.raises(LangFuseUnavailableError, match="Connection refused"):
             fetch_prompt(mock_client, "test-prompt")
 
+    def test_production_label_uses_default_cache(self):
+        """Production keeps the SDK's default 60s prompt cache for outage resilience."""
+        mock_client = MagicMock()
+        mock_prompt = MagicMock()
+        mock_prompt.is_fallback = False
+        mock_client.get_prompt.return_value = mock_prompt
+
+        fetch_prompt(mock_client, "test-prompt", label="production")
+
+        call_kwargs = mock_client.get_prompt.call_args.kwargs
+        assert "cache_ttl_seconds" not in call_kwargs
+
+    def test_non_production_label_disables_cache(self):
+        """Dev/staging labels skip the prompt cache so freshly-published versions
+        are picked up immediately."""
+        mock_client = MagicMock()
+        mock_prompt = MagicMock()
+        mock_prompt.is_fallback = False
+        mock_client.get_prompt.return_value = mock_prompt
+
+        fetch_prompt(mock_client, "test-prompt", label="development")
+
+        mock_client.get_prompt.assert_called_once_with(
+            "test-prompt", label="development", type="chat", cache_ttl_seconds=0
+        )
+
     def test_logs_warning_when_serving_fallback(self, caplog):
         mock_client = MagicMock()
         mock_prompt = MagicMock()

--- a/services/api/tests/test_classifier_hook.py
+++ b/services/api/tests/test_classifier_hook.py
@@ -1232,3 +1232,144 @@ class TestRejectionRerun:
             await agent.act(_event(), [_loop()], rejected_suggestion=rejected)
 
         suggestion_service.create_suggestion.assert_called_once()
+
+
+class TestGenerationCancellation:
+    """Per-thread generation tokens supersede in-flight agent runs.
+
+    Each worker handler claims a fresh token before calling agent.act().
+    The agent checks before the LLM round-trip and again before persisting
+    suggestions. If a newer worker has overwritten the token in Redis,
+    the older run logs and returns without writing.
+    """
+
+    def _redis_mock(self, current_token_per_get: list[str | None]):
+        """Build a redis mock whose .get() returns the next value in the list
+        on each call. Lets a test simulate the token flipping between
+        checkpoints."""
+        # iter exhausts after len(list); subsequent calls would StopIteration —
+        # tests should provide enough values for the calls they expect.
+        responses = iter(current_token_per_get)
+
+        async def _get(_key):
+            return next(responses)
+
+        redis = MagicMock()
+        redis.get = AsyncMock(side_effect=_get)
+        return redis
+
+    @pytest.mark.asyncio
+    async def test_aborts_before_llm_when_superseded(self):
+        """If the token in Redis doesn't match ours before the LLM call,
+        skip the round-trip entirely. No LLM call, no persist."""
+        agent, suggestion_service = _make_agent()
+        agent._llm.complete = AsyncMock()  # should never be called
+        redis = self._redis_mock(["different-token-already"])
+
+        with patch(
+            "api.classifier.next_action_agent.fetch_prompt",
+            return_value=_FakeTextPrompt(),
+        ):
+            await agent.act(
+                _event(),
+                [_loop()],
+                arq_pool=redis,
+                generation_token="our-token",
+                generation_thread_id="thread1",
+            )
+
+        agent._llm.complete.assert_not_awaited()
+        suggestion_service.create_suggestion.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_aborts_before_persist_when_superseded_mid_llm(self):
+        """LLM call succeeds, but a newer worker overwrote the token while we
+        were waiting. Drop the (now-stale) suggestions; do not persist."""
+        agent, suggestion_service = _make_agent()
+        item = _suggestion_item(action=SuggestedAction.ADVANCE_STAGE)
+        agent._llm.complete = AsyncMock(return_value=_llm_response(_suggestions_envelope([item])))
+        # Checkpoint 1 still sees our token → continue.
+        # Checkpoint 2 sees a different token → abort.
+        redis = self._redis_mock(["our-token", "superseded-by-newer-worker"])
+
+        with patch(
+            "api.classifier.next_action_agent.fetch_prompt",
+            return_value=_FakeTextPrompt(),
+        ):
+            await agent.act(
+                _event(),
+                [_loop()],
+                arq_pool=redis,
+                generation_token="our-token",
+                generation_thread_id="thread1",
+            )
+
+        agent._llm.complete.assert_awaited_once()
+        suggestion_service.create_suggestion.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_runs_to_completion_when_token_stays_current(self):
+        """Token matches at both checkpoints → suggestions persisted."""
+        agent, suggestion_service = _make_agent()
+        item = _suggestion_item(action=SuggestedAction.ADVANCE_STAGE)
+        agent._llm.complete = AsyncMock(return_value=_llm_response(_suggestions_envelope([item])))
+        redis = self._redis_mock(["our-token", "our-token"])
+
+        with patch(
+            "api.classifier.next_action_agent.fetch_prompt",
+            return_value=_FakeTextPrompt(),
+        ):
+            await agent.act(
+                _event(),
+                [_loop()],
+                arq_pool=redis,
+                generation_token="our-token",
+                generation_thread_id="thread1",
+            )
+
+        suggestion_service.create_suggestion.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_no_redis_falls_open(self):
+        """When arq_pool is None (Redis unavailable or test path that doesn't
+        wire it), the checkpoints fail open and the run proceeds normally."""
+        agent, suggestion_service = _make_agent()
+        item = _suggestion_item(action=SuggestedAction.ADVANCE_STAGE)
+        agent._llm.complete = AsyncMock(return_value=_llm_response(_suggestions_envelope([item])))
+
+        with patch(
+            "api.classifier.next_action_agent.fetch_prompt",
+            return_value=_FakeTextPrompt(),
+        ):
+            await agent.act(
+                _event(),
+                [_loop()],
+                arq_pool=None,
+                generation_token=None,
+                generation_thread_id=None,
+            )
+
+        suggestion_service.create_suggestion.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_token_missing_in_redis_treated_as_superseded(self):
+        """TTL expired (or someone cleared the key) → stored is None →
+        is_current_generation returns False → abort before LLM."""
+        agent, suggestion_service = _make_agent()
+        agent._llm.complete = AsyncMock()
+        redis = self._redis_mock([None])
+
+        with patch(
+            "api.classifier.next_action_agent.fetch_prompt",
+            return_value=_FakeTextPrompt(),
+        ):
+            await agent.act(
+                _event(),
+                [_loop()],
+                arq_pool=redis,
+                generation_token="our-token",
+                generation_thread_id="thread1",
+            )
+
+        agent._llm.complete.assert_not_awaited()
+        suggestion_service.create_suggestion.assert_not_called()

--- a/services/api/tests/test_classifier_hook.py
+++ b/services/api/tests/test_classifier_hook.py
@@ -474,6 +474,71 @@ class TestErrorHandling:
         assert call_kwargs["item"].action == SuggestedAction.ASK_COORDINATOR
         assert call_kwargs["item"].confidence == 0.0
 
+    @pytest.mark.asyncio
+    async def test_parse_failure_writes_raw_responses_to_langfuse(self):
+        """When both the initial LLM call and the retry produce un-parseable
+        content (e.g., classification not in the enum), the agent must put
+        the raw response strings on the LangFuse span output before the
+        manual-review fallback fires. Without this, the trace shows an
+        empty output and we can't see what the model actually produced.
+        """
+        agent, suggestion_service = _make_agent()
+        # Both responses are valid JSON but the classification is invalid —
+        # mirrors the real failure case the user reported.
+        bad_envelope = (
+            "<suggestions>[{"
+            '"classification": "information",'  # not in the enum
+            '"action": "ask_coordinator",'
+            '"confidence": 0.5,'
+            '"summary": "x",'
+            '"reasoning": "x",'
+            '"target_loop_id": "lop_1",'
+            '"action_data": {"question": "x"}'
+            "}]</suggestions>"
+        )
+        agent._llm.complete = AsyncMock(
+            side_effect=[
+                _llm_response(bad_envelope),
+                _llm_response(bad_envelope),  # retry also fails
+            ]
+        )
+
+        with patch(
+            "api.classifier.next_action_agent.fetch_prompt",
+            return_value=_FakeTextPrompt(),
+        ):
+            await agent.act(_event(), [_loop()])
+
+        # Find the span update that carries raw_responses + parse_error.
+        update_calls = agent._langfuse.update_current_span.call_args_list
+        failure_update = next(
+            (call for call in update_calls if "parse_error" in (call.kwargs.get("output") or {})),
+            None,
+        )
+        assert failure_update is not None, (
+            "expected update_current_span(output={...'parse_error'...}) "
+            "before the fallback was created"
+        )
+        output = failure_update.kwargs["output"]
+        assert output["raw_responses"] == [bad_envelope, bad_envelope]
+        parse_error = output["parse_error"].lower()
+        assert "validation" in parse_error or "schema" in parse_error
+
+        # Manual-review fallback still fires (no regression on that behavior).
+        suggestion_service.create_suggestion.assert_called_once()
+        call_kwargs = suggestion_service.create_suggestion.call_args.kwargs
+        assert call_kwargs["item"].action == SuggestedAction.ASK_COORDINATOR
+        assert call_kwargs["item"].confidence == 0.0
+
+    def test_next_action_agent_error_carries_raw_responses(self):
+        """Plain unit assertion that the exception preserves raw_responses."""
+        from api.classifier.next_action_agent import NextActionAgentError
+
+        exc = NextActionAgentError("nope", raw_responses=["a", "b"])
+        assert exc.raw_responses == ["a", "b"]
+        # Default empty when not provided — keeps the no-payload call sites valid.
+        assert NextActionAgentError("nope").raw_responses == []
+
 
 # --- Coordinator name resolution ---
 

--- a/services/api/tests/test_classifier_hook.py
+++ b/services/api/tests/test_classifier_hook.py
@@ -1002,3 +1002,107 @@ class TestExpireSuggestionFlow:
             await agent.act(_event(), [_loop()])
 
         suggestion_service.create_suggestion.assert_not_called()
+
+
+# --- Rejection re-run ---
+
+
+def _rejected_draft_suggestion() -> Suggestion:
+    return Suggestion(
+        id="sug_rejected",
+        coordinator_email="coord@lrp.com",
+        gmail_message_id="msg0",
+        gmail_thread_id="thread1",
+        loop_id="lop_1",
+        classification=EmailClassification.AVAILABILITY_RESPONSE,
+        action=SuggestedAction.DRAFT_EMAIL,
+        confidence=0.8,
+        summary="Drafted to recruiter",
+        action_data={"body": "Original body", "recipient_type": "recruiter"},
+        status=SuggestionStatus.REJECTED,
+    )
+
+
+class TestRejectionRerun:
+    @pytest.mark.asyncio
+    async def test_rejection_splices_prior_turn_and_followup(self):
+        agent, _ = _make_agent()
+
+        replacement = [
+            _suggestion_item(
+                action=SuggestedAction.ASK_COORDINATOR,
+                action_data={"question": "How should I handle this differently?"},
+            )
+        ]
+        agent._llm.complete = AsyncMock(
+            return_value=_llm_response(_suggestions_envelope(replacement))
+        )
+
+        with patch(
+            "api.classifier.next_action_agent.fetch_prompt",
+            return_value=_FakeTextPrompt(),
+        ):
+            await agent.act(
+                _event(),
+                [_loop()],
+                rejected_suggestion=_rejected_draft_suggestion(),
+            )
+
+        messages = agent._llm.complete.await_args.kwargs["messages"]
+        roles = [m["role"] for m in messages]
+        assert roles == ["system", "user", "assistant", "user"]
+        # The rejected suggestion appears in the reconstructed assistant turn.
+        assert "draft_email" in messages[-2]["content"]
+        # The follow-up explicitly tells the agent it was rejected with no reason.
+        followup = messages[-1]["content"]
+        assert "rejected" in followup.lower()
+        assert "materially different" in followup.lower()
+        assert "no_action" in followup
+
+    @pytest.mark.asyncio
+    async def test_rejection_dedups_identical_resuggestion(self):
+        """Agent ignores the prompt and re-emits the exact same DRAFT_EMAIL —
+        the dedup fingerprint should drop it silently."""
+        agent, suggestion_service = _make_agent()
+
+        rejected = _rejected_draft_suggestion()
+        # Agent re-emits the rejected suggestion verbatim.
+        duplicate = _suggestion_item(
+            action=SuggestedAction.DRAFT_EMAIL,
+            action_data=rejected.action_data,
+        )
+        agent._llm.complete = AsyncMock(
+            return_value=_llm_response(_suggestions_envelope([duplicate]))
+        )
+
+        with patch(
+            "api.classifier.next_action_agent.fetch_prompt",
+            return_value=_FakeTextPrompt(),
+        ):
+            await agent.act(_event(), [_loop()], rejected_suggestion=rejected)
+
+        suggestion_service.create_suggestion.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_rejection_accepts_different_alternative(self):
+        """Agent proposes a materially different action — that suggestion is persisted."""
+        agent, suggestion_service = _make_agent()
+
+        rejected = _rejected_draft_suggestion()
+        alternative = [
+            _suggestion_item(
+                action=SuggestedAction.DRAFT_EMAIL,
+                action_data={"body": "Totally different body", "recipient_type": "client"},
+            )
+        ]
+        agent._llm.complete = AsyncMock(
+            return_value=_llm_response(_suggestions_envelope(alternative))
+        )
+
+        with patch(
+            "api.classifier.next_action_agent.fetch_prompt",
+            return_value=_FakeTextPrompt(),
+        ):
+            await agent.act(_event(), [_loop()], rejected_suggestion=rejected)
+
+        suggestion_service.create_suggestion.assert_called_once()

--- a/services/api/tests/test_classifier_hook.py
+++ b/services/api/tests/test_classifier_hook.py
@@ -568,8 +568,11 @@ class TestIsInternalOnly:
 
 class TestInternalOnlyFilter:
     @pytest.mark.asyncio
-    async def test_all_internal_skips_classification(self):
+    async def test_internal_only_skips_classification_on_unlinked_thread(self):
+        """Pure LRP-to-LRP chatter on an unlinked thread shouldn't try to
+        spawn a new scheduling loop — that's just noise."""
         router, classifier, agent, loop_service = _make_router()
+        loop_service.find_loops_by_thread.return_value = []
         event = EmailEvent(
             message=_internal_msg(cc_emails=("carol@longridgepartners.com",)),
             coordinator_email="alice@longridgepartners.com",
@@ -580,7 +583,6 @@ class TestInternalOnlyFilter:
         await router.on_email(event)
         classifier.classify.assert_not_called()
         agent.act.assert_not_called()
-        loop_service.find_loops_by_thread.assert_not_called()
 
     @pytest.mark.asyncio
     async def test_mixed_participants_routes_normally(self):
@@ -598,8 +600,11 @@ class TestInternalOnlyFilter:
         classifier.classify.assert_called_once()
 
     @pytest.mark.asyncio
-    async def test_internal_only_skips_even_on_linked_thread(self):
+    async def test_internal_only_on_linked_thread_routes_to_agent(self):
+        """Recruiter→coordinator on a live loop is the substance of the work —
+        internal LRP-to-LRP traffic on linked threads MUST reach the agent."""
         router, classifier, agent, loop_service = _make_router()
+        loop_service.find_loops_by_thread.return_value = [_loop()]
         event = EmailEvent(
             message=_internal_msg(),
             coordinator_email="alice@longridgepartners.com",
@@ -609,8 +614,7 @@ class TestInternalOnlyFilter:
         )
         await router.on_email(event)
         classifier.classify.assert_not_called()
-        agent.act.assert_not_called()
-        loop_service.find_loops_by_thread.assert_not_called()
+        agent.act.assert_called_once()
 
 
 # --- Deduplication ---
@@ -767,7 +771,7 @@ class TestXMLFormatters:
         loop = _loop()
         pending = [
             Suggestion(
-                id="sug_old",
+                id="sug_draft",
                 coordinator_email="coord@lrp.com",
                 gmail_message_id="msg0",
                 gmail_thread_id="thread1",
@@ -776,9 +780,25 @@ class TestXMLFormatters:
                 action=SuggestedAction.DRAFT_EMAIL,
                 confidence=0.8,
                 summary="Stale draft summary",
-                action_data={"body": "...", "recipient_type": "recruiter"},
+                action_data={
+                    "body": "Hey Rachel, can you send Jordan's avails?",
+                    "recipient_type": "recruiter",
+                },
                 status=SuggestionStatus.PENDING,
-            )
+            ),
+            Suggestion(
+                id="sug_ask",
+                coordinator_email="coord@lrp.com",
+                gmail_message_id="msg0",
+                gmail_thread_id="thread1",
+                loop_id=loop.id,
+                classification=EmailClassification.FOLLOW_UP_NEEDED,
+                action=SuggestedAction.ASK_COORDINATOR,
+                confidence=0.7,
+                summary="Need a tiebreaker",
+                action_data={"question": "Should we wait for Jordan or use Drew?"},
+                status=SuggestionStatus.PENDING,
+            ),
         ]
         xml = format_loop_xml(loop, pending)
         assert f"<loop id='{loop.id}'>" in xml
@@ -786,8 +806,14 @@ class TestXMLFormatters:
         assert "<candidate>John Smith</candidate>" in xml
         assert "<recruiter>Bob</recruiter>" in xml
         assert "<client-contact>Jane, HF Co</client-contact>" in xml
-        assert "sug_old" in xml
+        # DRAFT_EMAIL renders body + recipient_type for dedup-by-content + targeting.
+        assert "sug_draft" in xml
         assert "Stale draft summary" in xml
+        assert "<recipient-type>recruiter</recipient-type>" in xml
+        assert "Hey Rachel" in xml
+        # ASK_COORDINATOR renders the question.
+        assert "sug_ask" in xml
+        assert "<question>Should we wait for Jordan or use Drew?</question>" in xml
 
 
 # --- Batch guardrails ---

--- a/services/api/tests/test_classifier_hook.py
+++ b/services/api/tests/test_classifier_hook.py
@@ -415,6 +415,26 @@ class TestAgentGuardrails:
         assert error is None
         assert result.action == SuggestedAction.EXPIRE_SUGGESTION
 
+    def test_update_actor_valid_role_passes(self):
+        agent, _ = _make_agent()
+        item = _suggestion_item(
+            action=SuggestedAction.UPDATE_ACTOR,
+            action_data={"role": "recruiter"},
+        )
+        result, error = agent._apply_guardrails(item, set())
+        assert error is None
+        assert result.action == SuggestedAction.UPDATE_ACTOR
+
+    def test_update_actor_invalid_role_fails(self):
+        agent, _ = _make_agent()
+        item = _suggestion_item(
+            action=SuggestedAction.UPDATE_ACTOR,
+            action_data={"role": "wizard"},  # not in the Literal
+        )
+        _result, error = agent._apply_guardrails(item, set())
+        assert error is not None
+        assert "action_data" in error
+
 
 # --- Error handling ---
 
@@ -821,6 +841,29 @@ class TestXMLFormatters:
         assert xml.index("Body 3") < xml.index("Body 5")
         # Excludes the current message.
         assert "Body 7" not in xml
+
+    def test_pending_update_actor_renders_role(self):
+        from api.classifier.formatters import format_loop_xml
+
+        loop = _loop()
+        pending = [
+            Suggestion(
+                id="sug_upd",
+                coordinator_email="coord@lrp.com",
+                gmail_message_id="msg0",
+                gmail_thread_id="thread1",
+                loop_id=loop.id,
+                classification=EmailClassification.FOLLOW_UP_NEEDED,
+                action=SuggestedAction.UPDATE_ACTOR,
+                confidence=0.7,
+                summary="The recruiter on file looks wrong",
+                action_data={"role": "recruiter"},
+                status=SuggestionStatus.PENDING,
+            ),
+        ]
+        xml = format_loop_xml(loop, pending)
+        assert "sug_upd" in xml
+        assert "<role>recruiter</role>" in xml
 
     def test_loop_xml_renders_actors_and_pending(self):
         from api.classifier.formatters import format_loop_xml

--- a/services/api/tests/test_classifier_hook.py
+++ b/services/api/tests/test_classifier_hook.py
@@ -565,6 +565,29 @@ class TestIsInternalOnly:
         msg = _internal_msg(to_emails=(), cc_emails=())
         assert _is_internal_only(msg) is True
 
+    def test_thread_with_external_upstream_is_not_internal_only(self):
+        """If any message in the thread had an external participant, the
+        thread isn't internal-only even when the trigger message is all-LRP."""
+        external_inbound = Message(
+            id="msg0",
+            thread_id="thread1",
+            subject="Interview request",
+            **{"from": EmailAddress(email="client@external.com")},
+            to=[EmailAddress(email="coord@longridgepartners.com")],
+            date=datetime(2026, 4, 14, 9, 0, tzinfo=UTC),
+            body_text="Can you schedule a chat?",
+        )
+        internal_forward = _internal_msg()
+        internal_reply = _internal_msg(
+            from_email="recruiter@longridgepartners.com",
+            to_emails=("coord@longridgepartners.com",),
+        )
+        thread = [external_inbound, internal_forward, internal_reply]
+        # Internal-only check on the *trigger* (most recent) message: true alone…
+        assert _is_internal_only(internal_reply) is True
+        # …but false once we consider the whole thread.
+        assert _is_internal_only(internal_reply, thread) is False
+
 
 class TestInternalOnlyFilter:
     @pytest.mark.asyncio
@@ -615,6 +638,40 @@ class TestInternalOnlyFilter:
         await router.on_email(event)
         classifier.classify.assert_not_called()
         agent.act.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_forwarded_client_request_then_internal_reply_classifies(self):
+        """Coordinator forwarded a client's request to a recruiter; the
+        recruiter's internal-only reply should still spawn loop classification
+        because the thread participants include an external client upstream."""
+        router, classifier, _, loop_service = _make_router()
+        loop_service.find_loops_by_thread.return_value = []
+
+        external_inbound = Message(
+            id="msg0",
+            thread_id="thread1",
+            subject="Interview request",
+            **{"from": EmailAddress(email="client@external.com")},
+            to=[EmailAddress(email="alice@longridgepartners.com")],
+            date=datetime(2026, 4, 14, 9, 0, tzinfo=UTC),
+            body_text="Can you schedule?",
+        )
+        coord_forward = _internal_msg()  # alice -> bob
+        recruiter_reply = _internal_msg(
+            from_email="bob@longridgepartners.com",
+            to_emails=("alice@longridgepartners.com",),
+        )
+
+        event = EmailEvent(
+            message=recruiter_reply,
+            coordinator_email="alice@longridgepartners.com",
+            direction=MessageDirection.INCOMING,
+            message_type=MessageType.REPLY,
+            new_participants=[],
+            thread_messages=[external_inbound, coord_forward, recruiter_reply],
+        )
+        await router.on_email(event)
+        classifier.classify.assert_called_once()
 
 
 # --- Deduplication ---

--- a/services/api/tests/test_classifier_hook.py
+++ b/services/api/tests/test_classifier_hook.py
@@ -1,5 +1,6 @@
 """Tests for the two-stage classification pipeline: Router, LoopClassifier, NextActionAgent."""
 
+import json
 from datetime import UTC, datetime
 from unittest.mock import AsyncMock, MagicMock, patch
 
@@ -187,6 +188,51 @@ def _make_agent():
     return agent, suggestion_service
 
 
+def _llm_response(content: str):
+    """Stub for the LLMResponse return value from LLMService.complete()."""
+    resp = MagicMock()
+    resp.content = content
+    resp.model = "test-model"
+    resp.provider = "test"
+    resp.latency_ms = 1.0
+    return resp
+
+
+def _suggestions_envelope(items: list[SuggestionItem]) -> str:
+    """Re-serialize SuggestionItems into the prompt's <suggestions>[...]</suggestions> envelope."""
+    payload = [item.model_dump(mode="json") for item in items]
+    return f"<suggestions>{json.dumps(payload)}</suggestions>"
+
+
+class _FakeTextPrompt:
+    """Stands in for a LangFuse TextPromptClient — falls through the non-chat
+    branch in ``NextActionAgent._build_initial_messages`` so tests don't have
+    to model the chat compile contract.
+    """
+
+    from typing import ClassVar
+
+    version = 1
+    labels: ClassVar[tuple[str, ...]] = ("test",)
+    config: ClassVar[dict] = {
+        "model": "test-model",
+        "temperature": 0.0,
+        "max_tokens": 1024,
+    }
+
+    def compile(self, **_kwargs):
+        return "compiled prompt"
+
+
+def _patch_agent_llm(agent, content: str):
+    """Patch the agent's prompt fetch + LLM call to return ``content``."""
+    agent._llm.complete = AsyncMock(return_value=_llm_response(content))
+    return patch(
+        "api.classifier.next_action_agent.fetch_prompt",
+        return_value=_FakeTextPrompt(),
+    )
+
+
 # --- Router tests ---
 
 
@@ -305,16 +351,14 @@ class TestAgentGuardrails:
     def test_create_loop_blacklisted(self):
         agent, _ = _make_agent()
         item = _suggestion_item(action=SuggestedAction.CREATE_LOOP)
-        result, error = agent._apply_guardrails(item)
-        assert result.action == SuggestedAction.NO_ACTION
+        _result, error = agent._apply_guardrails(item, set())
         assert error is not None
         assert "not allowed" in error
 
     def test_link_thread_blacklisted(self):
         agent, _ = _make_agent()
         item = _suggestion_item(action=SuggestedAction.LINK_THREAD)
-        result, error = agent._apply_guardrails(item)
-        assert result.action == SuggestedAction.NO_ACTION
+        _result, error = agent._apply_guardrails(item, set())
         assert error is not None
 
     def test_advance_stage_passes(self):
@@ -323,22 +367,21 @@ class TestAgentGuardrails:
             action=SuggestedAction.ADVANCE_STAGE,
             target_stage=StageState.AWAITING_CLIENT,
         )
-        result, error = agent._apply_guardrails(item)
+        result, error = agent._apply_guardrails(item, set())
         assert result.action == SuggestedAction.ADVANCE_STAGE
         assert error is None
 
     def test_draft_email_passes(self):
         agent, _ = _make_agent()
         item = _suggestion_item(action=SuggestedAction.DRAFT_EMAIL)
-        result, error = agent._apply_guardrails(item)
+        result, error = agent._apply_guardrails(item, set())
         assert result.action == SuggestedAction.DRAFT_EMAIL
         assert error is None
 
     def test_missing_target_loop_id_fails(self):
         agent, _ = _make_agent()
         item = _suggestion_item(action=SuggestedAction.DRAFT_EMAIL, target_loop_id=None)
-        result, error = agent._apply_guardrails(item)
-        assert result.action == SuggestedAction.NO_ACTION
+        _result, error = agent._apply_guardrails(item, set())
         assert error is not None
         assert "target_loop_id" in error
 
@@ -348,10 +391,29 @@ class TestAgentGuardrails:
             action=SuggestedAction.ADVANCE_STAGE,
             action_data={},  # missing target_stage
         )
-        result, error = agent._apply_guardrails(item)
-        assert result.action == SuggestedAction.NO_ACTION
+        _result, error = agent._apply_guardrails(item, set())
         assert error is not None
         assert "action_data" in error
+
+    def test_expire_suggestion_unknown_id_fails(self):
+        agent, _ = _make_agent()
+        item = _suggestion_item(
+            action=SuggestedAction.EXPIRE_SUGGESTION,
+            action_data={"suggestion_id": "sug_unknown"},
+        )
+        _result, error = agent._apply_guardrails(item, {"sug_other"})
+        assert error is not None
+        assert "expire_suggestion" in error
+
+    def test_expire_suggestion_known_id_passes(self):
+        agent, _ = _make_agent()
+        item = _suggestion_item(
+            action=SuggestedAction.EXPIRE_SUGGESTION,
+            action_data={"suggestion_id": "sug_stale"},
+        )
+        result, error = agent._apply_guardrails(item, {"sug_stale"})
+        assert error is None
+        assert result.action == SuggestedAction.EXPIRE_SUGGESTION
 
 
 # --- Error handling ---
@@ -378,11 +440,11 @@ class TestErrorHandling:
     @pytest.mark.asyncio
     async def test_agent_llm_failure_creates_needs_attention(self):
         agent, suggestion_service = _make_agent()
+        agent._llm.complete = AsyncMock(side_effect=Exception("LLM down"))
 
         with patch(
-            "api.classifier.next_action_agent.determine_next_action",
-            new_callable=AsyncMock,
-            side_effect=Exception("LLM down"),
+            "api.classifier.next_action_agent.fetch_prompt",
+            return_value=_FakeTextPrompt(),
         ):
             event = _event()
             await agent.act(event, [_loop()])
@@ -586,20 +648,14 @@ class TestDeduplication:
         )
         suggestion_service.get_pending_for_loop.return_value = [existing]
 
-        result = _classification_result(
-            items=[
-                _suggestion_item(
-                    action=SuggestedAction.ADVANCE_STAGE,
-                    target_stage=StageState.AWAITING_CLIENT,
-                )
-            ]
-        )
+        items = [
+            _suggestion_item(
+                action=SuggestedAction.ADVANCE_STAGE,
+                target_stage=StageState.AWAITING_CLIENT,
+            )
+        ]
 
-        with patch(
-            "api.classifier.next_action_agent.determine_next_action",
-            new_callable=AsyncMock,
-            return_value=result,
-        ):
+        with _patch_agent_llm(agent, _suggestions_envelope(items)):
             await agent.act(_event(), [_loop()])
 
         suggestion_service.create_suggestion.assert_not_called()
@@ -612,13 +668,8 @@ class TestDeduplication:
             action=SuggestedAction.DRAFT_EMAIL,
             action_data={"body": "Hi there", "recipient_type": "recruiter"},
         )
-        result = _classification_result(items=[item, item])
 
-        with patch(
-            "api.classifier.next_action_agent.determine_next_action",
-            new_callable=AsyncMock,
-            return_value=result,
-        ):
+        with _patch_agent_llm(agent, _suggestions_envelope([item, item])):
             await agent.act(_event(), [_loop()])
 
         assert suggestion_service.create_suggestion.call_count == 1
@@ -632,21 +683,322 @@ class TestDeduplication:
         )
         suggestion_service.get_pending_for_loop.return_value = [existing]
 
-        result = _classification_result(
-            items=[
-                _suggestion_item(
-                    action=SuggestedAction.ADVANCE_STAGE,
-                    target_stage=StageState.SCHEDULED,
-                    action_data={"target_stage": "scheduled"},
-                )
+        items = [
+            _suggestion_item(
+                action=SuggestedAction.ADVANCE_STAGE,
+                target_stage=StageState.SCHEDULED,
+                action_data={"target_stage": "scheduled"},
+            )
+        ]
+
+        with _patch_agent_llm(agent, _suggestions_envelope(items)):
+            await agent.act(_event(), [_loop()])
+
+        suggestion_service.create_suggestion.assert_called_once()
+
+
+# --- XML formatters ---
+
+
+class TestXMLFormatters:
+    def test_email_xml_escapes_special_chars(self):
+        from api.classifier.formatters import format_email_xml
+
+        msg = Message(
+            id="msg1",
+            thread_id="thread1",
+            subject="Re: Q1 & Q2 <urgent>",
+            **{"from": EmailAddress(name="A & B", email="a@example.com")},
+            to=[EmailAddress(email="coord@lrp.com")],
+            date=datetime(2026, 5, 5, 11, 30, tzinfo=UTC),
+            body_text="Body with <tag> & ampersand",
+        )
+        xml = format_email_xml(msg, "incoming")
+        assert "<email direction='inbound'>" in xml
+        assert "&amp;" in xml
+        assert "&lt;tag&gt;" in xml
+        assert "<from>A &amp; B a@example.com</from>" in xml
+        # No raw '<' or '>' in interpolated values
+        assert "<tag>" not in xml.replace("<email", "").replace("</email>", "")
+
+    def test_email_xml_omits_empty_cc(self):
+        from api.classifier.formatters import format_email_xml
+
+        msg = Message(
+            id="msg1",
+            thread_id="thread1",
+            subject="Hi",
+            **{"from": EmailAddress(email="a@example.com")},
+            to=[EmailAddress(email="b@example.com")],
+            cc=[],
+            date=datetime(2026, 5, 5, 11, 30, tzinfo=UTC),
+            body_text="Hello",
+        )
+        xml = format_email_xml(msg, "outgoing")
+        assert "<cc>" not in xml
+        assert "<email direction='outbound'>" in xml
+
+    def test_thread_history_oldest_first(self):
+        from api.classifier.formatters import format_thread_history_xml
+
+        msgs = [
+            Message(
+                id=f"msg{i}",
+                thread_id="thread1",
+                subject="Re: Hi",
+                **{"from": EmailAddress(email="a@example.com")},
+                to=[EmailAddress(email="coord@lrp.com")],
+                date=datetime(2026, 5, i, 9, 0, tzinfo=UTC),
+                body_text=f"Body {i}",
+            )
+            for i in (3, 5, 7)
+        ]
+        xml = format_thread_history_xml(
+            msgs, current_message_id="msg7", coordinator_email="coord@lrp.com"
+        )
+        # Oldest body should appear before the newer one.
+        assert xml.index("Body 3") < xml.index("Body 5")
+        # Excludes the current message.
+        assert "Body 7" not in xml
+
+    def test_loop_xml_renders_actors_and_pending(self):
+        from api.classifier.formatters import format_loop_xml
+
+        loop = _loop()
+        pending = [
+            Suggestion(
+                id="sug_old",
+                coordinator_email="coord@lrp.com",
+                gmail_message_id="msg0",
+                gmail_thread_id="thread1",
+                loop_id=loop.id,
+                classification=EmailClassification.AVAILABILITY_RESPONSE,
+                action=SuggestedAction.DRAFT_EMAIL,
+                confidence=0.8,
+                summary="Stale draft summary",
+                action_data={"body": "...", "recipient_type": "recruiter"},
+                status=SuggestionStatus.PENDING,
+            )
+        ]
+        xml = format_loop_xml(loop, pending)
+        assert f"<loop id='{loop.id}'>" in xml
+        assert "<stage>awaiting_candidate</stage>" in xml
+        assert "<candidate>John Smith</candidate>" in xml
+        assert "<recruiter>Bob</recruiter>" in xml
+        assert "<client-contact>Jane, HF Co</client-contact>" in xml
+        assert "sug_old" in xml
+        assert "Stale draft summary" in xml
+
+
+# --- Batch guardrails ---
+
+
+def _two_loop_thread() -> list[Loop]:
+    """Two loops on the same thread with two distinct recruiters."""
+    return [
+        Loop(
+            id=f"lop_{i}",
+            coordinator_id="crd_1",
+            client_contact_id="cli_1",
+            recruiter_id=f"con_{i}",
+            candidate_id=f"can_{i}",
+            title=f"Loop {i}",
+            state=StageState.AWAITING_CANDIDATE,
+            created_at=datetime(2026, 4, 10, tzinfo=UTC),
+            updated_at=datetime(2026, 4, 14, tzinfo=UTC),
+            candidate=Candidate(
+                id=f"can_{i}",
+                name=f"Candidate {i}",
+                created_at=datetime(2026, 4, 10, tzinfo=UTC),
+            ),
+            recruiter=Contact(
+                id=f"con_{i}",
+                name=f"Recruiter {i}",
+                email=f"rec{i}@lrp.com",
+                role="recruiter",
+                created_at=datetime(2026, 4, 10, tzinfo=UTC),
+            ),
+        )
+        for i in (1, 2)
+    ]
+
+
+class TestBatchGuardrails:
+    def test_recruiter_draft_count_exceeds_known_recruiters(self):
+        agent, _ = _make_agent()
+        loops = [_loop()]  # one recruiter on the thread
+        items = [
+            _suggestion_item(
+                action=SuggestedAction.DRAFT_EMAIL,
+                action_data={"body": "A", "recipient_type": "recruiter"},
+            ),
+            _suggestion_item(
+                action=SuggestedAction.DRAFT_EMAIL,
+                action_data={"body": "B", "recipient_type": "recruiter"},
+            ),
+        ]
+        _, errors = agent._validate_batch(items, loops, [])
+        assert any("recruiter draft emails" in e for e in errors)
+
+    def test_recruiter_drafts_match_recruiter_count(self):
+        agent, _ = _make_agent()
+        loops = _two_loop_thread()
+        items = [
+            _suggestion_item(
+                action=SuggestedAction.DRAFT_EMAIL,
+                target_loop_id="lop_1",
+                action_data={"body": "A", "recipient_type": "recruiter"},
+            ),
+            _suggestion_item(
+                action=SuggestedAction.DRAFT_EMAIL,
+                target_loop_id="lop_2",
+                action_data={"body": "B", "recipient_type": "recruiter"},
+            ),
+        ]
+        _, errors = agent._validate_batch(items, loops, [])
+        assert not [e for e in errors if "recruiter draft" in e]
+
+    def test_multiple_client_drafts_rejected(self):
+        agent, _ = _make_agent()
+        loops = _two_loop_thread()
+        items = [
+            _suggestion_item(
+                action=SuggestedAction.DRAFT_EMAIL,
+                target_loop_id="lop_1",
+                action_data={"body": "A", "recipient_type": "client"},
+            ),
+            _suggestion_item(
+                action=SuggestedAction.DRAFT_EMAIL,
+                target_loop_id="lop_2",
+                action_data={"body": "B", "recipient_type": "client"},
+            ),
+        ]
+        _, errors = agent._validate_batch(items, loops, [])
+        assert any("client draft emails" in e for e in errors)
+
+
+# --- Conversation retry ---
+
+
+class TestConversationRetry:
+    @pytest.mark.asyncio
+    async def test_batch_error_triggers_followup_with_history(self):
+        agent, suggestion_service = _make_agent()
+        loops = [_loop()]
+
+        # First call: two recruiter drafts (violates batch guardrail).
+        bad_items = [
+            _suggestion_item(
+                action=SuggestedAction.DRAFT_EMAIL,
+                action_data={"body": "A", "recipient_type": "recruiter"},
+            ),
+            _suggestion_item(
+                action=SuggestedAction.DRAFT_EMAIL,
+                action_data={"body": "B", "recipient_type": "recruiter"},
+            ),
+        ]
+        # Retry call: one recruiter draft (valid).
+        good_items = [
+            _suggestion_item(
+                action=SuggestedAction.DRAFT_EMAIL,
+                action_data={"body": "Combined", "recipient_type": "recruiter"},
+            ),
+        ]
+
+        responses = [
+            _llm_response(_suggestions_envelope(bad_items)),
+            _llm_response(_suggestions_envelope(good_items)),
+        ]
+        agent._llm.complete = AsyncMock(side_effect=responses)
+
+        with patch(
+            "api.classifier.next_action_agent.fetch_prompt",
+            return_value=_FakeTextPrompt(),
+        ):
+            await agent.act(_event(), loops)
+
+        # Two LLM calls: original + retry.
+        assert agent._llm.complete.await_count == 2
+
+        # Second call's messages must include the original + assistant turn + error follow-up.
+        retry_messages = agent._llm.complete.await_args_list[1].kwargs["messages"]
+        roles = [m["role"] for m in retry_messages]
+        assert roles == ["system", "user", "assistant", "user"]
+        assert "errors" in retry_messages[-1]["content"].lower()
+
+        suggestion_service.create_suggestion.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_coordinator_response_splices_prior_turn(self):
+        agent, _suggestion_service = _make_agent()
+
+        items = [
+            _suggestion_item(
+                action=SuggestedAction.ADVANCE_STAGE,
+                target_stage=StageState.AWAITING_CLIENT,
+            )
+        ]
+        agent._llm.complete = AsyncMock(return_value=_llm_response(_suggestions_envelope(items)))
+
+        originating = Suggestion(
+            id="sug_q",
+            coordinator_email="coord@lrp.com",
+            gmail_message_id="msg0",
+            gmail_thread_id="thread1",
+            loop_id="lop_1",
+            classification=EmailClassification.FOLLOW_UP_NEEDED,
+            action=SuggestedAction.ASK_COORDINATOR,
+            confidence=0.7,
+            summary="Need decision",
+            action_data={"question": "Pick a time slot?"},
+            status=SuggestionStatus.ACCEPTED,
+        )
+
+        with patch(
+            "api.classifier.next_action_agent.fetch_prompt",
+            return_value=_FakeTextPrompt(),
+        ):
+            await agent.act(
+                _event(),
+                [_loop()],
+                coordinator_response="Pick 3pm",
+                originating_suggestion=originating,
+            )
+
+        messages = agent._llm.complete.await_args.kwargs["messages"]
+        roles = [m["role"] for m in messages]
+        assert roles == ["system", "user", "assistant", "user"]
+        assert "Pick 3pm" in messages[-1]["content"]
+        assert "ask_coordinator" in messages[-2]["content"]
+
+
+# --- Expire suggestion via act() ---
+
+
+class TestExpireSuggestionFlow:
+    @pytest.mark.asyncio
+    async def test_expire_suggestion_drops_unknown_target(self):
+        agent, suggestion_service = _make_agent()
+
+        items = [
+            _suggestion_item(
+                action=SuggestedAction.EXPIRE_SUGGESTION,
+                action_data={"suggestion_id": "sug_never_existed"},
+            )
+        ]
+        # No pending suggestions on the loop — and we don't allow retry to make the failure stick.
+        agent._llm.complete = AsyncMock(
+            side_effect=[
+                _llm_response(_suggestions_envelope(items)),
+                # Retry produces the same invalid response.
+                _llm_response(_suggestions_envelope(items)),
             ]
         )
 
         with patch(
-            "api.classifier.next_action_agent.determine_next_action",
-            new_callable=AsyncMock,
-            return_value=result,
+            "api.classifier.next_action_agent.fetch_prompt",
+            return_value=_FakeTextPrompt(),
         ):
             await agent.act(_event(), [_loop()])
 
-        suggestion_service.create_suggestion.assert_called_once()
+        suggestion_service.create_suggestion.assert_not_called()

--- a/services/api/tests/test_draft_service.py
+++ b/services/api/tests/test_draft_service.py
@@ -280,6 +280,75 @@ def _mock_pool():
     return mock_pool, mock_conn
 
 
+class TestResolveSubject:
+    """Subject derivation for outbound replies.
+
+    Gmail's threading rules (developers.google.com/gmail/api/guides/threads)
+    require the outbound Subject to match the existing thread's Subject for
+    the reply to attach. The function under test mirrors the latest thread
+    message's subject rather than synthesizing from loop.title.
+    """
+
+    def test_mirrors_latest_thread_subject(self):
+        msg = _thread_msg("alice@a.com", ["coord@lrp.com"])
+        msg.subject = "Trump"
+        result = DraftService._resolve_subject(_loop(), [msg])
+        assert result == "Re: Trump"
+
+    def test_no_double_re_prefix_lowercase(self):
+        msg = _thread_msg("alice@a.com", ["coord@lrp.com"])
+        msg.subject = "re: Phone screen"
+        result = DraftService._resolve_subject(_loop(), [msg])
+        assert result == "re: Phone screen"
+
+    def test_no_double_re_prefix_uppercase(self):
+        msg = _thread_msg("alice@a.com", ["coord@lrp.com"])
+        msg.subject = "RE: Phone screen"
+        result = DraftService._resolve_subject(_loop(), [msg])
+        assert result == "RE: Phone screen"
+
+    def test_no_double_re_prefix_titlecase(self):
+        msg = _thread_msg("alice@a.com", ["coord@lrp.com"])
+        msg.subject = "Re: Phone screen"
+        result = DraftService._resolve_subject(_loop(), [msg])
+        assert result == "Re: Phone screen"
+
+    def test_falls_back_to_loop_title_when_no_thread(self):
+        result = DraftService._resolve_subject(_loop(), None)
+        assert result == "Re: Round 1 - John Smith"
+
+    def test_falls_back_to_loop_title_when_thread_empty(self):
+        result = DraftService._resolve_subject(_loop(), [])
+        assert result == "Re: Round 1 - John Smith"
+
+    def test_picks_latest_by_date_not_list_order(self):
+        """The latest message wins even when list order is oldest-first."""
+        oldest = _thread_msg(
+            "alice@a.com",
+            ["coord@lrp.com"],
+            msg_id="msg_old",
+            date=datetime(2026, 4, 14, tzinfo=UTC),
+        )
+        oldest.subject = "Re: Old subject"
+        newest = _thread_msg(
+            "alice@a.com",
+            ["coord@lrp.com"],
+            msg_id="msg_new",
+            date=datetime(2026, 4, 16, tzinfo=UTC),
+        )
+        newest.subject = "Trump"
+        result = DraftService._resolve_subject(_loop(), [oldest, newest])
+        assert result == "Re: Trump"
+
+    def test_falls_back_when_latest_subject_is_blank(self):
+        """Defensive: a thread message with whitespace-only subject falls
+        back to the loop title rather than producing 'Re: ' alone."""
+        msg = _thread_msg("alice@a.com", ["coord@lrp.com"])
+        msg.subject = "   "
+        result = DraftService._resolve_subject(_loop(), [msg])
+        assert result == "Re: Round 1 - John Smith"
+
+
 class TestGenerateDraft:
     @pytest.mark.asyncio
     async def test_body_persisted(self):
@@ -313,6 +382,32 @@ class TestGenerateDraft:
             mock_queries.create_draft = AsyncMock(return_value=_draft_row(body=""))
             draft = await svc.generate_draft(suggestion=suggestion, loop=loop, body="")
             assert draft.body == ""
+
+    @pytest.mark.asyncio
+    async def test_subject_mirrors_thread_subject_not_loop_title(self):
+        """Regression: the persisted draft subject must come from the thread
+        (Gmail threading requires Subject match), not from loop.title."""
+        mock_pool, _ = _mock_pool()
+        svc = DraftService(db_pool=mock_pool, loop_service=MagicMock())
+
+        loop = _loop(state=StageState.AWAITING_CANDIDATE)
+        suggestion = _suggestion()
+        thread_msg = _thread_msg("alice@client.com", ["coord@lrp.com"])
+        thread_msg.subject = "Trump"
+
+        from unittest.mock import patch
+
+        with patch("api.drafts.service.queries") as mock_queries:
+            mock_queries.create_draft = AsyncMock(return_value=_draft_row(body=""))
+            await svc.generate_draft(
+                suggestion=suggestion,
+                loop=loop,
+                thread_messages=[thread_msg],
+                body="",
+            )
+            call_kwargs = mock_queries.create_draft.await_args.kwargs
+            # Subject derived from thread, not from loop.title ("Round 1 - John Smith").
+            assert call_kwargs["subject"] == "Re: Trump"
 
 
 class TestDraftLifecycle:

--- a/services/api/tests/test_draft_service.py
+++ b/services/api/tests/test_draft_service.py
@@ -260,6 +260,80 @@ class TestIsForwardDraft:
         )
         assert _is_forward_draft(["bob@b.com"], [trigger], "msg_new") is False
 
+    def test_client_recipient_never_forwards_even_when_not_on_trigger(self):
+        """Privacy guard: recipient_type='client' MUST short-circuit to False.
+
+        Scenario that motivated this: client → coord → coord forwards to
+        recruiter → recruiter replies → agent suggests drafting back to
+        client. The trigger is the recruiter's reply, which the client
+        isn't on. Without this guard, _is_forward_draft would return True
+        and the recruiter's reply would be quoted to the client (LEAK).
+        """
+        recruiter_reply = _thread_msg(
+            "recruiter@lrp.com",
+            ["coord@lrp.com"],
+            msg_id="msg_recruiter",
+        )
+        assert (
+            _is_forward_draft(
+                ["client@external.com"],
+                [recruiter_reply],
+                "msg_recruiter",
+                recipient_type="client",
+            )
+            is False
+        )
+
+    def test_client_recipient_returns_false_even_when_on_trigger(self):
+        """Consistency: client recipient is always reply, never forward."""
+        trigger = _thread_msg(
+            "alice@a.com",
+            ["client@external.com", "coord@lrp.com"],
+            msg_id="msg_new",
+        )
+        assert (
+            _is_forward_draft(
+                ["client@external.com"], [trigger], "msg_new", recipient_type="client"
+            )
+            is False
+        )
+
+    def test_recruiter_recipient_keeps_trigger_based_detection(self):
+        """Non-client recipient types retain existing behavior — forwarding
+        to internal LRP folks is safe and often correct."""
+        client_msg = _thread_msg(
+            "client@external.com",
+            ["coord@lrp.com"],
+            msg_id="msg_client",
+        )
+        # Recruiter not on the trigger → forward (preserves existing semantics).
+        assert (
+            _is_forward_draft(
+                ["recruiter@lrp.com"],
+                [client_msg],
+                "msg_client",
+                recipient_type="recruiter",
+            )
+            is True
+        )
+
+    def test_recipient_type_none_legacy_keeps_trigger_based_detection(self):
+        """recipient_type=None (legacy suggestions) → trigger-based detection."""
+        client_msg = _thread_msg(
+            "client@external.com",
+            ["coord@lrp.com"],
+            msg_id="msg_client",
+        )
+        assert (
+            _is_forward_draft(
+                ["new@elsewhere.com"],
+                [client_msg],
+                "msg_client",
+                recipient_type=None,
+            )
+            is True
+        )
+
 
 class _AsyncCtx:
     def __init__(self, value):

--- a/services/api/tests/test_overview_cards.py
+++ b/services/api/tests/test_overview_cards.py
@@ -299,3 +299,44 @@ class TestUpdateActorSuggestionBuilder:
         # Defensive: doesn't render input widgets or the Save button.
         assert "Save" not in text
         assert "update_actor_email_" not in text
+
+    def test_inputs_prefilled_from_pending_pick(self):
+        """When the autocomplete onChange has staged a pick via the route
+        handler, the card builder re-renders with the inputs pre-filled.
+        The user reviews the staged values and must explicitly click Save
+        to commit — autocomplete selection alone does NOT apply the change.
+        """
+        view = _view(
+            action=SuggestedAction.UPDATE_ACTOR,
+            summary="Recruiter looks wrong",
+            action_data={
+                "role": "recruiter",
+                "pending_pick": {
+                    "name": "Alice Recruiter",
+                    "email": "alice@lrp.com",
+                },
+            },
+        )
+        widgets = _build_update_actor_suggestion(view)
+        text = str([w.model_dump(by_alias=True, exclude_none=True) for w in widgets])
+        # The staged pick is visible in the rendered input values.
+        assert "Alice Recruiter" in text
+        assert "alice@lrp.com" in text
+        # Save button is still present — autocomplete-select did NOT commit.
+        assert "update_actor" in text
+
+    def test_inputs_not_prefilled_when_pending_pick_absent(self):
+        view = _view(
+            action=SuggestedAction.UPDATE_ACTOR,
+            summary="Pick a recruiter",
+            action_data={"role": "recruiter"},
+        )
+        widgets = _build_update_actor_suggestion(view)
+        # Pull the input widget values explicitly to assert they're None.
+        # (Searching the JSON dump for absence is fragile because the
+        # field names themselves appear.)
+        inputs = [w.text_input for w in widgets if getattr(w, "text_input", None) is not None]
+        recruiter_inputs = [ti for ti in inputs if ti.name.startswith("update_actor_")]
+        assert recruiter_inputs, "expected at least one update_actor_* input"
+        for ti in recruiter_inputs:
+            assert ti.value is None, f"input {ti.name!r} should have no prefill, got {ti.value!r}"

--- a/services/api/tests/test_overview_cards.py
+++ b/services/api/tests/test_overview_cards.py
@@ -17,9 +17,16 @@ from api.overview.cards import (
     _build_draft_suggestion,
     _build_link_thread_suggestion,
     _build_suggestion_widgets,
+    _build_update_actor_suggestion,
     build_overview,
 )
 from api.overview.models import LoopSuggestionGroup, SuggestionView
+from api.scheduling.cards import set_action_url
+
+# Configure the action URL once so directory autocomplete actions render
+# during card-builder tests (otherwise `directory_search_url()` returns "" and
+# the autocomplete widgets fall back to plain TextInputs).
+set_action_url("https://test.example.com/addon/action")
 
 
 def _suggestion(
@@ -207,7 +214,88 @@ class TestSuggestionDispatcher:
             SuggestedAction.ASK_COORDINATOR,
             SuggestedAction.LINK_THREAD,
             SuggestedAction.CREATE_LOOP,
+            SuggestedAction.UPDATE_ACTOR,
         ]:
-            view = _view(action=action)
+            extra = (
+                {"action_data": {"role": "recruiter"}}
+                if action == SuggestedAction.UPDATE_ACTOR
+                else {}
+            )
+            view = _view(action=action, **extra)
             widgets = _build_suggestion_widgets(view)
             assert len(widgets) > 0, f"No widgets for {action}"
+
+
+class TestUpdateActorSuggestionBuilder:
+    def test_shows_current_recruiter_when_role_is_filled(self):
+        view = _view(
+            action=SuggestedAction.UPDATE_ACTOR,
+            summary="Recruiter looks wrong — confirm",
+            action_data={"role": "recruiter"},
+        )
+        view.recruiter_name = "Rachel Kim"
+        view.recruiter_email = "rachel@lrp.com"
+        widgets = _build_update_actor_suggestion(view)
+        text = str([w.model_dump(by_alias=True, exclude_none=True) for w in widgets])
+        assert "Update Recruiter" in text
+        assert "Currently: Rachel Kim" in text
+        assert "rachel@lrp.com" in text
+        # Internal role → uses directory autocomplete
+        assert "auto_complete_action" in text or "autoCompleteAction" in text
+        # Form input names are suggestion-suffixed
+        assert "update_actor_name_sug_1" in text
+        assert "update_actor_email_sug_1" in text
+        # Save button wired to update_actor handler
+        assert "update_actor" in text
+
+    def test_omits_currently_line_when_role_is_empty(self):
+        view = _view(
+            action=SuggestedAction.UPDATE_ACTOR,
+            summary="No recruiter on this loop — please add one",
+            action_data={"role": "recruiter"},
+        )
+        # recruiter_name / recruiter_email left None by default
+        widgets = _build_update_actor_suggestion(view)
+        text = str([w.model_dump(by_alias=True, exclude_none=True) for w in widgets])
+        assert "Currently" not in text
+
+    def test_client_contact_uses_plain_inputs_not_directory(self):
+        view = _view(
+            action=SuggestedAction.UPDATE_ACTOR,
+            summary="Wrong client contact",
+            action_data={"role": "client_contact"},
+        )
+        view.client_contact_name = "Original Person"
+        view.client_contact_email = "orig@hf.com"
+        widgets = _build_update_actor_suggestion(view)
+        text = str([w.model_dump(by_alias=True, exclude_none=True) for w in widgets])
+        assert "Update Client Contact" in text
+        assert "Currently: Original Person" in text
+        # External role → NO directory autocomplete on the inputs
+        assert "directory/search" not in text
+        # Company input is included for client contacts
+        assert "update_actor_company_sug_1" in text
+
+    def test_client_manager_role_uses_directory_autocomplete(self):
+        view = _view(
+            action=SuggestedAction.UPDATE_ACTOR,
+            summary="Add CM for CC line",
+            action_data={"role": "client_manager"},
+        )
+        widgets = _build_update_actor_suggestion(view)
+        text = str([w.model_dump(by_alias=True, exclude_none=True) for w in widgets])
+        assert "Update Client Manager" in text
+        # Internal role → directory autocomplete present
+        assert "auto_complete_action" in text or "autoCompleteAction" in text
+
+    def test_unknown_role_renders_dismiss_only(self):
+        view = _view(
+            action=SuggestedAction.UPDATE_ACTOR,
+            summary="???",
+            action_data={"role": "nonsense"},
+        )
+        widgets = _build_update_actor_suggestion(view)
+        text = str([w.model_dump(by_alias=True, exclude_none=True) for w in widgets])
+        # Defensive: doesn't render input widgets or the Save button.
+        assert "Save" not in text
+        assert "update_actor_email_" not in text

--- a/services/api/tests/test_scheduling_cards.py
+++ b/services/api/tests/test_scheduling_cards.py
@@ -3,6 +3,7 @@
 from api.scheduling.cards import (
     build_contextual_unlinked,
     build_create_loop_form,
+    build_loop_caught_up_card,
     build_loop_pending_card,
     set_action_url,
 )
@@ -117,3 +118,48 @@ class TestLoopPendingCard:
         assert len(card["sections"]) == 1
         widget_kinds = {next(iter(w.keys())) for w in card["sections"][0]["widgets"]}
         assert widget_kinds == {"textParagraph", "buttonList"}
+
+
+class TestLoopCaughtUpCard:
+    def test_header_is_all_caught_up_not_generating(self):
+        # Regression: the in-message sidebar used to show "Loop created /
+        # Generating suggestions…" indefinitely whenever a linked loop had
+        # no pending suggestions, even after the agent had finished. The
+        # caught-up card replaces that copy when row history exists.
+        data = _card_json(build_loop_caught_up_card("thread_xyz"))
+        card = data["action"]["navigations"][0]["updateCard"]
+        assert card["header"]["title"] == "All caught up"
+        assert "Generating" not in card["header"].get("subtitle", "")
+
+    def test_has_refresh_button_with_reload(self):
+        data = _card_json(build_loop_caught_up_card("thread_xyz"))
+        card = data["action"]["navigations"][0]["updateCard"]
+        buttons = [
+            b
+            for s in card["sections"]
+            for w in s["widgets"]
+            if "buttonList" in w
+            for b in w["buttonList"]["buttons"]
+        ]
+        assert any("Refresh" in b["text"] for b in buttons)
+        refresh = next(b for b in buttons if "Refresh" in b["text"])
+        link = refresh["onClick"]["openLink"]
+        # Same OVERLAY + RELOAD affordance as the pending card — a new
+        # inbound on the thread can still produce fresh suggestions.
+        assert link["url"].endswith("/addon/refresh")
+        assert link["openAs"] == "OVERLAY"
+        assert link["onClose"] == "RELOAD"
+
+    def test_body_does_not_imply_in_flight_work(self):
+        # The whole point of this card vs. the pending one — body copy must
+        # not claim the AI is currently analyzing the thread.
+        data = _card_json(build_loop_caught_up_card("thread_xyz"))
+        card = data["action"]["navigations"][0]["updateCard"]
+        body_text = " ".join(
+            w["textParagraph"]["text"]
+            for s in card["sections"]
+            for w in s["widgets"]
+            if "textParagraph" in w
+        )
+        assert "analyzing" not in body_text.lower()
+        assert "generating" not in body_text.lower()


### PR DESCRIPTION
## Summary

Aligns the `next-action-agent` Python pipeline with the rewritten LangFuse prompt:

- **Input:** `NextActionInput` slimmed to four XML-formatted fields — `date`, `thread_history`, `email`, `loops`. New formatters render emails (`<email direction='inbound|outbound'>...`) and loops (`<loop id='lop_…'><stage>…</stage><actors>…</actors><pending-suggestions>…</pending-suggestions></loop>`). XML escaping on every interpolated value.
- **Output parsing:** extracts JSON array from `<suggestions>[…]</suggestions>` envelope. Tolerates markdown fences, surrounding chatter, and missing tags.
- **Retries via conversation history:** the input-field `error` / `coordinator_response` indirection is gone. On batch-guardrail violations or parse failures the agent appends `assistant` + `user(follow-up)` turns and retries once with the same input. For coordinator responses, the worker now fetches the originating `ASK_COORDINATOR` suggestion and the agent splices a reconstructed prior assistant turn + the coordinator's answer into the conversation.
- **New `expire_suggestion` action:** schema + per-item guardrail (target must be a known pending id) + auto-resolver + `SuggestionService.expire_by_id` + aiosql query.
- **Multi-loop guardrails:** recruiter draft cap (≤ distinct known recruiters on the thread) and single-client-draft cap. Both surface as retryable errors with the user-specified messages.

## Files

- Schema / models: `classifier/{schemas,models}.py`
- Formatters: `classifier/formatters.py` (additive; existing formatters retained for loop classifier)
- Agent: `classifier/next_action_agent.py` (bypasses the generic `LLMEndpoint`; drives `llm.complete()` directly for conversation history)
- Resolver + service: `classifier/{resolvers,service}.py`
- SQL: `queries/suggestions.sql` (new `expire_suggestion` query, no-op when row isn't pending)
- Worker: `gmail/workers.py` (`process_coordinator_response` plumbs `originating_suggestion`)
- Tests: `tests/test_classifier_hook.py` (existing tests rewritten to mock the new pipeline; new coverage for XML formatters, batch guardrails, conversation retry, coordinator response splicing, and expire_suggestion)

## Test plan

- [x] `cd services/api && uv run pytest tests/test_classifier_hook.py tests/test_classifier_formatters.py tests/test_classifier_resolvers.py tests/test_gmail_hooks.py tests/test_gmail_webhook.py -q` → 92/92 pass
- [x] `cd services/api && uv run ruff check src/api/classifier/ src/api/gmail/workers.py tests/test_classifier_hook.py` → clean
- [ ] Local end-to-end: trigger a multi-loop two-recruiter thread, confirm batch guardrail retries land cleanly in LangFuse trace
- [ ] Resolve an `ASK_COORDINATOR` via the addon → new LangFuse trace shows 4-message conversation with reconstructed assistant turn
- [ ] Confirm `expire_suggestion` flips the target row to `expired` in `agent_suggestions`

## Notes for reviewer

- `services/api/tests/test_ai_endpoint.py::TestLLMEndpointCall::test_successful_call_returns_parsed_output` is failing on this branch **and on `main`** — unrelated to this PR (spec mock missing `.name`). Flagged separately.
- The CLAUDE.md "Multi-loop draft strategy" memory remains accurate; the new guardrails enforce what was previously aspirational.
- No new env vars, no Railway changes — references/ docs not touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)