### PR TITLE
feat(agent): reject draft_email placeholders via retry pathway

### DIFF
--- a/services/api/src/api/classifier/next_action_agent.py
+++ b/services/api/src/api/classifier/next_action_agent.py
@@ -21,6 +21,7 @@ from __future__ import annotations
 
 import json
 import logging
+import re
 from typing import TYPE_CHECKING, Any
 
 import sentry_sdk
@@ -67,6 +68,13 @@ if TYPE_CHECKING:
     from api.scheduling.service import LoopService
 
 logger = logging.getLogger(__name__)
+
+# Matches any non-empty bracketed token in a draft body (e.g. "[Recruiter name]",
+# "[DATE]"). Prompt forbids placeholders; this guards the ~1% that slip through.
+# `\n` is excluded so stray brackets on separate lines can't get matched as one
+# giant span.
+_PLACEHOLDER_RE = re.compile(r"\[[^\]\n]+\]")
+
 
 _AGENT_ALLOWED_ACTIONS = frozenset(
     {
@@ -716,6 +724,15 @@ class NextActionAgent:
             model_cls.model_validate(item.action_data)
         except ValidationError as e:
             return item, f"action_data for '{item.action}' is invalid: {e}"
+
+        if item.action == SuggestedAction.DRAFT_EMAIL:
+            body = item.action_data.get("body", "")
+            if _PLACEHOLDER_RE.search(body):
+                return item, (
+                    "I detected a placeholder in the draft message. "
+                    "Placeholders are not permitted in draft messages. "
+                    "Please re-draft."
+                )
 
         if not item.target_loop_id:
             return item, (

--- a/services/api/tests/test_classifier_hook.py
+++ b/services/api/tests/test_classifier_hook.py
@@ -489,6 +489,45 @@ class TestAgentGuardrails:
         assert result.action == SuggestedAction.DRAFT_EMAIL
         assert error is None
 
+    def test_draft_email_placeholder_fails(self):
+        agent, _ = _make_agent()
+        item = _suggestion_item(
+            action=SuggestedAction.DRAFT_EMAIL,
+            action_data={
+                "body": "Hi [Recruiter name], here are the times.",
+                "recipient_type": "recruiter",
+            },
+        )
+        _result, error = agent._apply_guardrails(item, set())
+        assert error is not None
+        assert "placeholder" in error.lower()
+
+    def test_draft_email_bracketed_token_anywhere_fails(self):
+        agent, _ = _make_agent()
+        item = _suggestion_item(
+            action=SuggestedAction.DRAFT_EMAIL,
+            action_data={
+                "body": "Confirming the [DATE] slot works.",
+                "recipient_type": "recruiter",
+            },
+        )
+        _result, error = agent._apply_guardrails(item, set())
+        assert error is not None
+        assert "placeholder" in error.lower()
+
+    def test_draft_email_clean_body_passes(self):
+        agent, _ = _make_agent()
+        item = _suggestion_item(
+            action=SuggestedAction.DRAFT_EMAIL,
+            action_data={
+                "body": "Hi Sarah, can you confirm Tuesday 2pm ET?",
+                "recipient_type": "recruiter",
+            },
+        )
+        result, error = agent._apply_guardrails(item, set())
+        assert error is None
+        assert result.action == SuggestedAction.DRAFT_EMAIL
+
     def test_missing_target_loop_id_fails(self):
         agent, _ = _make_agent()
         item = _suggestion_item(action=SuggestedAction.DRAFT_EMAIL, target_loop_id=None)


### PR DESCRIPTION
## Summary

- Add `_PLACEHOLDER_RE` regex (`\[[^\]\n]+\]`) to `NextActionAgent._apply_guardrails`. For any `draft_email` action whose body contains a bracketed token (e.g. `[Recruiter name]`, `[DATE]`), the guardrail returns an error string and the existing `_validate_batch` / `build_error_followup` retry pathway re-prompts the model with: *"I detected a placeholder in the draft message. Placeholders are not permitted in draft messages. Please re-draft."*
- No new control flow — the agent's batch-error retry mechanism (next_action_agent.py:458) already feeds guardrail errors back as a user-turn and recurses once with `allow_retry=False`. We're just adding one more reason to fail validation.

## Why

The prompt forbids placeholders but ~1/100 generations emit them anyway. When they slip through, the coordinator sees an unsendable draft and has to discard or hand-edit it — breaking the "click yes" UX.

## Scope

- `NextActionAgent` only. Classifier draft outputs (if any) are not covered — out of scope per request.
- Empty `[]`, lone `[`, and lone `]` are not flagged. Any non-empty bracketed token on a single line is. If false positives surface in the wild (e.g. legitimate `[confidential]` markers), we can tighten later.

## Test plan

- [x] `pytest tests/test_classifier_hook.py::TestAgentGuardrails` — 13 pass, including 3 new cases (placeholder at start, bracketed token mid-body, clean body).
- [ ] Post-deploy: watch a few `next-action-agent` Langfuse spans for `call_diagnostics` length > 1 to confirm placeholder retries fire in prod.

🤖 Generated with [Claude Code](https://claude.com/claude-code)