### PR TITLE
feat(coordinators): onboard Jessica Kalish

### DIFF
--- a/services/api/src/api/encore/coordinators.py
+++ b/services/api/src/api/encore/coordinators.py
@@ -10,7 +10,8 @@ ANA_EMAIL = "acooke@longridgepartners.com"
 FIONA_EMAIL = "fcampbell@longridgepartners.com"
 SARA_EMAIL = "scampoli@longridgepartners.com"
 MARISSA_EMAIL = "mbradley@longridgepartners.com"
+JESSICA_EMAIL = "jkalish@longridgepartners.com"
 
 COORDINATOR_EMAILS: frozenset[str] = frozenset(
-    {ADAM_EMAIL, ANA_EMAIL, FIONA_EMAIL, SARA_EMAIL, MARISSA_EMAIL}
+    {ADAM_EMAIL, ANA_EMAIL, FIONA_EMAIL, SARA_EMAIL, MARISSA_EMAIL, JESSICA_EMAIL}
 )


### PR DESCRIPTION
## Summary
- Add `jkalish@longridgepartners.com` to `COORDINATOR_EMAILS` so the Encore resolver filters Jessica out of recruiter matches in loops she coordinates.

## Why
Without this, the resolver would happily return Jessica as a recruiter candidate in her own loops — incorrect matches and confusing UX.

## Notes for reviewer
- No special-case branch added (unlike Adam who skips loops, or Ana who triggers initials-parsing fallback). Jessica gets default coordinator behavior.
- Not added to `_VALID_CM_EMAILS` in `loop_classifier.py` — that list is for **client managers**, a separate role. Add her there only if she also owns client relationships (and update the LangFuse `<client-managers>` prompt list to match).
- No DB seeding required — `get_or_create_coordinator` upserts her row on first email arrival.
- No Gmail watch changes — the watch-renewal worker picks up new coordinators automatically once she completes the add-on OAuth flow.

## Test plan
- [ ] Jessica installs the add-on and completes OAuth
- [ ] Confirm her token appears in the token store and a Pub/Sub watch gets registered
- [ ] Send a test scheduling email — confirm the resolver does not surface Jessica as a recruiter match