### PR TITLE
refactor(agent): remove recruiter draft count guardrail

### DIFF
--- a/services/api/src/api/classifier/next_action_agent.py
+++ b/services/api/src/api/classifier/next_action_agent.py
@@ -673,21 +673,6 @@ class NextActionAgent:
 
             valid.append((item, target_loop))
 
-        # Batch-level: recruiter draft cap.
-        recruiter_drafts = sum(
-            1
-            for it, _ in valid
-            if it.action == SuggestedAction.DRAFT_EMAIL
-            and it.action_data.get("recipient_type") == "recruiter"
-        )
-        known_recruiters = len({lp.recruiter_id for lp in linked_loops if lp.recruiter_id})
-        if recruiter_drafts > known_recruiters:
-            errors.append(
-                f"Too many recruiter draft emails ({recruiter_drafts}) for "
-                f"{known_recruiters} known recruiter(s) on this thread — combine updates "
-                "so each recruiter receives a single email covering all of their candidates."
-            )
-
         # Batch-level: only one client draft per generation.
         client_drafts = sum(
             1

--- a/services/api/tests/test_classifier_hook.py
+++ b/services/api/tests/test_classifier_hook.py
@@ -1076,40 +1076,6 @@ def _two_loop_thread() -> list[Loop]:
 
 
 class TestBatchGuardrails:
-    def test_recruiter_draft_count_exceeds_known_recruiters(self):
-        agent, _ = _make_agent()
-        loops = [_loop()]  # one recruiter on the thread
-        items = [
-            _suggestion_item(
-                action=SuggestedAction.DRAFT_EMAIL,
-                action_data={"body": "A", "recipient_type": "recruiter"},
-            ),
-            _suggestion_item(
-                action=SuggestedAction.DRAFT_EMAIL,
-                action_data={"body": "B", "recipient_type": "recruiter"},
-            ),
-        ]
-        _, errors = agent._validate_batch(items, loops, [])
-        assert any("recruiter draft emails" in e for e in errors)
-
-    def test_recruiter_drafts_match_recruiter_count(self):
-        agent, _ = _make_agent()
-        loops = _two_loop_thread()
-        items = [
-            _suggestion_item(
-                action=SuggestedAction.DRAFT_EMAIL,
-                target_loop_id="lop_1",
-                action_data={"body": "A", "recipient_type": "recruiter"},
-            ),
-            _suggestion_item(
-                action=SuggestedAction.DRAFT_EMAIL,
-                target_loop_id="lop_2",
-                action_data={"body": "B", "recipient_type": "recruiter"},
-            ),
-        ]
-        _, errors = agent._validate_batch(items, loops, [])
-        assert not [e for e in errors if "recruiter draft" in e]
-
     def test_multiple_client_drafts_rejected(self):
         agent, _ = _make_agent()
         loops = _two_loop_thread()
@@ -1133,53 +1099,6 @@ class TestBatchGuardrails:
 
 
 class TestConversationRetry:
-    @pytest.mark.asyncio
-    async def test_batch_error_triggers_followup_with_history(self):
-        agent, suggestion_service = _make_agent()
-        loops = [_loop()]
-
-        # First call: two recruiter drafts (violates batch guardrail).
-        bad_items = [
-            _suggestion_item(
-                action=SuggestedAction.DRAFT_EMAIL,
-                action_data={"body": "A", "recipient_type": "recruiter"},
-            ),
-            _suggestion_item(
-                action=SuggestedAction.DRAFT_EMAIL,
-                action_data={"body": "B", "recipient_type": "recruiter"},
-            ),
-        ]
-        # Retry call: one recruiter draft (valid).
-        good_items = [
-            _suggestion_item(
-                action=SuggestedAction.DRAFT_EMAIL,
-                action_data={"body": "Combined", "recipient_type": "recruiter"},
-            ),
-        ]
-
-        responses = [
-            _llm_response(_suggestions_envelope(bad_items)),
-            _llm_response(_suggestions_envelope(good_items)),
-        ]
-        agent._llm.complete = AsyncMock(side_effect=responses)
-
-        with patch(
-            "api.classifier.next_action_agent.fetch_prompt",
-            return_value=_FakeTextPrompt(),
-        ):
-            await agent.act(_event(), loops)
-
-        # Two LLM calls: original + retry.
-        assert agent._llm.complete.await_count == 2
-
-        # Second call's messages must include the original + assistant turn + error follow-up.
-        retry_messages = agent._llm.complete.await_args_list[1].kwargs["messages"]
-        roles = [m["role"] for m in retry_messages]
-        assert roles == ["system", "user", "assistant", "user"]
-        assert "errors" in retry_messages[-1]["content"].lower()
-
-        suggestion_service.create_suggestion.assert_called_once()
-
     @pytest.mark.asyncio
     async def test_coordinator_response_splices_prior_turn(self):
         agent, _suggestion_service = _make_agent()


### PR DESCRIPTION
## Summary
- Drop the `_validate_batch` rule that errored when recruiter `DRAFT_EMAIL` suggestions exceeded the count of distinct recruiters on a thread. The constraint conflated the one-loop-per-candidate strategy with a hard draft-count cap that didn't generalize (e.g. distinct updates for distinct candidates who share a recruiter).
- Delete the three tests that exercised the cap directly, including `test_batch_error_triggers_followup_with_history` which used the cap as its retry trigger. The surviving `_FakeTextPrompt`-based retry test (`test_coordinator_response_splices_prior_turn`) still covers the conversation-history retry path.
- The one-client-draft-per-generation cap is unchanged.

## Test plan
- [x] `uv run pytest tests/test_classifier_hook.py -v` — 59 passed
- [x] `grep -rn "recruiter_drafts\|known_recruiters\|recruiter draft emails" services/api/src services/api/tests` — zero matches
- [x] `uv run ruff check` and `uv run ruff format --check` on touched files

## Follow-up
- The LangFuse `next-action-agent` prompt may still instruct the model to combine recruiter updates into one email per recruiter. Reviewing/relaxing the prompt is intentionally out of scope for this PR.