### PR TITLE
fix(debug-ui): merge multi-thread emails and align timeline sort direction

### DIFF
--- a/services/debug-ui/src/components/message-card.tsx
+++ b/services/debug-ui/src/components/message-card.tsx
@@ -1,17 +1,40 @@
 import type { GmailMessage } from "@/lib/gmail/types";
+import { Badge } from "@/components/ui/badge";
 
 function formatAddr(addr: { name: string | null; email: string }) {
   return addr.name ? `${addr.name} <${addr.email}>` : addr.email;
 }
 
-export function MessageCard({ message }: { message: GmailMessage }) {
+export function MessageCard({
+  message,
+  threadLabel,
+}: {
+  message: GmailMessage;
+  threadLabel?: { subject: string; gmailThreadId: string };
+}) {
   return (
     <div className="border rounded p-3 space-y-1">
-      <div className="flex items-center justify-between">
-        <span className="text-sm font-medium">{formatAddr(message.from)}</span>
-        <span className="text-xs text-muted-foreground">
-          {new Date(message.date).toLocaleString()}
+      <div className="flex items-center justify-between gap-2">
+        <span className="text-sm font-medium truncate">
+          {formatAddr(message.from)}
         </span>
+        <div className="flex items-center gap-2 shrink-0">
+          {threadLabel && (
+            <Badge
+              variant="outline"
+              className="text-[10px] font-normal max-w-[16rem] truncate"
+              title={`${threadLabel.subject} (${threadLabel.gmailThreadId})`}
+            >
+              <span className="truncate">{threadLabel.subject || "(no subject)"}</span>
+              <span className="ml-1 text-muted-foreground">
+                {threadLabel.gmailThreadId.slice(-6)}
+              </span>
+            </Badge>
+          )}
+          <span className="text-xs text-muted-foreground">
+            {new Date(message.date).toLocaleString()}
+          </span>
+        </div>
       </div>
       <div className="text-xs text-muted-foreground">
         To: {message.to.map(formatAddr).join(", ")}

--- a/services/debug-ui/src/components/thread-list.tsx
+++ b/services/debug-ui/src/components/thread-list.tsx
@@ -1,5 +1,5 @@
 import type { EmailThread, SuggestionForLoop } from "@/lib/types";
-import type { GmailThread } from "@/lib/gmail/types";
+import type { GmailMessage, GmailThread } from "@/lib/gmail/types";
 import { MessageCard } from "./message-card";
 import { Badge } from "@/components/ui/badge";
 
@@ -48,41 +48,45 @@ export function ThreadList({
     );
   }
 
-  return (
-    <div className="space-y-4">
-      {threads.map((thread) => {
-        const gmailThread = gmailThreads.get(thread.gmail_thread_id);
+  const rows: Array<{ msg: GmailMessage; thread: EmailThread }> = [];
+  const failedThreads: EmailThread[] = [];
 
-        return (
-          <div key={thread.id} className="space-y-2">
-            <div className="flex items-center gap-2">
-              <span className="text-sm font-medium">
-                {thread.subject || "No subject"}
-              </span>
-              <span className="text-xs text-muted-foreground">
-                {thread.gmail_thread_id}
-              </span>
-            </div>
-            {gmailThread ? (
-              <div className="space-y-2">
-                {gmailThread.messages.map((msg) => (
-                  <div key={msg.id}>
-                    <MessageCard message={msg} />
-                    <SuggestionsForMessage
-                      messageId={msg.id}
-                      suggestions={suggestions}
-                    />
-                  </div>
-                ))}
-              </div>
-            ) : (
-              <p className="text-xs text-muted-foreground italic">
-                Could not fetch Gmail thread messages.
-              </p>
-            )}
-          </div>
-        );
-      })}
+  for (const thread of threads) {
+    const gmailThread = gmailThreads.get(thread.gmail_thread_id);
+    if (!gmailThread) {
+      failedThreads.push(thread);
+      continue;
+    }
+    for (const msg of gmailThread.messages) {
+      rows.push({ msg, thread });
+    }
+  }
+
+  rows.sort(
+    (a, b) => new Date(a.msg.date).getTime() - new Date(b.msg.date).getTime()
+  );
+
+  return (
+    <div className="space-y-2">
+      {rows.map(({ msg, thread }) => (
+        <div key={msg.id}>
+          <MessageCard
+            message={msg}
+            threadLabel={{
+              subject: thread.subject || "No subject",
+              gmailThreadId: thread.gmail_thread_id,
+            }}
+          />
+          <SuggestionsForMessage messageId={msg.id} suggestions={suggestions} />
+        </div>
+      ))}
+      {failedThreads.length > 0 && (
+        <p className="text-xs text-muted-foreground italic">
+          Could not fetch Gmail messages for{" "}
+          {failedThreads.length === 1 ? "thread" : "threads"}:{" "}
+          {failedThreads.map((t) => t.gmail_thread_id).join(", ")}
+        </p>
+      )}
     </div>
   );
 }

--- a/services/debug-ui/src/lib/queries/suggestions.ts
+++ b/services/debug-ui/src/lib/queries/suggestions.ts
@@ -202,7 +202,7 @@ export async function getSuggestionsForLoop(
     FROM agent_suggestions s
     LEFT JOIN email_drafts d ON d.suggestion_id = s.id
     WHERE s.loop_id = $1
-    ORDER BY s.created_at DESC`,
+    ORDER BY s.created_at ASC`,
     [loopId]
   );
 }


### PR DESCRIPTION
## Summary

Two ordering bugs in the debug UI loop view, both surfaced when looking at multi-thread loops:

- **Emails were grouped, not merged.** When a loop linked multiple Gmail threads, the view rendered each thread as its own block (all of thread A in date order, then all of thread B in date order). You couldn't follow what actually happened across the loop in time.
- **Email and suggestion timelines sorted opposite ways.** Emails ascended (oldest → newest), suggestion history descended (newest → oldest). Reading them side-by-side was confusing.

## What changed

- [services/debug-ui/src/components/thread-list.tsx](services/debug-ui/src/components/thread-list.tsx) — flatten messages across all linked threads, sort ascending by date, render one merged timeline. Threads that fail to fetch are listed in a single trailing line instead of inline.
- [services/debug-ui/src/components/message-card.tsx](services/debug-ui/src/components/message-card.tsx) — new optional `threadLabel` prop. When provided, the header gets a compact badge showing the thread subject + last 6 chars of the gmail thread id (full id on hover).
- [services/debug-ui/src/lib/queries/suggestions.ts](services/debug-ui/src/lib/queries/suggestions.ts) — `getSuggestionsForLoop` flipped from `ORDER BY created_at DESC` → `ASC`, so the suggestion history reads the same direction as the email timeline. (The other query in this file already uses ASC.)

No backend or schema changes. The fetch layer still returns thread-grouped data — the flatten happens at render time, so `getGmailThread` / `getThreadsForLoop` remain reusable for views that *want* thread grouping.

## Test plan

- [ ] Open a loop with multiple linked Gmail threads in the debug UI. Confirm: messages appear in a single date-sorted timeline; each message shows a thread-subject badge; oldest is at the top.
- [ ] Open a single-thread loop. Confirm: still renders correctly with one badge value across all messages.
- [ ] Scroll to Suggestion History. Confirm: oldest at the top, newest at the bottom — same direction as the email timeline above.
- [ ] Temporarily break a linked thread's gmail id (or pick a loop with a stale thread). Confirm: the surviving thread's messages still render, and the failed thread id is reported in the trailing line rather than blowing up the view.

🤖 Generated with [Claude Code](https://claude.com/claude-code)