### PR TITLE
obs(agent): capture per-LLM-call diagnostics on parse failure

### DIFF
--- a/services/api/src/api/ai/llm_service.py
+++ b/services/api/src/api/ai/llm_service.py
@@ -34,11 +34,18 @@ DEFAULT_MODEL = os.environ.get("LLM_DEFAULT_MODEL", "google/gemini-2.5-flash")
 
 @dataclass
 class LLMResponse:
-    """Normalized response from an LLM call."""
+    """Normalized response from an LLM call.
+
+    ``finish_reason`` is captured for diagnostic purposes — without it,
+    parse failures on the consumer side can't distinguish "natural stop"
+    from "length truncation" from "content filter," all of which surface
+    as the same parse error at the agent layer.
+    """
 
     content: str
     model: str
     provider: str
+    finish_reason: str | None = None
     usage: dict[str, int] = field(default_factory=dict)
     latency_ms: float = 0.0
 
@@ -216,6 +223,7 @@ class LLMService:
 
             choice = response.choices[0]
             content = choice.message.content or ""
+            finish_reason = getattr(choice, "finish_reason", None)
 
             usage = {}
             if response.usage:
@@ -229,6 +237,7 @@ class LLMService:
                 content=content,
                 model=response.model or candidate_model,
                 provider=_provider_from_model(response.model or candidate_model),
+                finish_reason=finish_reason,
                 usage=usage,
                 latency_ms=elapsed_ms,
             )

--- a/services/api/src/api/classifier/next_action_agent.py
+++ b/services/api/src/api/classifier/next_action_agent.py
@@ -24,6 +24,7 @@ import logging
 import re
 from typing import TYPE_CHECKING, Any
 
+import sentry_sdk
 from langfuse.model import ChatPromptClient
 from pydantic import ValidationError
 
@@ -87,16 +88,25 @@ def _suggestion_fingerprint(loop_id: str | None, action: str, action_data: dict)
 class NextActionAgentError(Exception):
     """Raised when the agent cannot produce a usable response.
 
-    Carries ``raw_responses`` so the caller can write the unparsed LLM
-    output to the LangFuse span even when validation fails. Without this,
-    a parse failure (e.g., the model emits an out-of-enum classification
-    value) yields an empty trace output and we lose visibility into what
-    the model actually produced.
+    Carries ``raw_responses`` and ``call_diagnostics`` so the caller can
+    write the unparsed LLM output AND per-call diagnostic metadata
+    (finish_reason, completion_tokens, model, provider, latency) to the
+    LangFuse span when validation fails. Without ``call_diagnostics`` we
+    can't distinguish "natural stop with bad content" from "length
+    truncation" from "content filter" — they all surface as the same
+    parse error at the agent layer.
     """
 
-    def __init__(self, message: str, *, raw_responses: list[str] | None = None):
+    def __init__(
+        self,
+        message: str,
+        *,
+        raw_responses: list[str] | None = None,
+        call_diagnostics: list[dict] | None = None,
+    ):
         super().__init__(message)
         self.raw_responses = list(raw_responses or [])
+        self.call_diagnostics = list(call_diagnostics or [])
 
 
 class NextActionAgent:
@@ -177,7 +187,7 @@ class NextActionAgent:
                     )
                     return
                 try:
