### PR TITLE
fix(agent): auto-resolve no_action suggestions on creation

### DIFF
--- a/services/api/src/api/classifier/resolvers.py
+++ b/services/api/src/api/classifier/resolvers.py
@@ -1,13 +1,15 @@
 """Auto-resolver registry — actions applied without coordinator approval.
 
-Some actions (CREATE_LOOP, ADVANCE_STAGE, LINK_THREAD) are mechanical —
-there is no judgment for the coordinator to add. The matching resolver
-applies them in the background and marks the suggestion AUTO_APPLIED so the
-overview UI never surfaces it.
+Some actions (CREATE_LOOP, ADVANCE_STAGE, LINK_THREAD, EXPIRE_SUGGESTION,
+NO_ACTION) are mechanical or carry no work the coordinator should review.
+The matching resolver applies them in the background and marks the
+suggestion AUTO_APPLIED so the overview UI never surfaces it.
 
 Two registries serve the two-stage pipeline:
-- build_classifier_registry(): CREATE_LOOP, LINK_THREAD (for LoopClassifier)
-- build_agent_registry(): ADVANCE_STAGE (for NextActionAgent)
+- build_classifier_registry(): CREATE_LOOP, LINK_THREAD, NO_ACTION
+  (for LoopClassifier)
+- build_agent_registry(): ADVANCE_STAGE, EXPIRE_SUGGESTION, NO_ACTION
+  (for NextActionAgent)
 
 After CREATE_LOOP/LINK_THREAD auto-resolve, enqueue_next_action() fires
 the NextActionAgent on the now-linked thread — this prevents the recursion
@@ -315,6 +317,25 @@ class ExpireSuggestionResolver:
 
 
 # ---------------------------------------------------------------------------
+# NO_ACTION
+# ---------------------------------------------------------------------------
+
+
+class NoActionResolver:
+    """No-op resolver for NO_ACTION.
+
+    NO_ACTION means the LLM explicitly decided to do nothing — typically a
+    rejection follow-up where no materially different alternative exists.
+    The row is persisted for the debug-UI timeline (reasoning intact) but
+    marked terminal at creation so it never lingers in pending_ids and
+    prompt the agent to emit a wasteful expire_suggestion on the next turn.
+    """
+
+    async def resolve(self, suggestion: Suggestion, ctx: ResolverContext) -> None:
+        return
+
+
+# ---------------------------------------------------------------------------
 # Registry
 # ---------------------------------------------------------------------------
 
@@ -324,6 +345,7 @@ def build_classifier_registry() -> dict[SuggestedAction, Resolver]:
     return {
         SuggestedAction.CREATE_LOOP: CreateLoopResolver(),
         SuggestedAction.LINK_THREAD: LinkThreadResolver(),
+        SuggestedAction.NO_ACTION: NoActionResolver(),
     }
 
 
@@ -332,6 +354,7 @@ def build_agent_registry() -> dict[SuggestedAction, Resolver]:
     return {
         SuggestedAction.ADVANCE_STAGE: AdvanceStageResolver(),
         SuggestedAction.EXPIRE_SUGGESTION: ExpireSuggestionResolver(),
+        SuggestedAction.NO_ACTION: NoActionResolver(),
     }
 
 

--- a/services/api/tests/test_classifier_resolvers.py
+++ b/services/api/tests/test_classifier_resolvers.py
@@ -1,4 +1,4 @@
-"""Tests for the auto-resolver registry — CreateLoop, AdvanceStage, LinkThread."""
+"""Tests for the auto-resolver registry — CreateLoop, AdvanceStage, LinkThread, NoAction."""
 
 from datetime import UTC, datetime
 from unittest.mock import AsyncMock, MagicMock
@@ -15,7 +15,10 @@ from api.classifier.resolvers import (
     AdvanceStageResolver,
     CreateLoopResolver,
     LinkThreadResolver,
+    NoActionResolver,
     ResolverContext,
+    build_agent_registry,
+    build_classifier_registry,
     build_registry,
     try_auto_resolve,
 )
@@ -208,13 +211,38 @@ class TestLinkThreadResolver:
         loop_service.link_thread.assert_not_called()
 
 
+class TestNoActionResolver:
+    @pytest.mark.asyncio
+    async def test_resolve_is_a_noop(self):
+        loop_service = MagicMock()
+        loop_service.advance_state = AsyncMock()
+        loop_service.create_loop = AsyncMock()
+        loop_service.link_thread = AsyncMock()
+        suggestion_service = MagicMock()
+        suggestion_service.expire_by_id = AsyncMock()
+
+        suggestion = _suggestion(SuggestedAction.NO_ACTION)
+        ctx = _ctx(loop_service, suggestion_service, arq_pool=AsyncMock())
+        await NoActionResolver().resolve(suggestion, ctx)
+
+        loop_service.advance_state.assert_not_called()
+        loop_service.create_loop.assert_not_called()
+        loop_service.link_thread.assert_not_called()
+        suggestion_service.expire_by_id.assert_not_called()
+
+
 class TestRegistry:
-    def test_combined_registry_has_three_actions(self):
+    def test_combined_registry_has_expected_actions(self):
         registry = build_registry()
         assert SuggestedAction.CREATE_LOOP in registry
         assert SuggestedAction.ADVANCE_STAGE in registry
         assert SuggestedAction.LINK_THREAD in registry
+        assert SuggestedAction.NO_ACTION in registry
         assert SuggestedAction.DRAFT_EMAIL not in registry
+
+    def test_no_action_registered_in_both_registries(self):
+        assert SuggestedAction.NO_ACTION in build_classifier_registry()
+        assert SuggestedAction.NO_ACTION in build_agent_registry()
 
 
 class TestTryAutoResolve:
@@ -240,8 +268,24 @@ class TestTryAutoResolve:
         assert kwargs["status"] == SuggestionStatus.AUTO_APPLIED
 
     @pytest.mark.asyncio
-    async def test_returns_false_when_action_not_registered(self):
+    async def test_no_action_is_marked_auto_applied(self):
+        suggestion_service = MagicMock()
+        suggestion_service.resolve = AsyncMock()
         suggestion = _suggestion(SuggestedAction.NO_ACTION)
+        ctx = _ctx(MagicMock(), suggestion_service)
+
+        applied = await try_auto_resolve(suggestion, ctx, build_agent_registry())
+
+        assert applied is True
+        suggestion_service.resolve.assert_awaited_once()
+        call = suggestion_service.resolve.await_args
+        assert call.args[0] == "sug_1"
+        assert call.kwargs["status"] == SuggestionStatus.AUTO_APPLIED
+        assert call.kwargs["resolved_by"] == "agent"
+
+    @pytest.mark.asyncio
+    async def test_returns_false_when_action_not_registered(self):
+        suggestion = _suggestion(SuggestedAction.DRAFT_EMAIL)
         ctx = _ctx(MagicMock(), MagicMock())
         applied = await try_auto_resolve(suggestion, ctx, build_registry())
         assert applied is False


### PR DESCRIPTION
## Summary

- `no_action` suggestions are inserted as `PENDING`. The UI hides them via `AND s.action != 'no_action'`, but the agent still sees them in `pending_ids` and emits `expire_suggestion` to clean them up — extra LLM round-trips and extra suggestion rows for nothing.
- Add a no-op `NoActionResolver` and register it in both `build_classifier_registry()` and `build_agent_registry()`. `try_auto_resolve` then marks new `no_action` rows `AUTO_APPLIED` on creation. Row + reasoning are preserved for the debug-UI timeline; the agent never wastes a turn expiring them.
- `AGENT_AUTO_RESOLVE_ACTIONS` is derived from `build_agent_registry()` so it picks up `NO_ACTION` automatically.

## Why this is safe

`no_action` rows in the DB today come from one place: the LLM legitimately emitted `no_action` and it passed guardrails (most commonly the rejection-followup case where no materially different alternative exists). Guardrail-failed items are **not** persisted at either call site — they're filtered out of `valid_items` before `create_suggestion`. So flipping these rows to terminal at creation doesn't hide any failure signal.

## Test plan

- [x] `pytest tests/test_classifier_resolvers.py` — 15/15 pass (3 new tests covering the resolver, dual registration, and the AUTO_APPLIED flow)
- [ ] Trigger the agent on a rejection-followup thread and confirm the `no_action` row appears as `auto_applied` in the debug timeline, and that no subsequent `expire_suggestion` is emitted against it
- [ ] (Optional) Backfill: `UPDATE agent_suggestions SET status='auto_applied', resolved_at=now(), resolved_by='backfill' WHERE action='no_action' AND status='pending';`