### PR TITLE
feat(router): skip loop classifier when coordinator is off-thread

### DIFF
--- a/services/api/src/api/classifier/router.py
+++ b/services/api/src/api/classifier/router.py
@@ -50,6 +50,24 @@ def _is_internal_only(msg: Message, thread_messages: list[Message] | None = None
     return True
 
 
+def _coordinator_on_trigger(msg: Message, coordinator_email: str) -> bool:
+    """True iff the coordinator appears in From/To/Cc of the trigger message.
+
+    The coordinator is the watched-mailbox owner. If they aren't visibly
+    addressed on the trigger, the message reached their mailbox via a
+    mailbox-level forward (personal Gmail filter or Workspace routing) and
+    must not spawn a new scheduling loop. Note: does not consider aliases —
+    if a coordinator is onboarded with a primary address plus aliases, mail
+    sent to the alias will be filtered. LRP doesn't currently use aliases.
+    """
+    coord = coordinator_email.lower()
+    if msg.from_.email.lower() == coord:
+        return True
+    if any(addr.email.lower() == coord for addr in msg.to):
+        return True
+    return any(addr.email.lower() == coord for addr in msg.cc)
+
+
 class EmailRouter:
     """Routes emails to the correct handler based on thread linkage."""
 
@@ -123,6 +141,21 @@ class EmailRouter:
             logger.debug(
                 "skipping outgoing email on unlinked thread %s",
                 msg.thread_id,
+            )
+            return
+
+        # 4. Off-thread filter — the coordinator (watched-mailbox owner) is not
+        # addressed on the trigger message. The message arrived via mailbox-level
+        # forwarding (personal Gmail filter or Workspace routing) and must not
+        # create a new scheduling loop. Logged at INFO to keep a baseline metric
+        # of how often the rule fires without a separate metric pipeline.
+        if not _coordinator_on_trigger(msg, event.coordinator_email):
+            logger.info(
+                "skipping off-thread message id=%s thread=%s coordinator=%s from=%s",
+                msg.id,
+                msg.thread_id,
+                event.coordinator_email,
+                msg.from_.email,
             )
             return
 

--- a/services/api/tests/test_classifier_hook.py
+++ b/services/api/tests/test_classifier_hook.py
@@ -16,7 +16,7 @@ from api.classifier.models import (
     SuggestionStatus,
 )
 from api.classifier.next_action_agent import NextActionAgent
-from api.classifier.router import EmailRouter, _is_internal_only
+from api.classifier.router import EmailRouter, _coordinator_on_trigger, _is_internal_only
 from api.classifier.sender_blacklist import SenderBlacklist
 from api.gmail.hooks import EmailEvent, MessageDirection, MessageType
 from api.gmail.models import EmailAddress, Message
@@ -918,6 +918,151 @@ class TestInternalOnlyFilter:
         )
         await router.on_email(event)
         classifier.classify.assert_called_once()