-                    valid_items, raw_responses = await self._act_with_messages(
+                    valid_items, raw_responses, call_diagnostics = await self._act_with_messages(
                         prompt,
                         messages,
                         linked_loops,
@@ -187,15 +197,33 @@ class NextActionAgent:
                 except NextActionAgentError as exc:
                     # The model produced something — we just couldn't use it
                     # (schema mismatch, malformed JSON, etc.). Put the raw
-                    # content on the LangFuse span before the exception
-                    # escapes this with-block (the span closes on exit).
-                    # The outer except creates the manual-review fallback.
+                    # content AND per-call diagnostics (finish_reason,
+                    # completion_tokens, model, provider, latency) on the
+                    # LangFuse span before the exception escapes this with-
+                    # block. The diagnostics are load-bearing for diagnosing
+                    # WHY the response was bad: a finish_reason of "stop"
+                    # with completion_tokens far below max_tokens points to
+                    # the model emitting an early EOS rather than length
+                    # truncation. The outer except creates the manual-review
+                    # fallback.
                     self._langfuse.update_current_span(
                         output={
                             "raw_responses": exc.raw_responses,
+                            "call_diagnostics": exc.call_diagnostics,
                             "parse_error": str(exc),
                         }
                     )
+                    # Sentry context so the existing Sentry error captures
+                    # surface the diagnostic fields without us needing to
+                    # query LangFuse to correlate.
+                    if exc.call_diagnostics:
+                        sentry_sdk.set_context(
+                            "next_action_agent",
+                            {
+                                "call_count": len(exc.call_diagnostics),
+                                "last_call": exc.call_diagnostics[-1],
+                            },
+                        )
                     raise
                 self._langfuse.update_current_span(
                     output={
@@ -210,6 +238,7 @@ class NextActionAgent:
                             for item, _ in valid_items
                         ],
                         "raw_responses": raw_responses,
+                        "call_diagnostics": call_diagnostics,
                     }
                 )
         except Exception:
@@ -338,26 +367,44 @@ class NextActionAgent:
         *,
         allow_retry: bool,
         prior_responses: list[str] | None = None,
-    ) -> tuple[list[tuple[SuggestionItem, Loop | None]], list[str]]:
+        prior_diagnostics: list[dict] | None = None,
+    ) -> tuple[list[tuple[SuggestionItem, Loop | None]], list[str], list[dict]]:
         """Run one LLM round-trip and validate the result.
 
         On batch/per-item errors, optionally append the assistant reply plus a
         user follow-up describing the errors and recurse once with
         ``allow_retry=False``.
 
-        Returns ``(valid_items, raw_responses)`` where ``raw_responses`` is the
-        full list of assistant payloads across the initial call and any retry —
-        captured on the span output so LangFuse traces show what the model
-        produced even if guardrails dropped items.
+        Returns ``(valid_items, raw_responses, call_diagnostics)``. The two
+        list returns are accumulated across the initial call and any retry —
+        each call appends one element to each list, in chronological order,
+        so ``call_diagnostics[i]`` describes the LLM call that produced
+        ``raw_responses[i]``. Both are written to the LangFuse span on
+        success and attached to ``NextActionAgentError`` on failure.
         """
         prior_responses = prior_responses or []
+        prior_diagnostics = prior_diagnostics or []
         response = await self._call_llm(prompt, messages)
         responses = [*prior_responses, response.content]
+        diagnostics = [
+            *prior_diagnostics,
+            _diagnostics_from_response(response, attempt=len(prior_responses)),
+        ]
         try:
             result = self._parse_response(response.content)
         except NextActionAgentError as exc:
             if allow_retry:
-                logger.warning("next-action-agent parse failed (%s) — retrying with follow-up", exc)
+                logger.warning(
+                    "next-action-agent parse failed (%s) — retrying with follow-up "
+                    "[finish_reason=%s, completion_tokens=%s, model=%s, "
+                    "provider=%s, latency_ms=%.0f]",
+                    exc,
+                    response.finish_reason,
+                    response.usage.get("completion_tokens"),
+                    response.model,
+                    response.provider,
+                    response.latency_ms,
+                )
                 follow_up = (
                     "Your previous response could not be parsed. "
                     f"Error: {exc}\n\n"
@@ -376,12 +423,31 @@ class NextActionAgent:
                     existing_pending,
                     allow_retry=False,
                     prior_responses=responses,
+                    prior_diagnostics=diagnostics,
                 )
-            # Final failure on the retry attempt — attach the accumulated
-            # responses so the caller can put them on the LangFuse span
-            # before falling through to the manual-review fallback. The bare
-            # ``raise`` would discard the responses list (and the trace).
-            raise NextActionAgentError(str(exc), raw_responses=responses) from exc
+            # Final failure on the retry attempt — attach both raw responses
+            # AND per-call diagnostic metadata so the caller can put them on
+            # the LangFuse span and Sentry context. Without diagnostics
+            # ("finish_reason=stop, completion_tokens=140, ..."), we can't
+            # distinguish natural-stop / length / content-filter failures
+            # from each other — they all surface as the same parse error.
+            logger.warning(
+                "next-action-agent parse failed on retry (%s) — giving up "
+                "[final_finish_reason=%s, completion_tokens=%s, model=%s, "
+                "provider=%s, latency_ms=%.0f, total_attempts=%d]",
+                exc,
+                response.finish_reason,
+                response.usage.get("completion_tokens"),
+                response.model,
+                response.provider,
+                response.latency_ms,
+                len(diagnostics),
+            )
+            raise NextActionAgentError(
+                str(exc),
+                raw_responses=responses,
+                call_diagnostics=diagnostics,
+            ) from exc
 
         valid_items, errors = self._validate_batch(
             result.suggestions, linked_loops, existing_pending
@@ -404,6 +470,7 @@ class NextActionAgent:
                 existing_pending,
                 allow_retry=False,
                 prior_responses=responses,
+                prior_diagnostics=diagnostics,
             )
 
         if errors:
