### PR TITLE
fix(agent): stop client CC leaking onto recruiter drafts

### DIFF
--- a/services/api/src/api/drafts/service.py
+++ b/services/api/src/api/drafts/service.py
@@ -212,32 +212,15 @@ def _apply_reply_all_cc(
     return result
 
 
-def _strip_external_cc(
-    cc_emails: list[str],
-    recipient_type: RecipientType | None,
-) -> list[str]:
-    """Keep only internal (LRP-domain) addresses on recruiter/internal CC.
+def _internal_only(emails: list[str]) -> list[str]:
+    """Drop every non-internal (non-LRP-domain) address from ``emails``.
 
-    Recruiter-bound drafts and internal notes are LRP-internal coordination
-    the client must never see. Reply-all carry-over
-    (``_apply_reply_all_cc``) can drag *any* address off the trigger
-    thread's CC line onto ours — including client-side participants who were
-    CC'd on the upstream request (e.g. a client teammate who is not even
-    ``loop.client_contact``). Rather than trying to identify who is
-    "client-side", we invert it: on these comms, allow only the internal
-    domain through. Anything else is dropped.
-
-    Mirror of the client privacy guard in ``_is_forward_draft`` — same
-    intent (no internal/external leakage), opposite direction.
-
-    Only applies when ``recipient_type in ("recruiter", "internal")``.
-    Client-bound drafts are untouched (the client is the intended audience).
-    Order preserved; domain compared case-insensitively.
+    Pure list filter — order preserved, domain compared case-insensitively.
+    The caller decides *when* internal-only filtering applies; this just
+    enforces it on whatever list it's handed.
     """
-    if recipient_type not in ("recruiter", "internal"):
-        return cc_emails
     return [
-        email for email in cc_emails if email.rpartition("@")[2].strip().lower() == INTERNAL_DOMAIN
+        email for email in emails if email.rpartition("@")[2].strip().lower() == INTERNAL_DOMAIN
     ]
 
 
@@ -270,7 +253,12 @@ def resolve_reply_recipients(
         trigger = _pick_trigger(thread_messages, trigger_message_id)
         trigger_cc = [addr.email for addr in trigger.cc]
         cc_emails = _apply_reply_all_cc(cc_emails, trigger_cc, to_emails, sender_email)
-    cc_emails = _strip_external_cc(cc_emails, recipient_type)
+    # Recruiter-bound drafts and internal notes are LRP-internal coordination
+    # the client must never see. Carry-over above can drag client-side
+    # addresses off the trigger thread's CC; scrub them here. Client-bound
+    # drafts are untouched — the client is the intended audience.
+    if recipient_type in ("recruiter", "internal"):
+        cc_emails = _internal_only(cc_emails)
     return to_emails, cc_emails, is_forward
 
 

--- a/services/api/src/api/drafts/service.py
+++ b/services/api/src/api/drafts/service.py
@@ -16,6 +16,7 @@ from typing import TYPE_CHECKING, Literal
 
 from psycopg.rows import dict_row, tuple_row
 
+from api.classifier.router import INTERNAL_DOMAIN
 from api.drafts.models import DraftStatus, EmailDraft
 from api.drafts.queries import queries
 from api.ids import make_id
@@ -71,7 +72,16 @@ def _is_forward_draft(
     """
     if recipient_type == "client":
         return False
-    if not thread_messages or not to_emails:
+    if not to_emails:
+        # JIT-pending: recruiter not yet attached, so we can't run the
+        # trigger-based check. Default to *forward*, not reply — this keeps
+        # reply-all CC carry-over from dragging the trigger thread's
+        # (possibly client-bearing) CC onto a draft whose recipient we don't
+        # even know yet. Result: CM-only CC until the coordinator fills the
+        # contact in. (Was: returned False/"reply" here, which leaked the
+        # client onto recruiter drafts — issue this fixes.)
+        return True
+    if not thread_messages:
         return False
 
     trigger = _pick_trigger(thread_messages, trigger_message_id)
