### PR TITLE
feat(agent): reply-all CC carry-over plus client manager on replies

### DIFF
--- a/services/api/src/api/addon/routes.py
+++ b/services/api/src/api/addon/routes.py
@@ -1271,14 +1271,36 @@ async def _apply_jit_contacts(
     # We need recipient_type from the originating suggestion to route
     # correctly — fetch the suggestion to read its action_data.
     from api.classifier.service import SuggestionService
-    from api.drafts.service import resolve_recipients
+    from api.drafts.service import resolve_reply_recipients
 
     suggestion_svc = SuggestionService(db_pool=svc._pool)
     suggestion = await suggestion_svc.get_suggestion(suggestion_id)
     recipient_type = (suggestion.action_data or {}).get("recipient_type") if suggestion else None
 
+    # Re-resolving must preserve reply-all CC carry-over (otherwise attaching a
+    # JIT contact would silently drop everyone we'd already CC'd). Fetch the
+    # thread so resolve_reply_recipients can re-derive the carried-over CCs.
+    thread_messages = None
+    trigger_message_id = suggestion.gmail_message_id if suggestion else None
+    gmail_thread_id = suggestion.gmail_thread_id if suggestion else draft.gmail_thread_id
+    if svc._gmail is not None and gmail_thread_id:
+        try:
+            thread = await svc._gmail.get_thread(coordinator_email, gmail_thread_id)
+            thread_messages = thread.messages if thread else None
+        except Exception:
+            logger.exception(
+                "compose_email: failed to fetch thread %s for reply-all CC re-resolve",
+                gmail_thread_id,
+            )
+
     loop = await svc.get_loop(draft.loop_id)
-    to_emails, cc_emails = resolve_recipients(loop, recipient_type, sender_email=coordinator_email)
+    to_emails, cc_emails, _is_forward = resolve_reply_recipients(
+        loop,
+        recipient_type,
+        sender_email=coordinator_email,
+        thread_messages=thread_messages,
+        trigger_message_id=trigger_message_id,
+    )
     await draft_svc.update_draft_recipients(draft.id, to_emails, cc_emails)
     if pending:
         await draft_svc.update_pending_jit_data(draft.id, {})

--- a/services/api/src/api/drafts/service.py
+++ b/services/api/src/api/drafts/service.py
@@ -32,6 +32,21 @@ if TYPE_CHECKING:
 RecipientType = Literal["client", "recruiter", "internal"]
 
 
+def _pick_trigger(
+    thread_messages: list[Message],
+    trigger_message_id: str | None,
+) -> Message:
+    """The message we're replying to: the one named by ``trigger_message_id``,
+    falling back to the latest message by date. Single definition so forward
+    detection and reply-all CC carry-over never disagree on which message is
+    the trigger."""
+    if trigger_message_id:
+        match = next((m for m in thread_messages if m.id == trigger_message_id), None)
+        if match is not None:
+            return match
+    return max(thread_messages, key=lambda m: m.date)
+
+
 def _is_forward_draft(
     to_emails: list[str],
     thread_messages: list[Message] | None,
@@ -59,11 +74,7 @@ def _is_forward_draft(
     if not thread_messages or not to_emails:
         return False
 
-    trigger = None
-    if trigger_message_id:
-        trigger = next((m for m in thread_messages if m.id == trigger_message_id), None)
-    if trigger is None:
-        trigger = max(thread_messages, key=lambda m: m.date)
+    trigger = _pick_trigger(thread_messages, trigger_message_id)
 
     seen: set[str] = {trigger.from_.email.lower()}
     for addr in trigger.to + trigger.cc:
@@ -159,6 +170,70 @@ def resolve_recipients(
     return to_emails, cc_emails
 
 
+def _apply_reply_all_cc(
+    cc_emails: list[str],
+    trigger_cc: list[str],
+    to_emails: list[str],
+    sender_email: str | None,
+) -> list[str]:
+    """Reply-all: carry the trigger message's CC line onto our outgoing CC.
+
+    ``cc_emails`` is the base (the client manager, already sender-filtered by
+    ``resolve_recipients``). Every address on ``trigger_cc`` is unioned in.
+    First-seen order is preserved (CM first, then carried-over order) so the
+    sidebar shows a stable, reviewable list.
+
+    Dropped, case-insensitively: the sending coordinator (we never CC
+    ourselves — same rule the CM path already applies), anyone already on our
+    ``to_emails`` line, and exact duplicates.
+    """
+    result: list[str] = []
+    seen: set[str] = set()
+    blocked = {e.lower() for e in to_emails}
+    if sender_email:
+        blocked.add(sender_email.lower())
+
+    for email in [*cc_emails, *trigger_cc]:
+        key = email.lower()
+        if key in seen or key in blocked:
+            continue
+        seen.add(key)
+        result.append(email)
+    return result
+
+
+def resolve_reply_recipients(
+    loop: Loop,
+    recipient_type: RecipientType | None,
+    *,
+    sender_email: str | None = None,
+    thread_messages: list[Message] | None = None,
+    trigger_message_id: str | None = None,
+) -> tuple[list[str], list[str], bool]:
+    """Routing + reply-vs-forward + reply-all CC carry-over, in one place.
+
+    Consolidates the sequence both call sites need so they can't drift:
+      1. ``resolve_recipients`` for ``to_emails`` + the client-manager CC.
+      2. ``_is_forward_draft`` to decide reply vs. forward.
+      3. On a *reply* (not a forward), carry the trigger message's CC line
+         onto our CC via ``_apply_reply_all_cc``. Forwards keep exactly the
+         CM-only CC — a forward already puts the thread in front of someone
+         new; reply-all semantics don't apply.
+
+    ``resolve_recipients`` itself is intentionally left untouched so its
+    existing callers and tests are unaffected.
+    """
+    to_emails, cc_emails = resolve_recipients(loop, recipient_type, sender_email=sender_email)
+    is_forward = _is_forward_draft(
+        to_emails, thread_messages, trigger_message_id, recipient_type=recipient_type
+    )
+    if not is_forward and thread_messages:
+        trigger = _pick_trigger(thread_messages, trigger_message_id)
+        trigger_cc = [addr.email for addr in trigger.cc]
+        cc_emails = _apply_reply_all_cc(cc_emails, trigger_cc, to_emails, sender_email)
+    return to_emails, cc_emails, is_forward
+
+
 class DraftService:
     """Persists and manages email drafts for scheduling communications."""
 
@@ -185,8 +260,12 @@ class DraftService:
     ) -> EmailDraft:
         """Create and persist an email draft for a DRAFT_EMAIL suggestion."""
         recipient_type = (suggestion.action_data or {}).get("recipient_type")
-        to_emails, cc_emails = resolve_recipients(
-            loop, recipient_type, sender_email=suggestion.coordinator_email
+        to_emails, cc_emails, is_forward = resolve_reply_recipients(
+            loop,
+            recipient_type,
+            sender_email=suggestion.coordinator_email,
+            thread_messages=thread_messages,
+            trigger_message_id=suggestion.gmail_message_id,
         )
         subject = self._resolve_subject(loop, thread_messages)
 
@@ -197,13 +276,6 @@ class DraftService:
                 suggestion.id,
             )
             body = body[:MAX_BODY_LENGTH] + "\n\n[Draft truncated — please review]"
-
-        is_forward = _is_forward_draft(
-            to_emails,
-            thread_messages,
-            suggestion.gmail_message_id,
-            recipient_type=recipient_type,
-        )
 
         draft_id = make_id("drf")
         async with self._pool.connection() as conn, conn.transaction():

--- a/services/api/tests/test_draft_service.py
+++ b/services/api/tests/test_draft_service.py
@@ -7,7 +7,13 @@ import pytest
 
 from api.classifier.models import EmailClassification, Suggestion, SuggestionStatus
 from api.drafts.models import DraftStatus
-from api.drafts.service import DraftService, _is_forward_draft, _row_to_draft, resolve_recipients
+from api.drafts.service import (
+    DraftService,
+    _is_forward_draft,
+    _row_to_draft,
+    resolve_recipients,
+    resolve_reply_recipients,
+)
 from api.gmail.models import EmailAddress, Message
 from api.scheduling.models import (
     Candidate,
@@ -333,6 +339,128 @@ class TestIsForwardDraft:
             )
             is True
         )
+
+
+class TestResolveReplyRecipients:
+    """Reply-all: a reply carries the trigger message's CC line onto our CC,
+    on top of the client manager. Forwards keep the CM-only CC."""
+
+    def test_reply_carries_trigger_cc_on_top_of_cm(self):
+        loop = _loop(state=StageState.AWAITING_CANDIDATE, with_client_manager=True)
+        trigger = _thread_msg(
+            "haley@client.com",
+            ["fiona@lrp.com"],
+            cc_emails=["a@x.com", "b@y.com"],
+            msg_id="msg_1",
+        )
+        to, cc, is_forward = resolve_reply_recipients(
+            loop,
+            "client",
+            thread_messages=[trigger],
+            trigger_message_id="msg_1",
+        )
+        assert to == ["haley@client.com"]
+        # CM first, then carried-over CCs in order.
+        assert cc == ["sarah@lrp.com", "a@x.com", "b@y.com"]
+        assert is_forward is False
+
+    def test_sender_on_trigger_cc_is_filtered(self):
+        loop = _loop(state=StageState.AWAITING_CANDIDATE, with_client_manager=True)
+        trigger = _thread_msg(
+            "haley@client.com",
+            ["fiona@lrp.com"],
+            cc_emails=["fiona@lrp.com", "a@x.com"],
+            msg_id="msg_1",
+        )
+        _, cc, _ = resolve_reply_recipients(
+            loop,
+            "client",
+            sender_email="fiona@lrp.com",
+            thread_messages=[trigger],
+            trigger_message_id="msg_1",
+        )
+        assert cc == ["sarah@lrp.com", "a@x.com"]
+
+    def test_cm_equals_sender_still_carries_trigger_cc(self):
+        """CM == coordinator: CM dropped (don't CC yourself), but the
+        carried-over CCs still come through."""
+        loop = _loop(state=StageState.AWAITING_CANDIDATE, with_client_manager=True)
+        trigger = _thread_msg(
+            "haley@client.com",
+            ["sarah@lrp.com"],
+            cc_emails=["a@x.com"],
+            msg_id="msg_1",
+        )
+        _, cc, _ = resolve_reply_recipients(
+            loop,
+            "client",
+            sender_email="sarah@lrp.com",
+            thread_messages=[trigger],
+            trigger_message_id="msg_1",
+        )
+        assert cc == ["a@x.com"]
+
+    def test_to_recipient_not_duplicated_into_cc(self):
+        loop = _loop(state=StageState.AWAITING_CANDIDATE, with_client_manager=True)
+        trigger = _thread_msg(
+            "haley@client.com",
+            ["fiona@lrp.com"],
+            cc_emails=["haley@client.com", "a@x.com"],
+            msg_id="msg_1",
+        )
+        to, cc, _ = resolve_reply_recipients(
+            loop,
+            "client",
+            thread_messages=[trigger],
+            trigger_message_id="msg_1",
+        )
+        assert to == ["haley@client.com"]
+        assert "haley@client.com" not in cc
+        assert cc == ["sarah@lrp.com", "a@x.com"]
+
+    def test_case_insensitive_dedupe(self):
+        loop = _loop(state=StageState.AWAITING_CANDIDATE, with_client_manager=True)
+        trigger = _thread_msg(
+            "haley@client.com",
+            ["fiona@lrp.com"],
+            cc_emails=["Sarah@LRP.com", "A@X.com", "a@x.com"],
+            msg_id="msg_1",
+        )
+        _, cc, _ = resolve_reply_recipients(
+            loop,
+            "client",
+            thread_messages=[trigger],
+            trigger_message_id="msg_1",
+        )
+        # CM already present (case-insensitively) — not re-added; A@X.com kept once.
+        assert cc == ["sarah@lrp.com", "A@X.com"]
+
+    def test_forward_keeps_cm_only_cc(self):
+        """Forward (recruiter not on the client's trigger) → no carry-over,
+        CM-only CC, exactly today's behavior."""
+        loop = _loop(state=StageState.AWAITING_CANDIDATE, with_client_manager=True)
+        trigger = _thread_msg(
+            "haley@client.com",
+            ["fiona@lrp.com"],
+            cc_emails=["a@x.com", "b@y.com"],
+            msg_id="msg_1",
+        )
+        to, cc, is_forward = resolve_reply_recipients(
+            loop,
+            "recruiter",
+            thread_messages=[trigger],
+            trigger_message_id="msg_1",
+        )
+        assert to == ["mike@recruiter.com"]
+        assert is_forward is True
+        assert cc == ["sarah@lrp.com"]
+
+    def test_no_thread_messages_falls_back_to_cm_only(self):
+        loop = _loop(state=StageState.AWAITING_CANDIDATE, with_client_manager=True)
+        to, cc, is_forward = resolve_reply_recipients(loop, "client")
+        assert to == ["haley@client.com"]
+        assert cc == ["sarah@lrp.com"]
+        assert is_forward is False
 
 
 class _AsyncCtx:


### PR DESCRIPTION
## Summary
- Replies now behave like **Reply All**: every address on the trigger message's CC line is carried onto our outgoing **CC**, on top of the client manager.
- The sending coordinator and anyone already on the **To** line are filtered out (case-insensitive); CM==sender still drops the CM but keeps carried-over CCs.
- **Forwards keep exactly today's behavior**: To = forwarded person, CC = client manager only (no carry-over).
- Routing + forward-detection + carry-over consolidated into `resolve_reply_recipients` so the draft-generation and JIT re-resolve paths can't drift. The JIT re-resolve path now fetches the thread so attaching a contact no longer wipes carried-over CCs.
- Sidebar already renders the CC row, so all carried-over addresses are visible to the coordinator before they approve (no UI change needed).

### Design decisions (confirmed with user)
- **Candidate safety:** accept the risk and rely on coordinator visibility — if someone was intentionally CC'd, the reply was meant for them. (The `Candidate` model stores no email, so deterministic stripping isn't possible.)
- **Applies to all reply types**, including client-bound replies.

## Test plan
- [x] `pytest tests/test_draft_service.py` — 39 passed (32 existing + 7 new: carry-over, sender filtering, CM==sender, To-dedupe, case-insensitive dedupe, forward = CM-only, no-thread fallback)
- [x] `ruff check` / `ruff format --check` clean on changed files
- [ ] End-to-end sanity via the addon: draft on a thread with multiple CCs → confirm sidebar CC row + sent message CC header include CM + all carried-over CCs
- [ ] Full integration suite (`pytest`) requires local Postgres (`docker compose up -d` + migrations) — not run here