### PR TITLE
feat(agent): schedule_interview suggestion type — bones only

### DIFF
--- a/services/api/migrations/0015_scheduled_interviews.py
+++ b/services/api/migrations/0015_scheduled_interviews.py
@@ -1,0 +1,22 @@
+"""Create scheduled_interviews table — booked interviews tracked per loop."""
+
+from yoyo import step
+
+step(
+    """
+    CREATE TABLE scheduled_interviews (
+        id                      TEXT PRIMARY KEY,
+        loop_id                 TEXT NOT NULL REFERENCES loops(id),
+        interview_start_time    TIMESTAMPTZ NOT NULL,
+        interview_duration      INTEGER NOT NULL,
+        interview_notes         TEXT NOT NULL DEFAULT '',
+        is_canceled             BOOLEAN NOT NULL DEFAULT false,
+        created_at              TIMESTAMPTZ NOT NULL DEFAULT now(),
+        updated_at              TIMESTAMPTZ NOT NULL DEFAULT now()
+    );
+    CREATE INDEX idx_scheduled_interviews_loop ON scheduled_interviews(loop_id);
+    """,
+    """
+    DROP TABLE IF EXISTS scheduled_interviews;
+    """,
+)

--- a/services/api/queries/scheduling.sql
+++ b/services/api/queries/scheduling.sql
@@ -411,10 +411,12 @@ WHERE loop_id = :loop_id AND is_canceled = false
 ORDER BY interview_start_time;
 
 -- name: update_scheduled_interview!
+-- PATCH semantics: any bound param that is NULL means "leave the existing value
+-- alone." Lets the agent send only the fields it wants to change.
 UPDATE scheduled_interviews
-SET interview_start_time = :interview_start_time,
-    interview_duration   = :interview_duration,
-    interview_notes      = :interview_notes,
+SET interview_start_time = COALESCE(:interview_start_time, interview_start_time),
+    interview_duration   = COALESCE(:interview_duration, interview_duration),
+    interview_notes      = COALESCE(:interview_notes, interview_notes),
     updated_at           = now()
 WHERE id = :id;
 

--- a/services/api/queries/scheduling.sql
+++ b/services/api/queries/scheduling.sql
@@ -383,3 +383,43 @@ SELECT id, loop_id, gmail_thread_id, subject, linked_at
 FROM loop_email_threads
 WHERE loop_id = ANY(:loop_ids)
 ORDER BY loop_id, linked_at;
+
+-- ============================================================
+-- Scheduled interviews
+-- ============================================================
+
+-- name: create_scheduled_interview^
+INSERT INTO scheduled_interviews (
+    id, loop_id, interview_start_time, interview_duration, interview_notes
+)
+VALUES (:id, :loop_id, :interview_start_time, :interview_duration, :interview_notes)
+RETURNING id, loop_id, interview_start_time, interview_duration, interview_notes,
+          is_canceled, created_at, updated_at;
+
+-- name: get_scheduled_interview^
+SELECT id, loop_id, interview_start_time, interview_duration, interview_notes,
+       is_canceled, created_at, updated_at
+FROM scheduled_interviews
+WHERE id = :id;
+
+-- name: get_active_interviews_for_loop
+-- Non-canceled interviews for a loop, earliest first.
+SELECT id, loop_id, interview_start_time, interview_duration, interview_notes,
+       is_canceled, created_at, updated_at
+FROM scheduled_interviews
+WHERE loop_id = :loop_id AND is_canceled = false
+ORDER BY interview_start_time;
+
+-- name: update_scheduled_interview!
+UPDATE scheduled_interviews
+SET interview_start_time = :interview_start_time,
+    interview_duration   = :interview_duration,
+    interview_notes      = :interview_notes,
+    updated_at           = now()
+WHERE id = :id;
+
+-- name: cancel_scheduled_interview!
+UPDATE scheduled_interviews
+SET is_canceled = true,
+    updated_at  = now()
+WHERE id = :id;