@@ -413,7 +480,7 @@ class NextActionAgent:
                 len(valid_items),
             )
 
-        return valid_items, responses
+        return valid_items, responses, diagnostics
 
     async def _call_llm(self, prompt: Any, messages: list[dict[str, str]]) -> LLMResponse:
         """Dispatch the conversation to the LLM service.
@@ -713,6 +780,26 @@ _REJECTION_FOLLOWUP_TEXT = (
     "If no materially different alternative is appropriate, emit no_action. "
     "It is better to do nothing than to propose another likely-bad option."
 )
+
+
+def _diagnostics_from_response(response: LLMResponse, *, attempt: int) -> dict:
+    """Distill an LLMResponse into a JSON-friendly diagnostic dict.
+
+    These end up on the LangFuse span and Sentry error context, so they
+    have to round-trip through JSON cleanly. Keep the shape stable —
+    LangFuse / Sentry dashboards may filter or alert on these keys.
+    """
+    return {
+        "attempt": attempt,  # 0 for initial call, 1 for retry, etc.
+        "finish_reason": response.finish_reason,
+        "model": response.model,
+        "provider": response.provider,
+        "latency_ms": round(response.latency_ms, 1),
+        "prompt_tokens": response.usage.get("prompt_tokens"),
+        "completion_tokens": response.usage.get("completion_tokens"),
+        "total_tokens": response.usage.get("total_tokens"),
+        "content_length_chars": len(response.content or ""),
+    }
 
 
 def _build_error_followup(errors: list[str]) -> str:

--- a/services/api/tests/test_classifier_hook.py
+++ b/services/api/tests/test_classifier_hook.py
@@ -188,13 +188,24 @@ def _make_agent():
     return agent, suggestion_service
 
 
-def _llm_response(content: str):
-    """Stub for the LLMResponse return value from LLMService.complete()."""
+def _llm_response(content: str, *, finish_reason: str = "stop", completion_tokens: int = 100):
+    """Stub for the LLMResponse return value from LLMService.complete().
+
+    Default finish_reason='stop' and a small completion_tokens count mirror
+    the most common real-world response shape so tests touching diagnostics
+    don't have to set them every time.
+    """
     resp = MagicMock()
     resp.content = content
     resp.model = "test-model"
     resp.provider = "test"
+    resp.finish_reason = finish_reason
     resp.latency_ms = 1.0
+    resp.usage = {
+        "prompt_tokens": 1000,
+        "completion_tokens": completion_tokens,
+        "total_tokens": 1000 + completion_tokens,
+    }
     return resp
 
 
@@ -530,14 +541,64 @@ class TestErrorHandling:
         assert call_kwargs["item"].action == SuggestedAction.ASK_COORDINATOR
         assert call_kwargs["item"].confidence == 0.0
 
+    @pytest.mark.asyncio
+    async def test_parse_failure_writes_call_diagnostics_to_langfuse(self):
+        """LangFuse span output must include per-call diagnostics
+        (finish_reason, completion_tokens, model, provider) on the failure
+        path. Without these, "agent failed to parse" traces are
+        indistinguishable from each other and can't be triaged from the
+        dashboard alone.
+        """
+        agent, _ = _make_agent()
+        bad = "no envelope in here at all"
+        agent._llm.complete = AsyncMock(
+            side_effect=[
+                _llm_response(bad, finish_reason="stop", completion_tokens=42),
+                _llm_response(bad, finish_reason="stop", completion_tokens=18),
+            ]
+        )
+
+        with patch(
+            "api.classifier.next_action_agent.fetch_prompt",
+            return_value=_FakeTextPrompt(),
+        ):
+            await agent.act(_event(), [_loop()])
+
+        update_calls = agent._langfuse.update_current_span.call_args_list
+        failure_update = next(
+            (call for call in update_calls if "parse_error" in (call.kwargs.get("output") or {})),
+            None,
+        )
+        assert failure_update is not None
+        output = failure_update.kwargs["output"]
+        diagnostics = output["call_diagnostics"]
+        assert len(diagnostics) == 2, "expected one diagnostics entry per LLM call"
+
+        # First attempt diagnostics
+        assert diagnostics[0]["attempt"] == 0
+        assert diagnostics[0]["finish_reason"] == "stop"
+        assert diagnostics[0]["completion_tokens"] == 42
+        assert diagnostics[0]["model"] == "test-model"
+        assert diagnostics[0]["provider"] == "test"
+        assert diagnostics[0]["content_length_chars"] == len(bad)
+
+        # Retry attempt diagnostics
+        assert diagnostics[1]["attempt"] == 1
+        assert diagnostics[1]["completion_tokens"] == 18
+
     def test_next_action_agent_error_carries_raw_responses(self):
-        """Plain unit assertion that the exception preserves raw_responses."""
+        """Plain unit assertion that the exception preserves raw_responses
+        and call_diagnostics."""
         from api.classifier.next_action_agent import NextActionAgentError
 
-        exc = NextActionAgentError("nope", raw_responses=["a", "b"])
+        diag = [{"attempt": 0, "finish_reason": "stop", "completion_tokens": 100}]
+        exc = NextActionAgentError("nope", raw_responses=["a", "b"], call_diagnostics=diag)
         assert exc.raw_responses == ["a", "b"]
-        # Default empty when not provided — keeps the no-payload call sites valid.
-        assert NextActionAgentError("nope").raw_responses == []
+        assert exc.call_diagnostics == diag
+        # Defaults empty when not provided.
+        bare = NextActionAgentError("nope")
+        assert bare.raw_responses == []
+        assert bare.call_diagnostics == []
 
 
 # --- Coordinator name resolution ---


### PR DESCRIPTION
## Summary

Next-action-agent parse failures in prod currently come through as `NextActionAgentError` + a manual-review fallback `ASK_COORDINATOR`, with `raw_responses` on the LangFuse span. That's enough to see WHAT the model emitted, but not WHY — we can't distinguish a natural early stop (`finish_reason=stop` with low `completion_tokens`) from length truncation (`finish_reason=length`) from content filtering without the API's `finish_reason` and token counts.

The recent prod investigation into Gemini Flash 2.5 stopping mid-thought took multiple rounds of speculation specifically because these fields weren't in the trace. This PR adds them so future debugging is one-trace-away.

## What changed

1. **`LLMResponse`** gains `finish_reason: str | None`. `LLMService` extracts it from `choice.finish_reason` at the same point we already read `choice.message.content`. Zero behavior change.

2. **`NextActionAgent._act_with_messages`** accumulates a parallel `call_diagnostics: list[dict]` alongside `raw_responses`. Each entry carries `{attempt, finish_reason, model, provider, latency_ms, prompt_tokens, completion_tokens, total_tokens, content_length_chars}`. On success the list rides on the return tuple and lands in `span.output`. On failure it's attached to `NextActionAgentError` (alongside `raw_responses`) and surfaced in both `span.output` AND Sentry context under `next_action_agent`.

3. **Parse-failure log lines** upgraded to include `finish_reason`, `completion_tokens`, `model`, `provider`, and `latency_ms`. The retry-also-failed log line includes those plus `total_attempts`. So in addition to LangFuse and Sentry, plain log inspection now answers \"what kind of failure was this?\"

## Why this matters for the live investigation

Gemini Flash 2.5 in prod fails ~2% of calls with `finish_reason=stop` and completion tokens far below `max_tokens` (i.e., the model is choosing to stop early, not getting truncated). Now we can confirm that hypothesis deterministically from any single failed trace, and we'll see if the pattern shifts (e.g., a provider routing change starts surfacing as `finish_reason=length` on a specific provider).

## Test plan

- [x] \`cd services/api && uv run pytest tests/test_classifier_hook.py tests/test_ai_llm_service.py -q\` — 80/80 pass
- [x] \`uv run ruff check src/api/ai src/api/classifier\` — clean
- [x] New test \`test_parse_failure_writes_call_diagnostics_to_langfuse\` asserts both call entries carry the right `attempt` index, `finish_reason`, `completion_tokens`, `model`, `provider`, and `content_length_chars`
- [x] Updated unit test \`test_next_action_agent_error_carries_raw_responses\` confirms `call_diagnostics` is preserved through the exception with default `[]` when not provided
- [ ] Observe a real parse-failure trace post-merge to confirm the new fields appear in LangFuse + Sentry

🤖 Generated with [Claude Code](https://claude.com/claude-code)