### PR TITLE
fix(classifier): enforce role-domain guardrails on CREATE_LOOP

### DIFF
--- a/services/api/src/api/classifier/formatters.py
+++ b/services/api/src/api/classifier/formatters.py
@@ -267,6 +267,23 @@ def _format_address(name: str | None, email: str) -> str:
     return email
 
 
+def _format_actor_label(name: str | None, email: str | None) -> str:
+    """Render an actor as 'Name (email)', degrading gracefully.
+
+    name + email -> "Name (email)"
+    name only     -> "Name"      (candidate has no email)
+    email only    -> "email"
+    neither       -> "Unknown"
+    """
+    if name and email:
+        return f"{name} ({email})"
+    if name:
+        return name
+    if email:
+        return email
+    return "Unknown"
+
+
 _DIRECTION_LABELS = {
     "incoming": "inbound",
     "outgoing": "outbound",
@@ -339,19 +356,19 @@ def format_thread_history_xml(
     return "\n".join(parts)
 
 
-def _format_actor(prefix_tag: str, value: str | None) -> str:
-    """Render a single actor tag, defaulting to 'Unknown' when null."""
-    return f"<{prefix_tag}>{_escape(value or 'Unknown')}</{prefix_tag}>"
+def _format_actor(prefix_tag: str, name: str | None, email: str | None = None) -> str:
+    """Render a single actor tag, defaulting to 'Unknown' when empty."""
+    return f"<{prefix_tag}>{_escape(_format_actor_label(name, email))}</{prefix_tag}>"
 
 
 def _format_client_contact(loop: Loop) -> str:
     cc = loop.client_contact
     if cc is None:
         return "<client-contact>Unknown</client-contact>"
-    name = cc.name or cc.email
+    label = _format_actor_label(cc.name, cc.email)
     company = cc.company or ""
-    label = f"{name}, {company}".rstrip(", ").strip()
-    return f"<client-contact>{_escape(label or 'Unknown')}</client-contact>"
+    full = f"{label}, {company}".rstrip(", ").strip()
+    return f"<client-contact>{_escape(full or 'Unknown')}</client-contact>"
 
 
 def _format_pending_suggestion_body(sug: Suggestion) -> str:
@@ -403,10 +420,27 @@ def _format_pending_suggestions_xml(pending: list[Suggestion]) -> str:
 
 def format_loop_xml(loop: Loop, pending_for_loop: list[Suggestion]) -> str:
     """Render a single loop as a <loop> XML block."""
-    coordinator_name = loop.coordinator.name if loop.coordinator else None
-    recruiter_name = loop.recruiter.name if loop.recruiter else None
-    candidate_name = loop.candidate.name if loop.candidate else None
-    cm_name = loop.client_manager.name if loop.client_manager else None
+    coordinator = loop.coordinator
+    recruiter = loop.recruiter
+    candidate = loop.candidate
+    cm = loop.client_manager
+
+    coordinator_tag = _format_actor(
+        "coordinator",
+        coordinator.name if coordinator else None,
+        coordinator.email if coordinator else None,
+    )
+    cm_tag = _format_actor(
+        "client-manager",
+        cm.name if cm else None,
+        cm.email if cm else None,
+    )
+    recruiter_tag = _format_actor(
+        "recruiter",
+        recruiter.name if recruiter else None,
+        recruiter.email if recruiter else None,
+    )
+    candidate_tag = _format_actor("candidate", candidate.name if candidate else None)
 
     pending_block = _format_pending_suggestions_xml(pending_for_loop)
     # Indent the pending block by two spaces so it aligns with siblings.
@@ -416,11 +450,11 @@ def format_loop_xml(loop: Loop, pending_for_loop: list[Suggestion]) -> str:
         f"<loop id='{_escape(loop.id)}'>",
         f"  <stage>{_escape(loop.state.value)}</stage>",
         "  <actors>",
-        f"    {_format_actor('coordinator', coordinator_name)}",
+        f"    {coordinator_tag}",
         f"    {_format_client_contact(loop)}",
-        f"    {_format_actor('client-manager', cm_name)}",
-        f"    {_format_actor('recruiter', recruiter_name)}",
-        f"    {_format_actor('candidate', candidate_name)}",
+        f"    {cm_tag}",
+        f"    {recruiter_tag}",
+        f"    {candidate_tag}",
         "  </actors>",
         pending_block_indented,
         "</loop>",

--- a/services/api/src/api/classifier/loop_classifier.py
+++ b/services/api/src/api/classifier/loop_classifier.py
@@ -57,6 +57,51 @@ _CLASSIFIER_ALLOWED_ACTIONS = frozenset(
     {SuggestedAction.CREATE_LOOP, SuggestedAction.LINK_THREAD, SuggestedAction.NO_ACTION}
 )
 
+# A client contact never uses a consumer mailbox — a consumer-domain
+# client_email almost always means the model grabbed the candidate or
+# another non-client party. Enforced as a CREATE_LOOP guardrail.
+_CONSUMER_EMAIL_DOMAINS = frozenset(
+    {
+        "gmail.com",
+        "googlemail.com",
+        "yahoo.com",
+        "ymail.com",
+        "hotmail.com",
+        "outlook.com",
+        "live.com",
+        "msn.com",
+        "icloud.com",
+        "me.com",
+        "mac.com",
+        "aol.com",
+        "protonmail.com",
+        "proton.me",
+        "hey.com",
+        "fastmail.com",
+        "duck.com",
+        "gmx.com",
+        "mail.com",
+        "zoho.com",
+        "yandex.com",
+        "yandex.ru",
+        "qq.com",
+        "163.com",
+        "naver.com",
+    }
+)
+
+# CM and recruiter are always LRP employees. router.py:INTERNAL_DOMAIN holds
+# the same literal for an unrelated routing gate; this constant is kept
+# independent so the guardrail stays self-contained.
+_INTERNAL_EMAIL_DOMAIN = "longridgepartners.com"
+
+
+def _email_domain(addr: str) -> str | None:
+    """Lowercased domain of an email address, or None if there is no '@'."""
+    if "@" not in addr:
+        return None
+    return addr.rsplit("@", 1)[-1].strip().lower()
+
 
 def _resolve_coordinator_name(event: EmailEvent, coord: Coordinator | None) -> str:
     if coord and coord.name:
@@ -351,6 +396,59 @@ class LoopClassifier:
                     "CREATE_LOOP candidate_name must be a real name, not 'Unknown Candidate'. "
                     "Re-read the email to extract the candidate's actual name.",
                 )
+
+            # 7. CREATE_LOOP client_email must be a corporate address.
+            client_email = (item.action_data.get("client_email") or "").strip()
+            if client_email:
+                domain = _email_domain(client_email)
+                if domain is None:
+                    return (
+                        item.model_copy(update={"action": SuggestedAction.NO_ACTION}),
+                        f"CREATE_LOOP client_email '{client_email}' is malformed "
+                        "(no '@'). Re-read the email for the real client contact, "
+                        "or emit NO_ACTION if none can be identified.",
+                    )
+                if domain in _CONSUMER_EMAIL_DOMAINS:
+                    return (
+                        item.model_copy(update={"action": SuggestedAction.NO_ACTION}),
+                        f"CREATE_LOOP client_email '{client_email}' uses a consumer "
+                        f"email provider ({domain}). The client always uses a "
+                        "corporate domain; a consumer address almost always means "
+                        "the model extracted the candidate or another non-client "
+                        "party. Re-read the email for the real corporate client "
+                        "contact, or emit NO_ACTION if none can be identified.",
+                    )
+
+            # 8. CREATE_LOOP cm_email must be an internal LRP address.
+            cm_email = (item.action_data.get("cm_email") or "").strip()
+            if cm_email:
+                domain = _email_domain(cm_email)
+                if domain != _INTERNAL_EMAIL_DOMAIN:
+                    return (
+                        item.model_copy(update={"action": SuggestedAction.NO_ACTION}),
+                        f"CREATE_LOOP cm_email '{cm_email}' is not an internal LRP "
+                        f"address. The client manager is always an LRP employee "
+                        f"(@{_INTERNAL_EMAIL_DOMAIN}); an external address means "
+                        "the model picked the wrong person. Re-read the email for "
+                        "the internal CM, or emit NO_ACTION if none can be "
+                        "identified.",
+                    )
+
+            # 9. CREATE_LOOP recruiter_email must be an internal LRP address.
+            recruiter_email = (item.action_data.get("recruiter_email") or "").strip()
+            if recruiter_email:
+                domain = _email_domain(recruiter_email)
+                if domain != _INTERNAL_EMAIL_DOMAIN:
+                    return (
+                        item.model_copy(update={"action": SuggestedAction.NO_ACTION}),
+                        f"CREATE_LOOP recruiter_email '{recruiter_email}' is not an "
+                        f"internal LRP address. The recruiter is always an LRP "
+                        f"employee (@{_INTERNAL_EMAIL_DOMAIN}); an external address "
+                        "is typically a third-party recruiter pitching candidates, "
+                        "not the loop's recruiter. Re-read the email for the "
+                        "internal recruiter, or omit recruiter fields if none is "
+                        "clearly present.",
+                    )
 
         return item, None
 

--- a/services/api/tests/test_classifier_hook.py
+++ b/services/api/tests/test_classifier_hook.py
@@ -355,6 +355,83 @@ class TestClassifierGuardrails:
         assert error is not None
 
 
+class TestCreateLoopRoleDomainGuardrails:
+    """CREATE_LOOP role-domain guardrails: client must be corporate; CM and
+    recruiter must be internal LRP addresses."""
+
+    @staticmethod
+    def _create_loop(**action_data) -> SuggestionItem:
+        action_data.setdefault("candidate_name", "Amar Shah")
+        return _suggestion_item(action=SuggestedAction.CREATE_LOOP, action_data=action_data)
+
+    def test_consumer_client_email_blocked_even_with_company(self):
+        """Reproduces the screenshot bug: hotmail client + company set."""
+        classifier, _ = _make_classifier()
+        item = self._create_loop(
+            client_email="amar_shah80@hotmail.com",
+            client_company="5 Dimensions Energy",
+        )
+        result, error = classifier._apply_guardrails(item)
+        assert result.action == SuggestedAction.NO_ACTION
+        assert error is not None
+        assert "hotmail.com" in error
+
+    def test_corporate_client_email_passes(self):
+        classifier, _ = _make_classifier()
+        item = self._create_loop(
+            client_email="max@berlinuniversity.edu",
+            cm_email="adam@longridgepartners.com",
+            recruiter_email="rq@longridgepartners.com",
+        )
+        result, error = classifier._apply_guardrails(item)
+        assert result.action == SuggestedAction.CREATE_LOOP
+        assert error is None
+
+    def test_optional_role_emails_absent_passes(self):
+        classifier, _ = _make_classifier()
+        item = self._create_loop()
+        result, error = classifier._apply_guardrails(item)
+        assert result.action == SuggestedAction.CREATE_LOOP
+        assert error is None
+
+    def test_malformed_client_email_blocked(self):
+        classifier, _ = _make_classifier()
+        item = self._create_loop(client_email="notanemail")
+        result, error = classifier._apply_guardrails(item)
+        assert result.action == SuggestedAction.NO_ACTION
+        assert error is not None
+
+    def test_external_cm_email_blocked(self):
+        classifier, _ = _make_classifier()
+        item = self._create_loop(cm_email="someone@gmail.com")
+        result, error = classifier._apply_guardrails(item)
+        assert result.action == SuggestedAction.NO_ACTION
+        assert error is not None
+        assert "cm_email" in error
+
+    def test_internal_cm_email_passes(self):
+        classifier, _ = _make_classifier()
+        item = self._create_loop(cm_email="adam@longridgepartners.com")
+        result, error = classifier._apply_guardrails(item)
+        assert result.action == SuggestedAction.CREATE_LOOP
+        assert error is None
+
+    def test_external_recruiter_email_blocked(self):
+        classifier, _ = _make_classifier()
+        item = self._create_loop(recruiter_email="ext@acme.com")
+        result, error = classifier._apply_guardrails(item)
+        assert result.action == SuggestedAction.NO_ACTION
+        assert error is not None
+        assert "recruiter_email" in error
+
+    def test_internal_recruiter_email_passes(self):
+        classifier, _ = _make_classifier()
+        item = self._create_loop(recruiter_email="rq@longridgepartners.com")
+        result, error = classifier._apply_guardrails(item)
+        assert result.action == SuggestedAction.CREATE_LOOP
+        assert error is None
+
+
 # --- Agent guardrails ---
 
 

--- a/services/api/tests/test_classifier_hook.py
+++ b/services/api/tests/test_classifier_hook.py
@@ -1030,8 +1030,8 @@ class TestXMLFormatters:
         assert f"<loop id='{loop.id}'>" in xml
         assert "<stage>awaiting_candidate</stage>" in xml
         assert "<candidate>John Smith</candidate>" in xml
-        assert "<recruiter>Bob</recruiter>" in xml
-        assert "<client-contact>Jane, HF Co</client-contact>" in xml
+        assert "<recruiter>Bob (bob@lrp.com)</recruiter>" in xml
+        assert "<client-contact>Jane (jane@hf.com), HF Co</client-contact>" in xml
         # DRAFT_EMAIL renders body + recipient_type for dedup-by-content + targeting.
         assert "sug_draft" in xml
         assert "Stale draft summary" in xml


### PR DESCRIPTION
## What

A scheduling loop was created with a candidate's personal hotmail address (`amar_shah80@hotmail.com`, "Amar Shah") classified as the **client**, with client company "5 Dimensions Energy". Amar is the candidate.

## Root cause

The consumer-email / internal-domain rules existed **only as prose** in the LangFuse classifier prompt — there was no deterministic code-level guardrail. `LoopClassifier._apply_guardrails` never inspected `client_email`, `cm_email`, or `recruiter_email` domains, so the misclassification passed straight through to loop creation. `hotmail.com` was not "missing from a list" — there was no list and no check.

## Change

Adds three CREATE_LOOP guardrails in `_apply_guardrails`, riding the **existing error-driven retry rail** (same pattern as the `candidate_name` check — returns a `NO_ACTION` copy + an instructive error string so the LLM re-reads the thread on retry):

- **`client_email`** — reject consumer-provider domains (26-entry `_CONSUMER_EMAIL_DOMAINS`, incl. `hotmail.com`) or malformed addresses. Always blocks regardless of whether `client_company` is set (the bug had a company and was still wrong).
- **`cm_email`** — must be an internal `@longridgepartners.com` address.
- **`recruiter_email`** — must be internal; otherwise typically third-party pitch spam. Remediation nudges "omit recruiter fields" (recruiter is optional for a loop), not abandon.

Also adds an `_email_domain()` helper and `_INTERNAL_EMAIL_DOMAIN`.

## Tests

8 new unit tests in `TestCreateLoopRoleDomainGuardrails`, including an exact reproduction of the screenshot bug. Full classifier suite: **67 passed**, ruff clean.

## Reviewer notes

- One file, additive only (175 insertions, 0 deletions across impl + tests).
- Prompt (`update_loop_classifier_v22.py`) intentionally unchanged — it already states all three rules correctly; the deterministic checks were the missing enforcement.
- Out of scope (parked follow-ups): the stricter 12-person CM allow-list, and rejecting internal-domain `client_email`.