--- a/services/api/src/api/addon/routes.py
+++ b/services/api/src/api/addon/routes.py
@@ -1624,6 +1624,34 @@ async def _handle_accept_suggestion(body: AddonRequest, svc: LoopService, email:
             await svc.link_thread(suggestion.loop_id, suggestion.gmail_thread_id, None, email)
         else:
             logger.warning("LINK_THREAD suggestion %s missing loop_id or thread_id", suggestion_id)
+    elif suggestion.action == SuggestedAction.SCHEDULE_INTERVIEW:
+        from api.classifier.models import ScheduleInterviewData
+        from api.scheduling.service import ScheduledInterviewService
+
+        data = ScheduleInterviewData.model_validate(suggestion.action_data or {})
+        interview_svc = ScheduledInterviewService(db_pool=svc._pool)
+        if data.interview_op == "schedule":
+            assert data.interview_start_time is not None
+            assert data.interview_duration is not None
+            await interview_svc.create(
+                loop_id=data.loop_id,
+                start_time=data.interview_start_time,
+                duration=data.interview_duration,
+                notes=data.interview_notes,
+            )
+        elif data.interview_op == "update":
+            assert data.interview_id is not None
+            assert data.interview_start_time is not None
+            assert data.interview_duration is not None
+            await interview_svc.update(
+                interview_id=data.interview_id,
+                start_time=data.interview_start_time,
+                duration=data.interview_duration,
+                notes=data.interview_notes,
+            )
+        elif data.interview_op == "cancel":
+            assert data.interview_id is not None
+            await interview_svc.cancel(data.interview_id)
     else:
         logger.warning(
             "accept_suggestion called for unsupported action %s (suggestion %s) — ignoring",

--- a/services/api/src/api/addon/routes.py
+++ b/services/api/src/api/addon/routes.py
@@ -1631,6 +1631,7 @@ async def _handle_accept_suggestion(body: AddonRequest, svc: LoopService, email:
         data = ScheduleInterviewData.model_validate(suggestion.action_data or {})
         interview_svc = ScheduledInterviewService(db_pool=svc._pool)
         if data.interview_op == "schedule":
+            # Validator guarantees start_time + duration are non-null for schedule.
             assert data.interview_start_time is not None
             assert data.interview_duration is not None
             await interview_svc.create(
@@ -1640,9 +1641,8 @@ async def _handle_accept_suggestion(body: AddonRequest, svc: LoopService, email:
                 notes=data.interview_notes,
             )
         elif data.interview_op == "update":
+            # PATCH semantics: any None param leaves the existing value alone.
             assert data.interview_id is not None
-            assert data.interview_start_time is not None
-            assert data.interview_duration is not None
             await interview_svc.update(
                 interview_id=data.interview_id,
                 start_time=data.interview_start_time,

--- a/services/api/src/api/classifier/formatters.py
+++ b/services/api/src/api/classifier/formatters.py
@@ -18,7 +18,7 @@ from zoneinfo import ZoneInfo
 if TYPE_CHECKING:
     from api.classifier.models import Suggestion
     from api.gmail.models import Message
-    from api.scheduling.models import Loop, LoopEvent
+    from api.scheduling.models import Loop, LoopEvent, ScheduledInterview
 
 # Default thread history budget: ~3000 tokens x 4 chars/token = 12000 chars
 DEFAULT_THREAD_CHAR_BUDGET = 12_000
@@ -418,7 +418,33 @@ def _format_pending_suggestions_xml(pending: list[Suggestion]) -> str:
     return f"<pending-suggestions>\n{inner}\n  </pending-suggestions>"
 
 
-def format_loop_xml(loop: Loop, pending_for_loop: list[Suggestion]) -> str:
+def _format_scheduled_interviews_xml(
+    interviews: list[ScheduledInterview], candidate_name: str | None
+) -> str:
+    """Render a loop's active (non-canceled) scheduled interviews."""
+    if not interviews:
+        return "<scheduled-interviews>No scheduled interviews</scheduled-interviews>"
+    children: list[str] = []
+    for iv in interviews:
+        start_time = _escape(format_llm_datetime(iv.interview_start_time))
+        notes = _escape((iv.interview_notes or "").strip())
+        children.append(
+            f"    <interview id=\"{_escape(iv.id)}\">\n"
+            f"      <candidate>{_escape(candidate_name or '')}</candidate>\n"
+            f"      <start-time>{start_time}</start-time>\n"
+            f"      <duration>{iv.interview_duration} minutes</duration>\n"
+            f"      <notes>{notes}</notes>\n"
+            f"    </interview>"
+        )
+    inner = "\n".join(children)
+    return f"<scheduled-interviews>\n{inner}\n  </scheduled-interviews>"
+
+
+def format_loop_xml(
+    loop: Loop,
+    pending_for_loop: list[Suggestion],
+    interviews_for_loop: list[ScheduledInterview] | None = None,
+) -> str:
     """Render a single loop as a <loop> XML block."""
     coordinator = loop.coordinator
     recruiter = loop.recruiter
@@ -446,6 +472,12 @@ def format_loop_xml(loop: Loop, pending_for_loop: list[Suggestion]) -> str:
     # Indent the pending block by two spaces so it aligns with siblings.
     pending_block_indented = "\n".join("  " + line for line in pending_block.split("\n"))
 
+    interviews_block = _format_scheduled_interviews_xml(
+        interviews_for_loop or [],
+        candidate.name if candidate else None,
+    )
+    interviews_block_indented = "\n".join("  " + line for line in interviews_block.split("\n"))
+
     lines = [
         f"<loop id='{_escape(loop.id)}'>",
         f"  <stage>{_escape(loop.state.value)}</stage>",
@@ -457,6 +489,7 @@ def format_loop_xml(loop: Loop, pending_for_loop: list[Suggestion]) -> str:
         f"    {candidate_tag}",
         "  </actors>",
         pending_block_indented,
+        interviews_block_indented,
         "</loop>",
     ]
     return "\n".join(lines)
@@ -465,11 +498,20 @@ def format_loop_xml(loop: Loop, pending_for_loop: list[Suggestion]) -> str:
 def format_loops_xml(
     loops: list[Loop],
     pending_by_loop: dict[str, list[Suggestion]],
+    interviews_by_loop: dict[str, list[ScheduledInterview]] | None = None,
 ) -> str:
     """Render all loops linked to the thread as concatenated <loop> blocks."""
     if not loops:
         return "<!-- No loops linked to this thread -->"
-    return "\n".join(format_loop_xml(lp, pending_by_loop.get(lp.id, [])) for lp in loops)
+    interviews_by_loop = interviews_by_loop or {}
+    return "\n".join(
+        format_loop_xml(
+            lp,
+            pending_by_loop.get(lp.id, []),
+            interviews_by_loop.get(lp.id, []),
+        )
+        for lp in loops
+    )
 
 
 # ---------------------------------------------------------------------------

--- a/services/api/src/api/classifier/formatters.py
+++ b/services/api/src/api/classifier/formatters.py
@@ -429,7 +429,7 @@ def _format_scheduled_interviews_xml(
         start_time = _escape(format_llm_datetime(iv.interview_start_time))
         notes = _escape((iv.interview_notes or "").strip())
         children.append(
-            f"    <interview id=\"{_escape(iv.id)}\">\n"
+            f'    <interview id="{_escape(iv.id)}">\n'
             f"      <candidate>{_escape(candidate_name or '')}</candidate>\n"
             f"      <start-time>{start_time}</start-time>\n"
             f"      <duration>{iv.interview_duration} minutes</duration>\n"

--- a/services/api/src/api/classifier/models.py
+++ b/services/api/src/api/classifier/models.py
@@ -16,7 +16,7 @@ from datetime import datetime  # noqa: TC003
 from enum import StrEnum
 from typing import Any, Literal
 
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, Field, model_validator
 
 from api.scheduling.models import StageState  # noqa: TC001 — needed at runtime
 
@@ -40,6 +40,7 @@ class SuggestedAction(StrEnum):
     ASK_COORDINATOR = "ask_coordinator"
     EXPIRE_SUGGESTION = "expire_suggestion"
     UPDATE_ACTOR = "update_actor"
+    SCHEDULE_INTERVIEW = "schedule_interview"
     NO_ACTION = "no_action"
 
 
@@ -110,6 +111,44 @@ class LinkThreadData(BaseModel):
     client_company: str
 
 
+class ScheduleInterviewData(BaseModel):
+    """Action data for SCHEDULE_INTERVIEW — book, reschedule, or cancel an interview
+    against a specific loop. The agent must always specify which loop; for update
+    and cancel it must also reference an existing interview_id."""
+
+    interview_op: Literal["schedule", "update", "cancel"]
+    loop_id: str
+    interview_id: str | None = None
+    interview_start_time: datetime | None = None
+    interview_duration: int | None = None
+    interview_notes: str = ""
+
+    @model_validator(mode="after")
+    def _check_op_nullability(self) -> ScheduleInterviewData:
+        op = self.interview_op
+        if op == "schedule":
+            if self.interview_id is not None:
+                raise ValueError(
+                    "schedule op must not include interview_id (it references a "
+                    "record that does not exist yet)"
+                )
+            if self.interview_start_time is None:
+                raise ValueError("schedule op requires interview_start_time")
+            if self.interview_duration is None:
+                raise ValueError("schedule op requires interview_duration")
+        elif op == "update":
+            if self.interview_id is None:
+                raise ValueError("update op requires interview_id")
+            if self.interview_start_time is None:
+                raise ValueError("update op requires interview_start_time")
+            if self.interview_duration is None:
+                raise ValueError("update op requires interview_duration")
+        elif op == "cancel":
+            if self.interview_id is None:
+                raise ValueError("cancel op requires interview_id")
+        return self
+
+
 class CreateLoopExtraction(BaseModel):
     """Typed payload for CREATE_LOOP action_data.
 
@@ -141,6 +180,7 @@ ACTION_DATA_MODELS: dict[SuggestedAction, type[BaseModel]] = {
     SuggestedAction.CREATE_LOOP: CreateLoopExtraction,
     SuggestedAction.EXPIRE_SUGGESTION: ExpireSuggestionData,
     SuggestedAction.UPDATE_ACTOR: UpdateActorData,
+    SuggestedAction.SCHEDULE_INTERVIEW: ScheduleInterviewData,
 }
 
 

--- a/services/api/src/api/classifier/models.py
+++ b/services/api/src/api/classifier/models.py
@@ -114,14 +114,18 @@ class LinkThreadData(BaseModel):
 class ScheduleInterviewData(BaseModel):
     """Action data for SCHEDULE_INTERVIEW — book, reschedule, or cancel an interview
     against a specific loop. The agent must always specify which loop; for update
-    and cancel it must also reference an existing interview_id."""
+    and cancel it must also reference an existing interview_id.
+
+    ``update`` uses PATCH semantics: any of start_time / duration / notes may be
+    null, meaning "leave this field as-is." The SQL update path COALESCEs nulls
+    against existing column values."""
 
     interview_op: Literal["schedule", "update", "cancel"]
     loop_id: str
     interview_id: str | None = None
     interview_start_time: datetime | None = None
     interview_duration: int | None = None
-    interview_notes: str = ""
+    interview_notes: str | None = None
 
     @model_validator(mode="after")
     def _check_op_nullability(self) -> ScheduleInterviewData:
@@ -139,10 +143,9 @@ class ScheduleInterviewData(BaseModel):
         elif op == "update":
             if self.interview_id is None:
                 raise ValueError("update op requires interview_id")
-            if self.interview_start_time is None:
-                raise ValueError("update op requires interview_start_time")
-            if self.interview_duration is None:
-                raise ValueError("update op requires interview_duration")
+            # start_time / duration / notes are intentionally optional on update —
+            # null means "leave existing value." See SQL COALESCE in
+            # update_scheduled_interview.
         elif op == "cancel":
             if self.interview_id is None:
                 raise ValueError("cancel op requires interview_id")

--- a/services/api/src/api/classifier/next_action_agent.py
+++ b/services/api/src/api/classifier/next_action_agent.py
@@ -64,8 +64,8 @@ if TYPE_CHECKING:
     from api.drafts.service import DraftService
     from api.gmail.hooks import EmailEvent
     from api.gmail.models import Message
-    from api.scheduling.models import Loop
-    from api.scheduling.service import LoopService
+    from api.scheduling.models import Loop, ScheduledInterview
+    from api.scheduling.service import LoopService, ScheduledInterviewService
 
 logger = logging.getLogger(__name__)
 
@@ -127,12 +127,14 @@ class NextActionAgent:
         langfuse: Langfuse,
         suggestion_service: SuggestionService,
         loop_service: LoopService,
+        interview_service: ScheduledInterviewService,
         draft_service: DraftService | None = None,
     ):
         self._llm = llm
         self._langfuse = langfuse
         self._suggestions = suggestion_service
         self._loops = loop_service
+        self._interviews = interview_service
         self._draft_service = draft_service
         self._resolver_registry = build_agent_registry()
 
@@ -614,17 +616,19 @@ class NextActionAgent:
 
         all_pending: list[Suggestion] = []
         pending_by_loop: dict[str, list[Suggestion]] = {}
+        interviews_by_loop: dict[str, list[ScheduledInterview]] = {}
         for lp in linked_loops:
             loop_pending = await self._suggestions.get_pending_for_loop(lp.id)
             pending_by_loop[lp.id] = loop_pending
             all_pending.extend(loop_pending)
+            interviews_by_loop[lp.id] = await self._interviews.list_active_for_loop(lp.id)
 
         return (
             NextActionInput(
                 date=date_str,
                 thread_history=thread_history_xml,
                 email=format_email_xml(msg, event.direction.value),
-                loops=format_loops_xml(linked_loops, pending_by_loop),
+                loops=format_loops_xml(linked_loops, pending_by_loop, interviews_by_loop),
             ),
             all_pending,
         )

--- a/services/api/src/api/classifier/next_action_agent.py
+++ b/services/api/src/api/classifier/next_action_agent.py
@@ -83,6 +83,7 @@ _AGENT_ALLOWED_ACTIONS = frozenset(
         SuggestedAction.ASK_COORDINATOR,
         SuggestedAction.EXPIRE_SUGGESTION,
         SuggestedAction.UPDATE_ACTOR,
+        SuggestedAction.SCHEDULE_INTERVIEW,
         SuggestedAction.NO_ACTION,
     }
 )

--- a/services/api/src/api/gmail/workers.py
+++ b/services/api/src/api/gmail/workers.py
@@ -68,7 +68,7 @@ async def startup(ctx: dict) -> None:
     from api.classifier.sender_blacklist import load_blacklist
     from api.classifier.service import SuggestionService
     from api.drafts.service import DraftService
-    from api.scheduling.service import LoopService
+    from api.scheduling.service import LoopService, ScheduledInterviewService
 
     langfuse = init_langfuse()
     llm = init_llm_service()
@@ -86,11 +86,13 @@ async def startup(ctx: dict) -> None:
         suggestion_service=suggestion_service,
         loop_service=loop_service,
     )
+    interview_service = ScheduledInterviewService(db_pool=pool)
     agent = NextActionAgent(
         llm=llm,
         langfuse=langfuse,
         suggestion_service=suggestion_service,
         loop_service=loop_service,
+        interview_service=interview_service,
         draft_service=draft_service,
     )
     ctx["router"] = EmailRouter(

--- a/services/api/src/api/main.py
+++ b/services/api/src/api/main.py
@@ -27,7 +27,7 @@ from api.gmail.auth import TokenStore  # noqa: E402
 from api.gmail.client import GmailClient  # noqa: E402
 from api.gmail.webhook import webhook_router  # noqa: E402
 from api.observability import RequestIdMiddleware, init_sentry  # noqa: E402
-from api.scheduling.service import LoopService  # noqa: E402
+from api.scheduling.service import LoopService, ScheduledInterviewService  # noqa: E402
 
 logger = logging.getLogger(__name__)
 
@@ -83,11 +83,14 @@ async def lifespan(app: FastAPI):
         suggestion_service=suggestion_service,
         loop_service=app.state.scheduling,
     )
+    interview_service = ScheduledInterviewService(db_pool=pool)
+    app.state.interviews = interview_service
     agent = NextActionAgent(
         llm=llm_service,
         langfuse=langfuse,
         suggestion_service=suggestion_service,
         loop_service=app.state.scheduling,
+        interview_service=interview_service,
         draft_service=draft_service,
     )
     app.state.email_router = EmailRouter(

--- a/services/api/src/api/overview/cards.py
+++ b/services/api/src/api/overview/cards.py
@@ -15,6 +15,9 @@ original card builders for these actions are kept so:
 
 from __future__ import annotations
 
+from datetime import UTC, datetime
+from zoneinfo import ZoneInfo
+
 from api.addon.contact_inputs import build_client_inputs, build_recruiter_inputs
 from api.addon.models import (
     Button,
@@ -656,6 +659,120 @@ def _escape_html_for_widget(text: str) -> str:
 
 
 # ---------------------------------------------------------------------------
+# SCHEDULE_INTERVIEW
+# ---------------------------------------------------------------------------
+
+_SIDEBAR_TZ = ZoneInfo("America/New_York")
+
+
+def _format_sidebar_datetime(dt: datetime) -> str:
+    """Render ``May 12, 2026, 3:00 PM ET`` for sidebar display."""
+    if dt.tzinfo is None:
+        dt = dt.replace(tzinfo=UTC)
+    local = dt.astimezone(_SIDEBAR_TZ)
+    hour_12 = local.hour % 12 or 12
+    return local.strftime(f"%B {local.day}, {local.year}, {hour_12}:%M %p ET")
+
+
+def _format_duration(minutes: int) -> str:
+    return f"{minutes} minutes"
+
+
+def _build_schedule_interview_suggestion(view: SuggestionView) -> list[Widget]:
+    """SCHEDULE_INTERVIEW — schedule / update / cancel an interview for a loop.
+
+    Not auto-resolved. Coordinator must Accept or Dismiss every interview op.
+    """
+    sug = view.suggestion
+    data = sug.action_data or {}
+    op = (data.get("interview_op") or "").strip()
+
+    candidate = view.candidate_name or "candidate"
+    client = view.client_company or "client"
+
+    if op == "schedule":
+        header_verb = "Schedule"
+        icon = "📅 Schedule"
+    elif op == "update":
+        header_verb = "Update"
+        icon = "✏️ Update"
+    elif op == "cancel":
+        header_verb = "Cancel"
+        icon = "✕ Cancel"
+    else:
+        op_html = _escape_html_for_widget(op)
+        return [
+            _text(f"<i>Unknown interview op <code>{op_html}</code> — please dismiss.</i>"),
+            _buttons(_dismiss_button(sug.id)),
+        ]
+
+    header = f"{header_verb} interview for {candidate} with {client}"
+    widgets: list[Widget] = [_decorated(header, icon)]
+
+    new_start_raw = data.get("interview_start_time")
+    new_start: datetime | None = None
+    if new_start_raw:
+        try:
+            new_start = datetime.fromisoformat(str(new_start_raw))
+        except ValueError:
+            new_start = None
+    new_duration = data.get("interview_duration")
+    new_notes = (data.get("interview_notes") or "").strip()
+    existing = view.existing_interview
+
+    if op == "schedule":
+        if new_start is not None:
+            widgets.append(_text(f"<b>Time:</b> {_format_sidebar_datetime(new_start)}"))
+        if isinstance(new_duration, int):
+            widgets.append(_text(f"<b>Duration:</b> {_format_duration(new_duration)}"))
+        if new_notes:
+            widgets.append(_text(f"<b>Notes:</b> {_escape_html_for_widget(new_notes)}"))
+
+    elif op == "update":
+        if existing is None:
+            widgets.append(
+                _text("<i>Existing interview record not found — please dismiss and retry.</i>")
+            )
+        else:
+            if new_start is not None and new_start != existing.interview_start_time:
+                old = _format_sidebar_datetime(existing.interview_start_time)
+                new = _format_sidebar_datetime(new_start)
+                widgets.append(_text(f"<b>Time:</b> {old} → {new}"))
+            if isinstance(new_duration, int) and new_duration != existing.interview_duration:
+                old_dur = _format_duration(existing.interview_duration)
+                new_dur = _format_duration(new_duration)
+                widgets.append(_text(f"<b>Duration:</b> {old_dur} → {new_dur}"))
+            existing_notes = (existing.interview_notes or "").strip()
+            if new_notes != existing_notes:
+                old_label = (
+                    _escape_html_for_widget(existing_notes) if existing_notes else "<i>(none)</i>"
+                )
+                new_label = _escape_html_for_widget(new_notes) if new_notes else "<i>(none)</i>"
+                widgets.append(_text(f"<b>Notes:</b> {old_label} → {new_label}"))
+
+    elif op == "cancel":
+        if existing is None:
+            widgets.append(
+                _text("<i>Existing interview record not found — please dismiss and retry.</i>")
+            )
+        else:
+            widgets.append(
+                _text(f"<b>Time:</b> {_format_sidebar_datetime(existing.interview_start_time)}")
+            )
+            widgets.append(
+                _text(f"<b>Duration:</b> {_format_duration(existing.interview_duration)}")
+            )
+
+    widgets.append(
+        _buttons(
+            _button("Accept", "accept_suggestion", suggestion_id=sug.id),
+            _dismiss_button(sug.id),
+        )
+    )
+    return widgets
+
+
+# ---------------------------------------------------------------------------
 # Dispatcher
 # ---------------------------------------------------------------------------
 
@@ -670,6 +787,7 @@ _SUGGESTION_BUILDERS = {
     SuggestedAction.LINK_THREAD: _build_link_thread_suggestion,
     SuggestedAction.ASK_COORDINATOR: _build_ask_suggestion,
     SuggestedAction.UPDATE_ACTOR: _build_update_actor_suggestion,
+    SuggestedAction.SCHEDULE_INTERVIEW: _build_schedule_interview_suggestion,
 }
 
 

--- a/services/api/src/api/overview/cards.py
+++ b/services/api/src/api/overview/cards.py
@@ -717,7 +717,13 @@ def _build_schedule_interview_suggestion(view: SuggestionView) -> list[Widget]:
         except ValueError:
             new_start = None
     new_duration = data.get("interview_duration")
-    new_notes = (data.get("interview_notes") or "").strip()
+    # For update ops, preserve the None-vs-empty-string distinction:
+    #   None  -> agent omitted notes; do not touch existing notes.
+    #   ""    -> agent wants to clear notes.
+    #   "..." -> agent wants to set notes to this value.
+    raw_notes = data.get("interview_notes")
+    new_notes_provided = raw_notes is not None
+    new_notes = raw_notes.strip() if isinstance(raw_notes, str) else ""
     existing = view.existing_interview
 
     if op == "schedule":
@@ -743,7 +749,7 @@ def _build_schedule_interview_suggestion(view: SuggestionView) -> list[Widget]:
                 new_dur = _format_duration(new_duration)
                 widgets.append(_text(f"<b>Duration:</b> {old_dur} → {new_dur}"))
             existing_notes = (existing.interview_notes or "").strip()
-            if new_notes != existing_notes:
+            if new_notes_provided and new_notes != existing_notes:
                 old_label = (
                     _escape_html_for_widget(existing_notes) if existing_notes else "<i>(none)</i>"
                 )

--- a/services/api/src/api/overview/models.py
+++ b/services/api/src/api/overview/models.py
@@ -12,6 +12,7 @@ from pydantic import BaseModel
 
 from api.classifier.models import Suggestion  # noqa: TC001
 from api.drafts.models import EmailDraft  # noqa: TC001
+from api.scheduling.models import ScheduledInterview  # noqa: TC001
 
 
 class SuggestionView(BaseModel):
@@ -32,6 +33,9 @@ class SuggestionView(BaseModel):
     recruiter_email: str | None = None
     client_manager_name: str | None = None
     client_manager_email: str | None = None
+    # Populated for SCHEDULE_INTERVIEW suggestions with an interview_id
+    # (update/cancel ops) — lets the card render a diff against existing state.
+    existing_interview: ScheduledInterview | None = None
 
 
 class LoopSuggestionGroup(BaseModel):

--- a/services/api/src/api/overview/service.py
+++ b/services/api/src/api/overview/service.py
@@ -14,6 +14,7 @@ from api.classifier.models import SuggestedAction, Suggestion
 from api.classifier.queries import queries
 from api.drafts.models import DraftStatus, EmailDraft
 from api.overview.models import LoopSuggestionGroup, SuggestionView
+from api.scheduling.service import ScheduledInterviewService
 
 if TYPE_CHECKING:
     from psycopg_pool import AsyncConnectionPool
@@ -145,9 +146,24 @@ def group_by_loop(views: list[SuggestionView]) -> list[LoopSuggestionGroup]:
     return sorted(groups.values(), key=lambda g: g.oldest_created_at)
 
 
+async def _attach_existing_interviews(
+    views: list[SuggestionView], interview_svc: ScheduledInterviewService
+) -> None:
+    """For SCHEDULE_INTERVIEW views referencing an existing interview_id,
+    fetch the row and attach it so the card can diff old vs. new fields."""
+    for v in views:
+        if v.suggestion.action != SuggestedAction.SCHEDULE_INTERVIEW:
+            continue
+        interview_id = (v.suggestion.action_data or {}).get("interview_id")
+        if not interview_id:
+            continue
+        v.existing_interview = await interview_svc.get(interview_id)
+
+
 class OverviewService:
     def __init__(self, db_pool: AsyncConnectionPool):
         self._pool = db_pool
+        self._interviews = ScheduledInterviewService(db_pool=db_pool)
 
     async def get_overview_data(self, coordinator_email: str) -> list[LoopSuggestionGroup]:
         """Fetch all pending suggestions with context, grouped by loop."""
@@ -158,6 +174,7 @@ class OverviewService:
                 )
             )
         views = [_row_to_suggestion_view(r) for r in rows]
+        await _attach_existing_interviews(views, self._interviews)
         return group_by_loop(views)
 
     async def get_thread_overview_data(
@@ -173,4 +190,5 @@ class OverviewService:
                 )
             )
         views = [_row_to_suggestion_view(r) for r in rows]
+        await _attach_existing_interviews(views, self._interviews)
         return group_by_loop(views)

--- a/services/api/src/api/scheduling/models.py
+++ b/services/api/src/api/scheduling/models.py
@@ -136,6 +136,19 @@ class Loop(BaseModel):
         return NEXT_ACTIONS[self.state]
 
 
+class ScheduledInterview(BaseModel):
+    """A booked interview attached to a loop. Persisted to scheduled_interviews."""
+
+    id: str
+    loop_id: str
+    interview_start_time: datetime
+    interview_duration: int
+    interview_notes: str = ""
+    is_canceled: bool = False
+    created_at: datetime
+    updated_at: datetime
+
+
 class LoopSummary(BaseModel):
     """Lightweight loop info for the status board."""
 

--- a/services/api/src/api/scheduling/service.py
+++ b/services/api/src/api/scheduling/service.py
@@ -812,7 +812,7 @@ class ScheduledInterviewService:
         loop_id: str,
         start_time: datetime,
         duration: int,
-        notes: str = "",
+        notes: str | None = None,
     ) -> ScheduledInterview:
         async with self._pool.connection() as conn, conn.transaction():
             row = await _fetch_dict_one(
@@ -822,7 +822,7 @@ class ScheduledInterviewService:
                 loop_id=loop_id,
                 interview_start_time=start_time,
                 interview_duration=duration,
-                interview_notes=notes,
+                interview_notes=notes or "",
             )
         assert row is not None
         return _row_to_scheduled_interview(row)
@@ -831,10 +831,12 @@ class ScheduledInterviewService:
         self,
         *,
         interview_id: str,
-        start_time: datetime,
-        duration: int,
-        notes: str = "",
+        start_time: datetime | None = None,
+        duration: int | None = None,
+        notes: str | None = None,
     ) -> ScheduledInterview:
+        """Partial update — any None param leaves the existing column value alone
+        (enforced by COALESCE in update_scheduled_interview)."""
         async with self._pool.connection() as conn, conn.transaction():
             await queries.update_scheduled_interview(
                 conn,

--- a/services/api/src/api/scheduling/service.py
+++ b/services/api/src/api/scheduling/service.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 import json
 import logging
 import os
+from datetime import datetime  # noqa: TC003
 from typing import TYPE_CHECKING, Any
 
 import sentry_sdk
@@ -25,6 +26,7 @@ from api.scheduling.models import (
     Loop,
     LoopEvent,
     LoopSummary,
+    ScheduledInterview,
     StageState,
     StatusBoard,
 )
@@ -783,6 +785,88 @@ def _row_to_email_thread(row: tuple) -> EmailThread:
         subject=row[3],
         linked_at=row[4],
     )
+
+
+def _row_to_scheduled_interview(row: dict) -> ScheduledInterview:
+    return ScheduledInterview(
+        id=row["id"],
+        loop_id=row["loop_id"],
+        interview_start_time=row["interview_start_time"],
+        interview_duration=row["interview_duration"],
+        interview_notes=row["interview_notes"] or "",
+        is_canceled=row["is_canceled"],
+        created_at=row["created_at"],
+        updated_at=row["updated_at"],
+    )
+
+
+class ScheduledInterviewService:
+    """CRUD for scheduled interviews. One row per booked (or canceled) interview."""
+
+    def __init__(self, db_pool: AsyncConnectionPool):
+        self._pool = db_pool
+
+    async def create(
+        self,
+        *,
+        loop_id: str,
+        start_time: datetime,
+        duration: int,
+        notes: str = "",
+    ) -> ScheduledInterview:
+        async with self._pool.connection() as conn, conn.transaction():
+            row = await _fetch_dict_one(
+                conn,
+                queries.create_scheduled_interview,
+                id=make_id("int"),
+                loop_id=loop_id,
+                interview_start_time=start_time,
+                interview_duration=duration,
+                interview_notes=notes,
+            )
+        assert row is not None
+        return _row_to_scheduled_interview(row)
+
+    async def update(
+        self,
+        *,
+        interview_id: str,
+        start_time: datetime,
+        duration: int,
+        notes: str = "",
+    ) -> ScheduledInterview:
+        async with self._pool.connection() as conn, conn.transaction():
+            await queries.update_scheduled_interview(
+                conn,
+                id=interview_id,
+                interview_start_time=start_time,
+                interview_duration=duration,
+                interview_notes=notes,
+            )
+            row = await _fetch_dict_one(conn, queries.get_scheduled_interview, id=interview_id)
+        if row is None:
+            raise ValueError(f"scheduled_interview {interview_id} not found after update")
+        return _row_to_scheduled_interview(row)
+
+    async def cancel(self, interview_id: str) -> ScheduledInterview:
+        async with self._pool.connection() as conn, conn.transaction():
+            await queries.cancel_scheduled_interview(conn, id=interview_id)
+            row = await _fetch_dict_one(conn, queries.get_scheduled_interview, id=interview_id)
+        if row is None:
+            raise ValueError(f"scheduled_interview {interview_id} not found after cancel")
+        return _row_to_scheduled_interview(row)
+
+    async def get(self, interview_id: str) -> ScheduledInterview | None:
+        async with self._pool.connection() as conn:
+            row = await _fetch_dict_one(conn, queries.get_scheduled_interview, id=interview_id)
+        if row is None:
+            return None
+        return _row_to_scheduled_interview(row)
+
+    async def list_active_for_loop(self, loop_id: str) -> list[ScheduledInterview]:
+        async with self._pool.connection() as conn:
+            rows = await _fetch_dicts(conn, queries.get_active_interviews_for_loop, loop_id=loop_id)
+        return [_row_to_scheduled_interview(r) for r in rows]
 
 
 def _loop_to_summary(loop: Loop) -> LoopSummary:

--- a/services/api/tests/test_classifier_hook.py
+++ b/services/api/tests/test_classifier_hook.py
@@ -179,11 +179,15 @@ def _make_agent():
     loop_service.get_coordinator_by_email = AsyncMock(return_value=None)
     loop_service.get_events = AsyncMock(return_value=[])
 
+    interview_service = MagicMock()
+    interview_service.list_active_for_loop = AsyncMock(return_value=[])
+
     agent = NextActionAgent(
         llm=llm,
         langfuse=langfuse,
         suggestion_service=suggestion_service,
         loop_service=loop_service,
+        interview_service=interview_service,
     )
     return agent, suggestion_service
 


### PR DESCRIPTION
## Summary

Adds the data path for booked interviews end-to-end without any side-effecting integrations (no calendar invites, no conflict checks). The agent can now propose \`schedule\`, \`update\`, and \`cancel\` ops against a \`scheduled_interviews\` table; coordinators approve from the sidebar.

## What changed

- **\`ScheduleInterviewData\`** pydantic model with per-op (schedule/update/cancel) null-rule validators; registered in \`ACTION_DATA_MODELS\` so guardrails bounce malformed payloads through the existing retry-with-explanation loop.
- **\`scheduled_interviews\`** table (migration 0015) + aiosql queries + \`ScheduledInterviewService\` for CRUD against it.
- **Sidebar builder** renders Schedule / Update / Cancel cards with the candidate + client company in the header; update ops diff old → new per changed field. Accept left, dismiss right per existing convention.
- **NextActionAgent input context** now includes a \`<scheduled-interviews>\` block per loop (active only — canceled rows are hidden from the LLM).
- **Accept handler** dispatches by \`interview_op\` to create / update / cancel the row, then resolves the suggestion as \`ACCEPTED\`. Reject path reuses the generic rejection branch since \`SCHEDULE_INTERVIEW\` is intentionally not auto-resolved.

## Why now

This is the "bones" only — wires the data flow end-to-end so we can iterate on richer behavior (calendar invites, conflict checking, attendee management) without rebuilding the plumbing. Coordinator approval is on the critical path for every interview op, matching the UX philosophy in CLAUDE.md.

## Test plan

- [ ] \`yoyo apply\` migrations against local Postgres; \`\\d scheduled_interviews\` shows expected schema
- [ ] Craft an agent response with \`interview_op=schedule\` and \`interview_start_time=null\` → confirm one error-followup round
- [ ] Seed a \`schedule_interview\` suggestion → sidebar header reads \`Schedule interview for <candidate> with <client_company>\`, time renders ET, Accept on left
- [ ] Accept schedule → row in \`scheduled_interviews\`, suggestion ACCEPTED
- [ ] Accept update changing only time → diff shows \`Time: <old> → <new>\` and nothing else
- [ ] Accept cancel → \`is_canceled = true\`
- [ ] Re-trigger NextActionAgent on a thread with an active interview → \`<scheduled-interviews>\` block present in rendered XML
- [ ] Dismiss a pending \`schedule_interview\` → REJECTED + \`process_rejection_response\` enqueued, no DB mutation to \`scheduled_interviews\`