+
+
+# --- Off-thread coordinator filter ---
+
+
+def _off_thread_msg(
+    from_email: str,
+    to_emails: tuple[str, ...] = (),
+    cc_emails: tuple[str, ...] = (),
+    msg_id: str = "msg1",
+    thread_id: str = "thread1",
+) -> Message:
+    """Build a Message with arbitrary participants (none of them the coordinator)."""
+    return Message(
+        id=msg_id,
+        thread_id=thread_id,
+        subject="Off-thread",
+        **{"from": EmailAddress(email=from_email)},
+        to=[EmailAddress(email=e) for e in to_emails],
+        cc=[EmailAddress(email=e) for e in cc_emails],
+        date=datetime(2026, 5, 19, 17, 42, tzinfo=UTC),
+        body_text="Body",
+    )
+
+
+class TestCoordinatorOnTrigger:
+    """Unit tests for the _coordinator_on_trigger helper."""
+
+    def test_coordinator_on_from(self):
+        msg = _off_thread_msg(from_email="coord@lrp.com", to_emails=("ext@example.com",))
+        assert _coordinator_on_trigger(msg, "coord@lrp.com") is True
+
+    def test_coordinator_on_to(self):
+        msg = _off_thread_msg(
+            from_email="ext@example.com", to_emails=("coord@lrp.com", "other@lrp.com")
+        )
+        assert _coordinator_on_trigger(msg, "coord@lrp.com") is True
+
+    def test_coordinator_on_cc(self):
+        msg = _off_thread_msg(
+            from_email="ext@example.com",
+            to_emails=("other@lrp.com",),
+            cc_emails=("coord@lrp.com",),
+        )
+        assert _coordinator_on_trigger(msg, "coord@lrp.com") is True
+
+    def test_coordinator_absent(self):
+        # Mirrors the Fubo / Trump / Eric-pitching-Steve traces: external sender,
+        # another LRP staffer on To, coordinator nowhere.
+        msg = _off_thread_msg(
+            from_email="stream@newsletters.fubo.tv",
+            to_emails=("aaron@longridgepartners.com",),
+        )
+        assert _coordinator_on_trigger(msg, "adam@longridgepartners.com") is False
+
+    def test_case_insensitive(self):
+        msg = _off_thread_msg(from_email="ext@example.com", to_emails=("COORD@LRP.COM",))
+        assert _coordinator_on_trigger(msg, "coord@lrp.com") is True
+
+
+class TestOffThreadFilter:
+    """Router-level integration: off-thread trigger never reaches the classifier."""
+
+    @pytest.mark.asyncio
+    async def test_coordinator_on_to_passes_through(self):
+        router, classifier, _, loop_service = _make_router()
+        loop_service.find_loops_by_thread.return_value = []
+
+        event = EmailEvent(
+            message=_off_thread_msg(from_email="ext@candidate.com", to_emails=("coord@lrp.com",)),
+            coordinator_email="coord@lrp.com",
+            direction=MessageDirection.INCOMING,
+            message_type=MessageType.NEW_THREAD,
+            new_participants=[],
+        )
+        await router.on_email(event)
+
+        classifier.classify.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_coordinator_on_cc_passes_through(self):
+        router, classifier, _, loop_service = _make_router()
+        loop_service.find_loops_by_thread.return_value = []
+
+        event = EmailEvent(
+            message=_off_thread_msg(
+                from_email="ext@candidate.com",
+                to_emails=("other@external.com",),
+                cc_emails=("coord@lrp.com",),
+            ),
+            coordinator_email="coord@lrp.com",
+            direction=MessageDirection.INCOMING,
+            message_type=MessageType.NEW_THREAD,
+            new_participants=[],
+        )
+        await router.on_email(event)
+
+        classifier.classify.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_coordinator_on_from_never_reaches_classifier(self):
+        """Outbound from the coordinator — the existing outgoing-on-unlinked
+        filter catches this first, so the assertion is just that the classifier
+        is never called (robust to which filter trips first)."""
+        router, classifier, _, loop_service = _make_router()
+        loop_service.find_loops_by_thread.return_value = []
+
+        event = EmailEvent(
+            message=_off_thread_msg(from_email="coord@lrp.com", to_emails=("ext@candidate.com",)),
+            coordinator_email="coord@lrp.com",
+            direction=MessageDirection.OUTGOING,
+            message_type=MessageType.NEW_THREAD,
+            new_participants=[],
+        )
+        await router.on_email(event)
+
+        classifier.classify.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_off_thread_marketing_blast_is_blocked(self, caplog):
+        """Mirrors the Fubo / Trump / pitched-candidate traces: marketing /
+        forwarded mail in the coordinator's mailbox where they aren't on
+        From/To/Cc must never reach the loop classifier."""
+        import logging
+
+        router, classifier, _, loop_service = _make_router()
+        loop_service.find_loops_by_thread.return_value = []
+
+        event = EmailEvent(
+            message=_off_thread_msg(
+                from_email="stream@newsletters.fubo.tv",
+                to_emails=("aaron@longridgepartners.com",),
+                msg_id="msg_fubo",
+                thread_id="thread_fubo",
+            ),
+            coordinator_email="adam@longridgepartners.com",
+            direction=MessageDirection.INCOMING,
+            message_type=MessageType.NEW_THREAD,
+            new_participants=[],
+        )
+        with caplog.at_level(logging.INFO, logger="api.classifier.router"):
+            await router.on_email(event)
+
+        classifier.classify.assert_not_called()
+        assert any("skipping off-thread message" in r.message for r in caplog.records)
 
 
 # --- Deduplication ---