@@ -202,6 +212,35 @@ def _apply_reply_all_cc(
     return result
 
 
+def _strip_external_cc(
+    cc_emails: list[str],
+    recipient_type: RecipientType | None,
+) -> list[str]:
+    """Keep only internal (LRP-domain) addresses on recruiter/internal CC.
+
+    Recruiter-bound drafts and internal notes are LRP-internal coordination
+    the client must never see. Reply-all carry-over
+    (``_apply_reply_all_cc``) can drag *any* address off the trigger
+    thread's CC line onto ours — including client-side participants who were
+    CC'd on the upstream request (e.g. a client teammate who is not even
+    ``loop.client_contact``). Rather than trying to identify who is
+    "client-side", we invert it: on these comms, allow only the internal
+    domain through. Anything else is dropped.
+
+    Mirror of the client privacy guard in ``_is_forward_draft`` — same
+    intent (no internal/external leakage), opposite direction.
+
+    Only applies when ``recipient_type in ("recruiter", "internal")``.
+    Client-bound drafts are untouched (the client is the intended audience).
+    Order preserved; domain compared case-insensitively.
+    """
+    if recipient_type not in ("recruiter", "internal"):
+        return cc_emails
+    return [
+        email for email in cc_emails if email.rpartition("@")[2].strip().lower() == INTERNAL_DOMAIN
+    ]
+
+
 def resolve_reply_recipients(
     loop: Loop,
     recipient_type: RecipientType | None,
@@ -231,6 +270,7 @@ def resolve_reply_recipients(
         trigger = _pick_trigger(thread_messages, trigger_message_id)
         trigger_cc = [addr.email for addr in trigger.cc]
         cc_emails = _apply_reply_all_cc(cc_emails, trigger_cc, to_emails, sender_email)
+    cc_emails = _strip_external_cc(cc_emails, recipient_type)
     return to_emails, cc_emails, is_forward
 
 

--- a/services/api/tests/test_draft_service.py
+++ b/services/api/tests/test_draft_service.py
@@ -44,7 +44,7 @@ def _loop(
         coordinator=Coordinator(
             id="crd_1",
             name="Fiona",
-            email="fiona@lrp.com",
+            email="fiona@longridgepartners.com",
             created_at=datetime(2026, 4, 15, tzinfo=UTC),
         ),
         client_contact=ClientContact(
@@ -65,7 +65,7 @@ def _loop(
         client_manager=Contact(
             id="con_2",
             name="Sarah",
-            email="sarah@lrp.com",
+            email="sarah@longridgepartners.com",
             role="client_manager",
             company=None,
             created_at=datetime(2026, 4, 15, tzinfo=UTC),
@@ -88,7 +88,7 @@ def _suggestion(
 ) -> Suggestion:
     return Suggestion(
         id=sug_id,
-        coordinator_email="fiona@lrp.com",
+        coordinator_email="fiona@longridgepartners.com",
         gmail_message_id="msg_1",
         gmail_thread_id="thread_1",
         loop_id="lop_1",
@@ -116,7 +116,7 @@ def _draft_row(
         "id": draft_id,
         "suggestion_id": "sug_1",
         "loop_id": "lop_1",
-        "coordinator_email": "fiona@lrp.com",
+        "coordinator_email": "fiona@longridgepartners.com",
         "to_emails": ["haley@client.com"],
         "cc_emails": [],
         "subject": "Re: Round 1 - John Smith",
@@ -167,7 +167,7 @@ class TestResolveRecipients:
         loop = _loop(state=StageState.SCHEDULED, with_client_manager=True)
         to, cc = resolve_recipients(loop, "internal")
         assert to == []
-        assert cc == ["sarah@lrp.com"]
+        assert cc == ["sarah@longridgepartners.com"]
 
     def test_state_does_not_override_recipient_type(self):
         """Regression: SCHEDULED loop + recipient_type='recruiter' → recruiter, not client."""
@@ -199,13 +199,13 @@ class TestResolveRecipients:
         loop = _loop(state=StageState.AWAITING_CANDIDATE, with_client_manager=True)
         to, cc = resolve_recipients(loop, "client")
         assert to == ["haley@client.com"]
-        assert cc == ["sarah@lrp.com"]
+        assert cc == ["sarah@longridgepartners.com"]
 
     def test_sender_filtered_from_cc(self):
         """Coordinators are sometimes their own CM — don't CC yourself."""
         loop = _loop(state=StageState.AWAITING_CANDIDATE, with_client_manager=True)
-        # sarah@lrp.com is the CM in the fixture
-        _, cc = resolve_recipients(loop, "client", sender_email="sarah@lrp.com")
+        # sarah@longridgepartners.com is the CM in the fixture
+        _, cc = resolve_recipients(loop, "client", sender_email="sarah@longridgepartners.com")
         assert cc == []
 
 
@@ -230,28 +230,41 @@ def _thread_msg(
 
 class TestIsForwardDraft:
     def test_new_recipient_is_forward(self):
-        msgs = [_thread_msg("alice@a.com", ["coord@lrp.com"])]
+        msgs = [_thread_msg("alice@a.com", ["coord@longridgepartners.com"])]
         assert _is_forward_draft(["bob@b.com"], msgs) is True
 
     def test_existing_recipient_is_not_forward(self):
-        msgs = [_thread_msg("alice@a.com", ["coord@lrp.com"])]
+        msgs = [_thread_msg("alice@a.com", ["coord@longridgepartners.com"])]
         assert _is_forward_draft(["alice@a.com"], msgs) is False
 
     def test_no_thread_messages_is_not_forward(self):
         assert _is_forward_draft(["anyone@a.com"], None) is False
         assert _is_forward_draft(["anyone@a.com"], []) is False
 
+    def test_empty_to_emails_is_forward(self):
+        """Rule 2: empty To (recruiter JIT-pending) → assume forward, so
+        reply-all CC carry-over is skipped and CC stays CM-only."""
+        trigger = _thread_msg("alice@a.com", ["coord@longridgepartners.com"])
+        assert _is_forward_draft([], [trigger], "msg_1") is True
+        assert _is_forward_draft([], None) is True
+
+    def test_client_guard_wins_over_empty_to(self):
+        """recipient_type=client still never forwards, even with empty To —
+        the client privacy guard is checked first."""
+        trigger = _thread_msg("alice@a.com", ["coord@longridgepartners.com"])
+        assert _is_forward_draft([], [trigger], "msg_1", recipient_type="client") is False
+
     def test_only_checks_trigger_message(self):
         """Recipient on an earlier message but NOT on the trigger → forward."""
         old = _thread_msg(
             "bob@b.com",
-            ["coord@lrp.com"],
+            ["coord@longridgepartners.com"],
             msg_id="msg_old",
             date=datetime(2026, 4, 14, tzinfo=UTC),
         )
         trigger = _thread_msg(
             "alice@a.com",
-            ["coord@lrp.com"],
+            ["coord@longridgepartners.com"],
             msg_id="msg_new",
             date=datetime(2026, 4, 15, tzinfo=UTC),
         )
@@ -261,7 +274,7 @@ class TestIsForwardDraft:
         """Recipient on the trigger message → not a forward."""
         trigger = _thread_msg(
             "alice@a.com",
-            ["bob@b.com", "coord@lrp.com"],
+            ["bob@b.com", "coord@longridgepartners.com"],
             msg_id="msg_new",
         )
         assert _is_forward_draft(["bob@b.com"], [trigger], "msg_new") is False
@@ -276,8 +289,8 @@ class TestIsForwardDraft:
         and the recruiter's reply would be quoted to the client (LEAK).
         """
         recruiter_reply = _thread_msg(
-            "recruiter@lrp.com",
-            ["coord@lrp.com"],
+            "recruiter@longridgepartners.com",
+            ["coord@longridgepartners.com"],
             msg_id="msg_recruiter",
         )
         assert (
@@ -294,7 +307,7 @@ class TestIsForwardDraft:
         """Consistency: client recipient is always reply, never forward."""
         trigger = _thread_msg(
             "alice@a.com",
-            ["client@external.com", "coord@lrp.com"],
+            ["client@external.com", "coord@longridgepartners.com"],
             msg_id="msg_new",
         )
         assert (
@@ -309,13 +322,13 @@ class TestIsForwardDraft:
         to internal LRP folks is safe and often correct."""
         client_msg = _thread_msg(
             "client@external.com",
-            ["coord@lrp.com"],
+            ["coord@longridgepartners.com"],
             msg_id="msg_client",
         )
         # Recruiter not on the trigger → forward (preserves existing semantics).
         assert (
             _is_forward_draft(
-                ["recruiter@lrp.com"],
+                ["recruiter@longridgepartners.com"],
                 [client_msg],
                 "msg_client",
                 recipient_type="recruiter",
@@ -327,7 +340,7 @@ class TestIsForwardDraft:
         """recipient_type=None (legacy suggestions) → trigger-based detection."""
         client_msg = _thread_msg(
             "client@external.com",
-            ["coord@lrp.com"],
+            ["coord@longridgepartners.com"],
             msg_id="msg_client",
         )
         assert (
@@ -349,7 +362,7 @@ class TestResolveReplyRecipients:
         loop = _loop(state=StageState.AWAITING_CANDIDATE, with_client_manager=True)
         trigger = _thread_msg(
             "haley@client.com",
-            ["fiona@lrp.com"],
+            ["fiona@longridgepartners.com"],
             cc_emails=["a@x.com", "b@y.com"],
             msg_id="msg_1",
         )
@@ -361,25 +374,25 @@ class TestResolveReplyRecipients:
         )
         assert to == ["haley@client.com"]
         # CM first, then carried-over CCs in order.
-        assert cc == ["sarah@lrp.com", "a@x.com", "b@y.com"]
+        assert cc == ["sarah@longridgepartners.com", "a@x.com", "b@y.com"]
         assert is_forward is False
 
     def test_sender_on_trigger_cc_is_filtered(self):
         loop = _loop(state=StageState.AWAITING_CANDIDATE, with_client_manager=True)
         trigger = _thread_msg(
             "haley@client.com",
-            ["fiona@lrp.com"],
-            cc_emails=["fiona@lrp.com", "a@x.com"],
+            ["fiona@longridgepartners.com"],
+            cc_emails=["fiona@longridgepartners.com", "a@x.com"],
             msg_id="msg_1",
         )
         _, cc, _ = resolve_reply_recipients(
             loop,
             "client",
-            sender_email="fiona@lrp.com",
+            sender_email="fiona@longridgepartners.com",
             thread_messages=[trigger],
             trigger_message_id="msg_1",
         )
-        assert cc == ["sarah@lrp.com", "a@x.com"]
+        assert cc == ["sarah@longridgepartners.com", "a@x.com"]
 
     def test_cm_equals_sender_still_carries_trigger_cc(self):
         """CM == coordinator: CM dropped (don't CC yourself), but the
@@ -387,14 +400,14 @@ class TestResolveReplyRecipients:
         loop = _loop(state=StageState.AWAITING_CANDIDATE, with_client_manager=True)
         trigger = _thread_msg(
             "haley@client.com",
-            ["sarah@lrp.com"],
+            ["sarah@longridgepartners.com"],
             cc_emails=["a@x.com"],
             msg_id="msg_1",
         )
         _, cc, _ = resolve_reply_recipients(
             loop,
             "client",
-            sender_email="sarah@lrp.com",
+            sender_email="sarah@longridgepartners.com",
             thread_messages=[trigger],
             trigger_message_id="msg_1",
         )
@@ -404,7 +417,7 @@ class TestResolveReplyRecipients:
         loop = _loop(state=StageState.AWAITING_CANDIDATE, with_client_manager=True)
         trigger = _thread_msg(
             "haley@client.com",
-            ["fiona@lrp.com"],
+            ["fiona@longridgepartners.com"],
             cc_emails=["haley@client.com", "a@x.com"],
             msg_id="msg_1",
         )
@@ -416,14 +429,14 @@ class TestResolveReplyRecipients:
         )
         assert to == ["haley@client.com"]
         assert "haley@client.com" not in cc
-        assert cc == ["sarah@lrp.com", "a@x.com"]
+        assert cc == ["sarah@longridgepartners.com", "a@x.com"]
 
     def test_case_insensitive_dedupe(self):
         loop = _loop(state=StageState.AWAITING_CANDIDATE, with_client_manager=True)
         trigger = _thread_msg(
             "haley@client.com",
-            ["fiona@lrp.com"],
-            cc_emails=["Sarah@LRP.com", "A@X.com", "a@x.com"],
+            ["fiona@longridgepartners.com"],
+            cc_emails=["Sarah@LongRidgePartners.com", "A@X.com", "a@x.com"],
             msg_id="msg_1",
         )
         _, cc, _ = resolve_reply_recipients(
@@ -433,7 +446,7 @@ class TestResolveReplyRecipients:
             trigger_message_id="msg_1",
         )
         # CM already present (case-insensitively) — not re-added; A@X.com kept once.
-        assert cc == ["sarah@lrp.com", "A@X.com"]
+        assert cc == ["sarah@longridgepartners.com", "A@X.com"]
 
     def test_forward_keeps_cm_only_cc(self):
         """Forward (recruiter not on the client's trigger) → no carry-over,
@@ -441,7 +454,7 @@ class TestResolveReplyRecipients:
         loop = _loop(state=StageState.AWAITING_CANDIDATE, with_client_manager=True)
         trigger = _thread_msg(
             "haley@client.com",
-            ["fiona@lrp.com"],
+            ["fiona@longridgepartners.com"],
             cc_emails=["a@x.com", "b@y.com"],
             msg_id="msg_1",
         )
@@ -453,14 +466,66 @@ class TestResolveReplyRecipients:
         )
         assert to == ["mike@recruiter.com"]
         assert is_forward is True
-        assert cc == ["sarah@lrp.com"]
+        assert cc == ["sarah@longridgepartners.com"]
 
     def test_no_thread_messages_falls_back_to_cm_only(self):
         loop = _loop(state=StageState.AWAITING_CANDIDATE, with_client_manager=True)
         to, cc, is_forward = resolve_reply_recipients(loop, "client")
         assert to == ["haley@client.com"]
-        assert cc == ["sarah@lrp.com"]
+        assert cc == ["sarah@longridgepartners.com"]
         assert is_forward is False
+
+    def test_unset_recruiter_jit_pending_is_forward_cm_only_cc(self):
+        """The screenshot bug: recipient_type=recruiter but recruiter not yet
+        set (JIT pending). Trigger is a CM reply whose CC carries a
+        client-domain teammate. Expect: empty To, is_forward=True (Rule 2 —
+        empty To assumes forward, no reply-all carry-over), CC = CM only.
+        Pre-fix this leaked the client onto the recruiter draft."""
+        loop = _loop(state=StageState.AWAITING_CANDIDATE, with_client_manager=True)
+        loop.recruiter = None
+        trigger = _thread_msg(
+            "sarah@longridgepartners.com",
+            ["haley@client.com"],
+            cc_emails=[
+                "mike@longridgepartners.com",
+                "teammate@client.com",
+                "fiona@longridgepartners.com",
+            ],
+            msg_id="msg_1",
+        )
+        to, cc, is_forward = resolve_reply_recipients(
+            loop,
+            "recruiter",
+            sender_email="fiona@longridgepartners.com",
+            thread_messages=[trigger],
+            trigger_message_id="msg_1",
+        )
+        assert to == []
+        assert is_forward is True
+        assert cc == ["sarah@longridgepartners.com"]
+
+    def test_recruiter_reply_strips_client_cc_keeps_internal(self):
+        """Rule 1: even when carry-over runs (recruiter set, on the trigger so
+        it's a reply), client-domain addresses are stripped from CC while
+        internal ones survive."""
+        loop = _loop(state=StageState.AWAITING_CANDIDATE, with_client_manager=True)
+        trigger = _thread_msg(
+            "haley@client.com",
+            ["mike@recruiter.com"],
+            cc_emails=["teammate@client.com", "lijo@longridgepartners.com"],
+            msg_id="msg_1",
+        )
+        to, cc, is_forward = resolve_reply_recipients(
+            loop,
+            "recruiter",
+            sender_email="fiona@longridgepartners.com",
+            thread_messages=[trigger],
+            trigger_message_id="msg_1",
+        )
+        assert to == ["mike@recruiter.com"]
+        assert is_forward is False
+        assert "teammate@client.com" not in cc
+        assert cc == ["sarah@longridgepartners.com", "lijo@longridgepartners.com"]
 
 
 class _AsyncCtx:
@@ -492,25 +557,25 @@ class TestResolveSubject:
     """
 
     def test_mirrors_latest_thread_subject(self):
-        msg = _thread_msg("alice@a.com", ["coord@lrp.com"])
+        msg = _thread_msg("alice@a.com", ["coord@longridgepartners.com"])
         msg.subject = "Trump"
         result = DraftService._resolve_subject(_loop(), [msg])
         assert result == "Re: Trump"
 
     def test_no_double_re_prefix_lowercase(self):
-        msg = _thread_msg("alice@a.com", ["coord@lrp.com"])
+        msg = _thread_msg("alice@a.com", ["coord@longridgepartners.com"])
         msg.subject = "re: Phone screen"
         result = DraftService._resolve_subject(_loop(), [msg])
         assert result == "re: Phone screen"
 
     def test_no_double_re_prefix_uppercase(self):
-        msg = _thread_msg("alice@a.com", ["coord@lrp.com"])
+        msg = _thread_msg("alice@a.com", ["coord@longridgepartners.com"])
         msg.subject = "RE: Phone screen"
         result = DraftService._resolve_subject(_loop(), [msg])
         assert result == "RE: Phone screen"
 
     def test_no_double_re_prefix_titlecase(self):
-        msg = _thread_msg("alice@a.com", ["coord@lrp.com"])
+        msg = _thread_msg("alice@a.com", ["coord@longridgepartners.com"])
         msg.subject = "Re: Phone screen"
         result = DraftService._resolve_subject(_loop(), [msg])
         assert result == "Re: Phone screen"
@@ -527,14 +592,14 @@ class TestResolveSubject:
         """The latest message wins even when list order is oldest-first."""
         oldest = _thread_msg(
             "alice@a.com",
-            ["coord@lrp.com"],
+            ["coord@longridgepartners.com"],
             msg_id="msg_old",
             date=datetime(2026, 4, 14, tzinfo=UTC),
         )
         oldest.subject = "Re: Old subject"
         newest = _thread_msg(
             "alice@a.com",
-            ["coord@lrp.com"],
+            ["coord@longridgepartners.com"],
             msg_id="msg_new",
             date=datetime(2026, 4, 16, tzinfo=UTC),
         )
@@ -545,7 +610,7 @@ class TestResolveSubject:
     def test_falls_back_when_latest_subject_is_blank(self):
         """Defensive: a thread message with whitespace-only subject falls
         back to the loop title rather than producing 'Re: ' alone."""
-        msg = _thread_msg("alice@a.com", ["coord@lrp.com"])
+        msg = _thread_msg("alice@a.com", ["coord@longridgepartners.com"])
         msg.subject = "   "
         result = DraftService._resolve_subject(_loop(), [msg])
         assert result == "Re: Round 1 - John Smith"
@@ -594,7 +659,7 @@ class TestGenerateDraft:
 
         loop = _loop(state=StageState.AWAITING_CANDIDATE)
         suggestion = _suggestion()
-        thread_msg = _thread_msg("alice@client.com", ["coord@lrp.com"])
+        thread_msg = _thread_msg("alice@client.com", ["coord@longridgepartners.com"])
         thread_msg.subject = "Trump"
 
         from unittest.mock import patch


### PR DESCRIPTION
## Summary

A recruiter-bound draft (`recipient_type=recruiter`) with the recruiter slot unset (JIT pending) was leaking a **client-domain address onto the CC line**. Root cause: `_is_forward_draft` returned `False` ("reply") whenever `to_emails` was empty, which fired reply-all CC carry-over while the recruiter's identity was still unknown — dragging the trigger thread's client CC onto the draft.

## What changed

- **Rule 1 — `_strip_external_cc`** (`services/api/src/api/drafts/service.py`): for `recipient_type in ("recruiter", "internal")`, the CC list keeps only addresses at `INTERNAL_DOMAIN` (reused from `api.classifier.router`). Inverts the problem — don't hunt client addresses, allow only internal. Wired as a backstop *after* `_apply_reply_all_cc`.
- **Rule 2 — `_is_forward_draft`**: empty `to_emails` now returns `True` (forward) → reply-all carry-over skipped → CM-only CC until the coordinator fills the contact. The `recipient_type == "client"` privacy guard is still checked first.

## Reviewer notes

- Test fixtures in `test_draft_service.py` had `lrp.com` as a synthetic internal stand-in; swapped to `longridgepartners.com` so the real `INTERNAL_DOMAIN` constant matches. External domains untouched.
- Added 4 tests: screenshot-bug repro (unset recruiter + client on trigger CC), recruiter-reply client-strip, and two `_is_forward_draft` Rule-2 units.
- No new env vars, no Railway changes.

## Test plan

- [x] `ruff check src/ tests/` + `ruff format --check` — clean
- [x] `pytest tests/test_draft_service.py` — 43 passed
- [ ] Adjacent suites (`test_addon_send_draft`, `test_draft_cards`, `test_addon`, `test_scheduling_integration`, `test_overview_service`) — recommend CI confirm (local runs kept auto-backgrounding)