### PR TITLE
fix(gmail): skip DRAFT messages in the push pipeline

### DIFF
--- a/services/api/src/api/gmail/workers.py
+++ b/services/api/src/api/gmail/workers.py
@@ -427,9 +427,15 @@ async def run_next_action_agent(
     gen_token = await claim_generation(redis, gmail_thread_id)
 
     try:
+        message = None
         if gmail_message_id:
-            message = await gmail.get_message(coordinator_email, gmail_message_id)
-        else:
+            fetched = await gmail.get_message(coordinator_email, gmail_message_id)
+            # The explicit id can point at a draft (e.g. the addon creating a
+            # loop while the coordinator's own reply is still an open draft).
+            # Never let a draft be the trigger — fall back to the thread.
+            if DRAFT_LABEL not in fetched.label_ids:
+                message = fetched
+        if message is None:
             thread = await gmail.get_thread(coordinator_email, gmail_thread_id)
             message = _latest_non_draft(thread.messages)
             if message is None:

--- a/services/api/src/api/gmail/workers.py
+++ b/services/api/src/api/gmail/workers.py
@@ -34,6 +34,12 @@ REDIS_URL = os.environ.get("REDIS_URL", "redis://localhost:6379")
 PUBSUB_TOPIC = os.environ.get("PUBSUB_TOPIC", "")
 DEBOUNCE_TTL = 60  # seconds
 
+# Gmail fires messageAdded history events for draft auto-saves, not just
+# sent/received mail. A draft is a half-typed message with this label; the
+# agent must never process one — it would run on partial bodies. The final
+# sent message arrives later as its own messageAdded event with the full body.
+DRAFT_LABEL = "DRAFT"
+
 
 async def startup(ctx: dict) -> None:
     """Initialize shared resources for all worker jobs.
@@ -234,6 +240,19 @@ async def cleanup_processed_messages(ctx: dict) -> None:
 # --- Internal helpers ---
 
 
+def _latest_non_draft(messages: list) -> object | None:
+    """Return the most recent message that isn't a draft, or None.
+
+    Thread fetches can include the coordinator's in-progress draft as the last
+    message. Acting on a draft means running on a half-typed body, so we pick
+    the latest real message instead.
+    """
+    for msg in reversed(messages):
+        if DRAFT_LABEL not in msg.label_ids:
+            return msg
+    return None
+
+
 async def _establish_baseline(ctx: dict, coordinator_email: str) -> None:
     """Set the initial history cursor for a coordinator without processing old emails."""
     gmail: GmailClient = ctx["gmail"]
@@ -280,13 +299,20 @@ async def _process_history(ctx: dict, coordinator_email: str, start_history_id: 
         await _establish_baseline(ctx, coordinator_email)
         return
 
-    # Extract new message IDs from history
+    # Extract new message IDs from history, skipping drafts. The history
+    # stub carries labelIds, so we can drop draft auto-saves without fetching
+    # them — and crucially without marking their IDs processed.
     new_message_ids: list[str] = []
     for entry in history_response.get("history", []):
         for msg_added in entry.get("messagesAdded", []):
-            msg_id = msg_added.get("message", {}).get("id")
-            if msg_id:
-                new_message_ids.append(msg_id)
+            msg = msg_added.get("message", {})
+            msg_id = msg.get("id")
+            if not msg_id:
+                continue
+            if DRAFT_LABEL in msg.get("labelIds", []):
+                logger.debug("skipping draft message %s for %s", msg_id, coordinator_email)
+                continue
+            new_message_ids.append(msg_id)
 
     if not new_message_ids:
         # Advance cursor even if no new messages
@@ -325,6 +351,13 @@ async def _process_history(ctx: dict, coordinator_email: str, start_history_id: 
         try:
             # Fetch full message
             message = await gmail.get_message(coordinator_email, msg_id)
+
+            # Backstop: drop drafts whose history stub lacked labelIds.
+            if DRAFT_LABEL in message.label_ids:
+                logger.info(
+                    "skipping draft message %s post-fetch for %s", msg_id, coordinator_email
+                )
+                continue
 
             # Fetch thread for forward detection (cached per thread)
             thread_id = message.thread_id
@@ -398,10 +431,13 @@ async def run_next_action_agent(
             message = await gmail.get_message(coordinator_email, gmail_message_id)
         else:
             thread = await gmail.get_thread(coordinator_email, gmail_thread_id)
-            if not thread.messages:
-                logger.warning("empty thread %s — skipping next action agent", gmail_thread_id)
+            message = _latest_non_draft(thread.messages)
+            if message is None:
+                logger.warning(
+                    "no non-draft message in thread %s — skipping next action agent",
+                    gmail_thread_id,
+                )
                 return
-            message = thread.messages[-1]
 
         thread = await gmail.get_thread(coordinator_email, gmail_thread_id)
         thread_messages = thread.messages
@@ -469,14 +505,16 @@ async def process_coordinator_response(
         originating = await suggestion_svc.get_suggestion(suggestion_id)
 
         thread = await gmail.get_thread(coordinator_email, gmail_thread_id)
-        if not thread.messages:
-            logger.warning("empty thread %s — cannot process coordinator response", gmail_thread_id)
+        message = _latest_non_draft(thread.messages)
+        if message is None:
+            logger.warning(
+                "no non-draft message in thread %s — cannot process coordinator response",
+                gmail_thread_id,
+            )
             await suggestion_svc.unresolve(
                 suggestion_id, "Thread has no messages — please review manually."
             )
             return
-
-        message = thread.messages[-1]
 
         direction = classify_direction(message, coordinator_email)
         prior_messages = [
@@ -571,15 +609,14 @@ async def process_rejection_response(
             return
 
         thread = await gmail.get_thread(coordinator_email, gmail_thread_id)
-        if not thread.messages:
+        message = _latest_non_draft(thread.messages)
+        if message is None:
             logger.warning(
-                "empty thread %s — cannot run rejection re-run for suggestion %s",
+                "no non-draft message in thread %s — cannot run rejection re-run for suggestion %s",
                 gmail_thread_id,
                 rejected_suggestion_id,
             )
             return
-
-        message = thread.messages[-1]
 
         direction = classify_direction(message, coordinator_email)
         prior_messages = [

--- a/services/api/tests/test_gmail_workers.py
+++ b/services/api/tests/test_gmail_workers.py
@@ -1,0 +1,157 @@
+"""Tests for the Gmail push worker — focused on draft filtering in _process_history.
+
+Regression coverage for the "truncated email" bug: Gmail fires messageAdded
+history events for draft auto-saves, and the pipeline used to process them,
+running the agent on half-typed bodies. Drafts must be skipped.
+"""
+
+from datetime import UTC, datetime
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from api.gmail.models import Message, Thread
+from api.gmail.workers import _process_history
+
+
+def _make_message(msg_id: str, *, labels: list[str], thread_id: str = "thread1") -> Message:
+    return Message(
+        id=msg_id,
+        thread_id=thread_id,
+        subject="Re: Feedback",
+        **{"from": {"name": "Adam", "email": "adam@longridgepartners.com"}},
+        to=[{"name": "Paul", "email": "paul@burkehillglobal.com"}],
+        date=datetime(2026, 5, 21, 9, 39, tzinfo=UTC),
+        body_text="hello",
+        label_ids=labels,
+    )
+
+
+class _ConnCtx:
+    """Async context manager that yields a throwaway connection mock."""
+
+    async def __aenter__(self):
+        return MagicMock()
+
+    async def __aexit__(self, *_args):
+        return False
+
+
+async def _empty_processed(*_args, **_kwargs):
+    """Async generator yielding no already-processed IDs (all are new)."""
+    return
+    yield  # pragma: no cover — makes this an async generator
+
+
+def _build_ctx():
+    """Assemble a mocked worker ctx and return (ctx, mocks) for assertions."""
+    gmail = MagicMock()
+    gmail.history_list = AsyncMock()
+    gmail.get_message = AsyncMock()
+    gmail.get_thread = AsyncMock(return_value=Thread(id="thread1", messages=[]))
+
+    token_store = MagicMock()
+    token_store.update_history_id = AsyncMock()
+
+    pool = MagicMock()
+    pool.connection = lambda: _ConnCtx()
+
+    router = MagicMock()
+    router.on_email = AsyncMock()
+
+    ctx = {
+        "gmail": gmail,
+        "token_store": token_store,
+        "db": pool,
+        "router": router,
+        "redis": None,
+    }
+    return ctx, gmail, token_store, router
+
+
+@pytest.fixture
+def _mock_queries():
+    """Patch the aiosql query object: nothing pre-processed, mark is a no-op."""
+    with patch("api.gmail.workers.gmail_queries") as mq:
+        mq.get_processed_message_ids = lambda *a, **k: _empty_processed()
+        mq.mark_messages_processed_batch = AsyncMock()
+        yield mq
+
+
+@pytest.mark.asyncio
+async def test_draft_skipped_normal_processed(_mock_queries):
+    """A DRAFT messageAdded is dropped at extraction; the SENT one is processed."""
+    ctx, gmail, _token_store, router = _build_ctx()
+    gmail.history_list.return_value = {
+        "history": [
+            {"messagesAdded": [{"message": {"id": "draft1", "labelIds": ["DRAFT"]}}]},
+            {"messagesAdded": [{"message": {"id": "sent1", "labelIds": ["SENT"]}}]},
+        ],
+        "historyId": "999",
+    }
+    gmail.get_message.return_value = _make_message("sent1", labels=["SENT"])
+
+    await _process_history(ctx, "adam@longridgepartners.com", "100")
+
+    # Only the real message is fetched and routed.
+    gmail.get_message.assert_awaited_once_with("adam@longridgepartners.com", "sent1")
+    router.on_email.assert_awaited_once()
+
+    # The draft ID is never marked processed (so a reused ID can't be deduped).
+    marked = _mock_queries.mark_messages_processed_batch.await_args.kwargs["message_ids"]
+    assert marked == ["sent1"]
+    assert "draft1" not in marked
+
+
+@pytest.mark.asyncio
+async def test_draft_only_history_advances_cursor(_mock_queries):
+    """If every added message is a draft, nothing runs but the cursor advances."""
+    ctx, gmail, token_store, router = _build_ctx()
+    gmail.history_list.return_value = {
+        "history": [
+            {"messagesAdded": [{"message": {"id": "draft1", "labelIds": ["DRAFT"]}}]},
+        ],
+        "historyId": "999",
+    }
+
+    await _process_history(ctx, "adam@longridgepartners.com", "100")
+
+    gmail.get_message.assert_not_awaited()
+    router.on_email.assert_not_awaited()
+    _mock_queries.mark_messages_processed_batch.assert_not_awaited()
+    token_store.update_history_id.assert_awaited_once_with("adam@longridgepartners.com", "999")
+
+
+@pytest.mark.asyncio
+async def test_draft_backstop_after_fetch(_mock_queries):
+    """Stub lacks labelIds, but the fetched message is a draft → skipped post-fetch."""
+    ctx, gmail, _token_store, router = _build_ctx()
+    gmail.history_list.return_value = {
+        "history": [
+            {"messagesAdded": [{"message": {"id": "mystery1"}}]},  # no labelIds in stub
+        ],
+        "historyId": "999",
+    }
+    gmail.get_message.return_value = _make_message("mystery1", labels=["DRAFT"])
+
+    await _process_history(ctx, "adam@longridgepartners.com", "100")
+
+    gmail.get_message.assert_awaited_once()
+    router.on_email.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_normal_sent_message_processes(_mock_queries):
+    """Sanity: a plain outbound SENT message is not over-filtered."""
+    ctx, gmail, _token_store, router = _build_ctx()
+    gmail.history_list.return_value = {
+        "history": [
+            {"messagesAdded": [{"message": {"id": "sent1", "labelIds": ["SENT"]}}]},
+        ],
+        "historyId": "999",
+    }
+    gmail.get_message.return_value = _make_message("sent1", labels=["SENT"])
+
+    await _process_history(ctx, "adam@longridgepartners.com", "100")
+
+    router.on_email.assert_awaited_once()

--- a/services/api/tests/test_gmail_workers.py
+++ b/services/api/tests/test_gmail_workers.py
@@ -11,7 +11,7 @@ from unittest.mock import AsyncMock, MagicMock, patch
 import pytest
 
 from api.gmail.models import Message, Thread
-from api.gmail.workers import _process_history
+from api.gmail.workers import _process_history, run_next_action_agent
 
 
 def _make_message(msg_id: str, *, labels: list[str], thread_id: str = "thread1") -> Message:
@@ -155,3 +155,38 @@ async def test_normal_sent_message_processes(_mock_queries):
     await _process_history(ctx, "adam@longridgepartners.com", "100")
 
     router.on_email.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_next_action_explicit_draft_id_falls_back():
+    """An explicit gmail_message_id pointing at a draft must not be the trigger.
+
+    Falls back to the latest non-draft message in the thread.
+    """
+    ctx, gmail, _token_store, router = _build_ctx()
+    gmail.get_message.return_value = _make_message("draft1", labels=["DRAFT"])
+    gmail.get_thread.return_value = Thread(
+        id="thread1", messages=[_make_message("sent1", labels=["SENT"])]
+    )
+
+    await run_next_action_agent(ctx, "adam@longridgepartners.com", "draft1", "thread1")
+
+    router.on_email.assert_awaited_once()
+    triggered = router.on_email.await_args.args[0]
+    assert triggered.message.id == "sent1"
+
+
+@pytest.mark.asyncio
+async def test_next_action_explicit_nondraft_id_used():
+    """A non-draft explicit gmail_message_id is used directly as the trigger."""
+    ctx, gmail, _token_store, router = _build_ctx()
+    gmail.get_message.return_value = _make_message("sent1", labels=["SENT"])
+    gmail.get_thread.return_value = Thread(
+        id="thread1", messages=[_make_message("sent1", labels=["SENT"])]
+    )
+
+    await run_next_action_agent(ctx, "adam@longridgepartners.com", "sent1", "thread1")
+
+    router.on_email.assert_awaited_once()
+    triggered = router.on_email.await_args.args[0]
+    assert triggered.message.id == "sent1"


### PR DESCRIPTION
## Problem

Traces showed outbound emails arriving at the LLM cut mid-sentence with the signature still attached — e.g. `"Thanks for the note...\n\nI spoke with Evan and \n-Adam"` and `"Here is \n-Adam"`. It looked like truncation, but the tail (`-Adam`) survived while the middle vanished.

These are **Gmail draft auto-save snapshots captured mid-compose**, not truncation.

## Root cause

The push pipeline triggers on Gmail `messagesAdded` history events and processed **every** new message ID with no DRAFT-label filter (`_process_history` in `services/api/src/api/gmail/workers.py`). Gmail emits `messagesAdded` for draft auto-saves too, so as a coordinator types a reply, a half-typed draft was fetched and run through the agent — yielding partial bodies and stale loop/suggestion analysis. `label_ids` was parsed and even logged, but never used to filter. The watch is registered with `labelIds: None` (whole mailbox), so drafts were always in scope.

## Fix

- Add `DRAFT_LABEL` constant and skip DRAFT-labeled messages at **history extraction**, so draft IDs are never marked processed (preserves at-most-once for real mail; avoids deduping a reused ID against a draft).
- **Post-fetch backstop**: drop a message if the fetched `Message.label_ids` contains `DRAFT` (covers history stubs missing `labelIds`).
- Guard `thread.messages[-1]` selection in `run_next_action_agent`, `process_coordinator_response`, and `process_rejection_response` via a `_latest_non_draft` helper, so a trailing draft in a thread is never acted on.

The final **sent** message arrives later as its own `messagesAdded` event with the full body and is processed normally — the fix heals forward, no backfill needed.

## Tests

New `services/api/tests/test_gmail_workers.py`:
- DRAFT messageAdded dropped at extraction; SENT one processed; draft ID never marked processed.
- Draft-only history → nothing runs, cursor still advances.
- Backstop: stub lacks `labelIds`, fetched message is DRAFT → skipped post-fetch.
- Sanity: a plain SENT outbound message still processes.

`ruff check` / `ruff format --check` pass on changed files.

## Reviewer notes

- No prompt, dependency, DB/schema, or Railway/env-var changes.
- Quote-chain stripping (the `>` / `On…wrote:` noise) is a separate prompt-noise improvement, intentionally out of scope here.