### PR DESCRIPTION
## Summary

Adds a structural pre-filter to `EmailRouter.on_email`: when the coordinator's email is absent from From/To/Cc of the trigger message, the loop-creation path short-circuits. Linked-thread (NextActionAgent) flow is untouched.

## Why

Diagnosed via three classifier traces today:

1. A Fubo Sportsbook newsletter (To: aaron@longridgepartners.com) showed up in Adam's loop classifier input.
2. A Trump campaign blast (To: sbuena@longridgepartners.com) — same shape, same pattern.
3. A phantom **"Grant Kjeldsen, Woodline Partners"** loop was created on Adam's status board from a thread where Eric Freiberg (CM) was pitching the candidate to Steven Rosenberg (client) — Adam was not on From/To/Cc anywhere.

Two unrelated mass-mail senders both landing in Adam's mailbox with another LRP staffer on To = forwarding pattern, not per-message BCC. The most parsimonious explanation is mailbox-level forwarding: personal Gmail filters on aaron@/sbuena@ that auto-forward bulk mail to Adam, or a Workspace admin routing rule sending all promotional mail to a central inbox. Manually forwarded mail preserves the original `To:` header on the message that lands in the destination mailbox, so the classifier had no structural signal to distinguish forwarded marketing from legitimate scheduling activity.

Cost of leaving this in:
- Wasted classifier spend on every newsletter / forwarded internal pitch.
- **State pollution** — phantom loops on the coordinator's status board (the Grant Kjeldsen case).
- Eval datasets built from production traces inherit the noise.

## What changed

`services/api/src/api/classifier/router.py`:
- New helper `_coordinator_on_trigger(msg, coordinator_email)` — returns True iff the coordinator's email appears in From/To/Cc. Case-folded, mirrors the existing `_is_internal_only` pattern.
- New filter in `EmailRouter.on_email`, placed after the outgoing-on-unlinked check and before the LoopClassifier dispatch. Logs at INFO (not DEBUG) so the skip rate is visible in production logs without a separate metric pipeline; tags `from=` so dominant senders are easy to grep.

`services/api/tests/test_classifier_hook.py`:
- `TestCoordinatorOnTrigger` (5 cases) — helper unit tests including case-insensitivity and the Fubo/Trump trace shape.
- `TestOffThreadFilter` (4 cases) — router integration: coordinator on To passes, on Cc passes, on From / outgoing is blocked by the existing outgoing-on-unlinked filter, and the marketing-blast case is blocked with the expected INFO log.

## Per-LRP assumptions baked in

Confirmed with the user before implementing:
- Legitimate loop-in always uses To/Cc — no BCC convention.
- Manual Gmail forwards put the new recipient on To, so a recruiter forwarding a candidate intro to a coordinator passes the filter.
- LRP doesn't use group/distribution addresses as routing targets.
- Mid-thread additions surface on a message that has the coordinator visibly addressed.

## Scope / out of scope

- **Only the loop-creation path.** Linked-thread mail still flows through to NextActionAgent unchanged — a forwarded side-message hitting a linked thread is vanishingly rare, and the agent operates on existing loops where the coordinator is already the owner.
- **Aliases not handled.** If a coordinator is onboarded with a primary address plus aliases, mail sent to an alias would be filtered. Flagged in the helper docstring. LRP doesn't currently use aliases.
- **Cleanup of pre-existing phantom loops is out of scope** per user direction. Will be a separate PR if needed.

## Test plan

- [x] `uv run pytest tests/test_classifier_hook.py -q` → 78 passed (9 new)
- [ ] Pre-commit (ruff + ruff-format) — passed at commit time
- [ ] Post-merge: grep staging logs for `skipping off-thread message` and confirm marketing-class senders (Fubo, newsletters.fubo.tv, win.donaldjtrump.com) appear; spot-check no legitimate coordinator-addressed mail is in the skip log.
- [ ] One week post-deploy: count skip rate vs LoopClassifier-invoked rate. >20% skip rate suggests the forwarding problem is widespread and warrants a Workspace-rule audit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)