### PR TITLE
fix(tests): unblock test_ai_endpoint.py after prompt-tracing change

### DIFF
--- a/services/api/tests/test_ai_endpoint.py
+++ b/services/api/tests/test_ai_endpoint.py
@@ -25,6 +25,9 @@ class SampleOutput(BaseModel):
 def _make_chat_prompt(config: dict | None = None):
     """Create a mock ChatPromptClient that compiles to a message list."""
     prompt = MagicMock(spec=ChatPromptClient)
+    prompt.name = "scheduling-classify-email"
+    prompt.version = 1
+    prompt.labels = ["production"]
     prompt.config = config or {
         "model": "claude-sonnet-4-20250514",
         "temperature": 0.1,
@@ -295,7 +298,7 @@ class TestLLMEndpointCall:
             data=SampleInput(subject="Test", body="Test"),
         )
 
-        mock_langfuse.update_current_span.assert_called_once_with(
+        mock_langfuse.update_current_span.assert_called_with(
             output={"classification": "scheduling", "confidence": 0.95},
         )
 
@@ -316,6 +319,6 @@ class TestLLMEndpointCall:
             data=SampleInput(subject="Test", body="Test"),
         )
 
-        mock_langfuse.update_current_span.assert_called_once_with(
+        mock_langfuse.update_current_span.assert_called_with(
             output={"classification": "other", "confidence": 0.7},
         )


### PR DESCRIPTION
## Summary

- `services/api/tests/test_ai_endpoint.py` had a pre-existing failure on `main` (reproduces without any new code) — `test_successful_call_returns_parsed_output` raised `AttributeError: Mock object has no attribute 'name'`.
- Root cause: commit 3c13f9b (\"Bug fixes: forward detection, create loop pre-fill, prompt tracing, ...\") added `prompt.name`/`prompt.version`/`prompt.labels` logging in `fetch_prompt` and a new `langfuse.update_current_span(metadata={...})` call in `LLMEndpoint._execute`, but the tests weren't updated to match.
- Fix is test-only:
  - Stub `name`/`version`/`labels` on the spec'd `MagicMock(spec=ChatPromptClient)` in `_make_chat_prompt`. Keeps spec-based drift protection, matches the existing pattern of explicitly stubbing each attribute production code touches (`config`, `is_fallback`, `compile`).
  - Switch two `update_current_span.assert_called_once_with(output=...)` assertions to `assert_called_with(output=...)`. Production now legitimately calls `update_current_span` twice per request (metadata first, then output); `assert_called_with` checks the most recent call and still verifies the test's actual intent — that the parsed output is recorded on the span.

No production code changed.

## Test plan

- [x] `cd services/api && uv run pytest tests/test_ai_endpoint.py -x` — 12 passed
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)